### PR TITLE
refactor: stop using magic numbers in tr_sys_path_capacity

### DIFF
--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -103,8 +103,8 @@ struct tr_sys_path_info
 
 struct tr_sys_path_capacity
 {
-    uintmax_t available = -1;
-    uintmax_t capacity = -1;
+    uintmax_t available = {};
+    uintmax_t capacity = {};
 };
 
 /**


### PR DESCRIPTION
Fix a simple mvsc warning

```
D:\a\transmission\transmission\src\libtransmission/file.h(106): warning C4245: 'initializing': conversion from 'int' to 'uintmax_t', signed/unsigned mismatch
D:\a\transmission\transmission\src\libtransmission/file.h(107): warning C4245: 'initializing': conversion from 'int' to 'uintmax_t', signed/unsigned mismatch
```

These fields are being set to a magic `-1`  value that hasn't been used in awhile. We can just default-initialize instead.