### PR TITLE
ci: install binutils and build-base on alpine

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -450,6 +450,9 @@ jobs:
           set -ex
           apk update
           apk add \
+            bash \
+            binutils \
+            build-base \
             ca-certificates \
             clang \
             cmake \


### PR DESCRIPTION
cherry-pick c0363083ddac22188c0432976cc7f01a4898f0b0 to 4.1.x.

Updates which packages we install on Alpine s.t. our GitHub actions work with the latest Alpine image.