### PR TITLE
feat: use portcheck.transmissiontorrent.com for the port checker

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1525,7 +1525,7 @@ void portTest(tr_session* session, tr_variant::Map const& args_in, struct tr_rpc
     static auto constexpr TimeoutSecs = 20s;
 
     auto const port = session->advertisedPeerPort();
-    auto const url = fmt::format("https://portcheck.transmissionbt.com/{:d}", port.host());
+    auto const url = fmt::format("https://portcheck.transmissiontorrent.com/{:d}", port.host());
     auto ip_proto = std::optional<tr_web::FetchOptions::IPProtocol>{};
 
     if (auto const val = args_in.value_if<std::string_view>(TR_KEY_ip_protocol); val)

--- a/macosx/PortChecker.mm
+++ b/macosx/PortChecker.mm
@@ -68,7 +68,7 @@ static NSTimeInterval const kCheckFireInterval = 3.0;
 {
     self.fTimer = nil;
 
-    NSString* urlString = [NSString stringWithFormat:@"https://portcheck.transmissionbt.com/%ld", port];
+    NSString* urlString = [NSString stringWithFormat:@"https://portcheck.transmissiontorrent.com/%ld", port];
     NSURLRequest* portProbeRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:urlString]
                                                       cachePolicy:NSURLRequestReloadIgnoringLocalAndRemoteCacheData
                                                   timeoutInterval:15.0];


### PR DESCRIPTION
portcheck.transmissiontorrent.com is live, so let's use it.

Notes: Use `portcheck.transmissiontorrent.com` for port checking