### PR TITLE
refactor: use `tr_variant::Map` in `RpcQueue::add()`

### DIFF
--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -392,11 +392,6 @@ tr_variant* tr_variantDictAdd(tr_variant* const var, tr_quark key)
     return {};
 }
 
-tr_variant* tr_variantDictAddList(tr_variant* const var, tr_quark const key, size_t const n_reserve)
-{
-    return dict_set(var, key, tr_variant::make_vector(n_reserve));
-}
-
 tr_variant* tr_variantDictAddStrView(tr_variant* const var, tr_quark const key, std::string_view const val)
 {
     return dict_set(var, key, tr_variant::unmanaged_string(val));

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -353,19 +353,6 @@ void tr_variantInitDict(tr_variant* initme, size_t n_reserve)
     *initme = tr_variant::Map{ n_reserve };
 }
 
-tr_variant* tr_variantListAdd(tr_variant* const var)
-{
-    TR_ASSERT(var != nullptr);
-    TR_ASSERT(var->holds_alternative<tr_variant::Vector>());
-
-    if (auto* const vec = var != nullptr ? var->get_if<tr_variant::VectorIndex>() : nullptr; vec != nullptr)
-    {
-        return &vec->emplace_back();
-    }
-
-    return nullptr;
-}
-
 size_t tr_variantListSize(tr_variant const* const var)
 {
     if (var != nullptr)

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -603,7 +603,6 @@ bool tr_variantGetStrView(tr_variant const* variant, std::string_view* setme);
 size_t tr_variantListSize(tr_variant const* var);
 tr_variant* tr_variantDictAdd(tr_variant* var, tr_quark key);
 tr_variant* tr_variantDictAddDict(tr_variant* var, tr_quark key, size_t n_reserve);
-tr_variant* tr_variantDictAddList(tr_variant* var, tr_quark key, size_t n_reserve);
 tr_variant* tr_variantDictAddStrView(tr_variant* var, tr_quark key, std::string_view value);
 tr_variant* tr_variantDictFind(tr_variant* var, tr_quark key);
 tr_variant* tr_variantListAdd(tr_variant* var);

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -605,7 +605,6 @@ tr_variant* tr_variantDictAdd(tr_variant* var, tr_quark key);
 tr_variant* tr_variantDictAddDict(tr_variant* var, tr_quark key, size_t n_reserve);
 tr_variant* tr_variantDictAddStrView(tr_variant* var, tr_quark key, std::string_view value);
 tr_variant* tr_variantDictFind(tr_variant* var, tr_quark key);
-tr_variant* tr_variantListAdd(tr_variant* var);
 tr_variant* tr_variantListChild(tr_variant* var, size_t pos);
 void tr_variantInitDict(tr_variant* initme, size_t n_reserve);
 void tr_variantInitList(tr_variant* initme, size_t n_reserve);

--- a/qt/FreeSpaceLabel.cc
+++ b/qt/FreeSpaceLabel.cc
@@ -21,7 +21,6 @@
 #include "Session.h"
 #include "VariantHelpers.h"
 
-using ::trqt::variant_helpers::dictAdd;
 using ::trqt::variant_helpers::dictFind;
 
 namespace

--- a/qt/FreeSpaceLabel.cc
+++ b/qt/FreeSpaceLabel.cc
@@ -10,8 +10,9 @@
 #include <QString>
 #include <QWidget>
 
-#include <libtransmission/transmission.h>
 #include <libtransmission/quark.h>
+#include <libtransmission/serializer.h>
+#include <libtransmission/types.h>
 #include <libtransmission/variant.h>
 
 #include "Formatter.h"
@@ -70,13 +71,12 @@ void FreeSpaceLabel::onTimer()
         return;
     }
 
-    tr_variant args;
-    tr_variantInitDict(&args, 1);
-    dictAdd(&args, TR_KEY_path, path_);
+    auto params = tr_variant::Map{ 1U };
+    params.insert_or_assign(TR_KEY_path, tr::serializer::to_variant(path_));
 
     auto* q = new RpcQueue{ this };
 
-    q->add([this, &args]() { return session_->exec(TR_KEY_free_space, &args); });
+    q->add([this, params = std::move(params)]() mutable { return session_->exec(TR_KEY_free_space, std::move(params)); });
 
     q->add(
         [this](RpcResponse const& r)

--- a/qt/OptionsDialog.cc
+++ b/qt/OptionsDialog.cc
@@ -12,6 +12,7 @@
 #include <libtransmission/transmission.h>
 
 #include <libtransmission/quark.h>
+#include <libtransmission/serializer.h>
 #include <libtransmission/variant.h>
 #include <libtransmission/torrent-metainfo.h>
 
@@ -23,9 +24,6 @@
 #include "Session.h"
 #include "Torrent.h"
 #include "Utils.h"
-#include "VariantHelpers.h"
-
-using ::trqt::variant_helpers::dictAdd;
 
 /***
 ****
@@ -225,8 +223,7 @@ void OptionsDialog::onAccepted()
 {
     // rpc spec section 3.4 "adding a torrent"
 
-    tr_variant args;
-    tr_variantInitDict(&args, 10);
+    auto args = tr_variant::Map{ 10U };
     QString download_dir;
 
     // "download-dir"
@@ -239,30 +236,33 @@ void OptionsDialog::onAccepted()
         download_dir = ui_.destinationEdit->text();
     }
 
-    dictAdd(&args, TR_KEY_download_dir, download_dir);
+    args.insert_or_assign(TR_KEY_download_dir, download_dir.toStdString());
 
     // paused
-    dictAdd(&args, TR_KEY_paused, !ui_.startCheck->isChecked());
+    args.insert_or_assign(TR_KEY_paused, !ui_.startCheck->isChecked());
 
     // priority
     int const index = ui_.priorityCombo->currentIndex();
     int const priority = ui_.priorityCombo->itemData(index).toInt();
-    dictAdd(&args, TR_KEY_bandwidth_priority, priority);
+    args.insert_or_assign(TR_KEY_bandwidth_priority, priority);
 
     // files_unwanted
     auto count = std::count(wanted_.begin(), wanted_.end(), false);
 
     if (count > 0)
     {
-        tr_variant* l = tr_variantDictAddList(&args, TR_KEY_files_unwanted, count);
+        auto files_unwanted = std::vector<int>{};
+        files_unwanted.reserve(static_cast<size_t>(count));
 
         for (size_t i = 0, n = wanted_.size(); i < n; ++i)
         {
             if (!wanted_.at(i))
             {
-                *tr_variantListAdd(l) = i;
+                files_unwanted.push_back(static_cast<int>(i));
             }
         }
+
+        args.insert_or_assign(TR_KEY_files_unwanted, tr::serializer::to_variant(files_unwanted));
     }
 
     // priority_low
@@ -270,15 +270,18 @@ void OptionsDialog::onAccepted()
 
     if (count > 0)
     {
-        tr_variant* l = tr_variantDictAddList(&args, TR_KEY_priority_low, count);
+        auto priority_low = std::vector<int>{};
+        priority_low.reserve(static_cast<size_t>(count));
 
         for (size_t i = 0, n = priorities_.size(); i < n; ++i)
         {
             if (priorities_.at(i) == TR_PRI_LOW)
             {
-                *tr_variantListAdd(l) = i;
+                priority_low.push_back(static_cast<int>(i));
             }
         }
+
+        args.insert_or_assign(TR_KEY_priority_low, tr::serializer::to_variant(priority_low));
     }
 
     // priority_high
@@ -286,21 +289,24 @@ void OptionsDialog::onAccepted()
 
     if (count > 0)
     {
-        tr_variant* l = tr_variantDictAddList(&args, TR_KEY_priority_high, count);
+        auto priority_high = std::vector<int>{};
+        priority_high.reserve(static_cast<size_t>(count));
 
         for (size_t i = 0, n = priorities_.size(); i < n; ++i)
         {
             if (priorities_.at(i) == TR_PRI_HIGH)
             {
-                *tr_variantListAdd(l) = i;
+                priority_high.push_back(static_cast<int>(i));
             }
         }
+
+        args.insert_or_assign(TR_KEY_priority_high, tr::serializer::to_variant(priority_high));
     }
 
     auto const disposal = ui_.trashCheck->isChecked() ? AddData::FilenameDisposal::Delete : AddData::FilenameDisposal::NoAction;
     add_.setFileDisposal(disposal);
 
-    session_.addTorrent(add_, &args);
+    session_.addTorrent(add_, std::move(args));
 
     deleteLater();
 }

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -41,7 +41,7 @@ char constexpr const* const RequestFutureinterfacePropertyKey{ "requestReplyFutu
     return id++;
 }
 
-[[nodiscard]] std::pair<tr_variant, int64_t> buildRequest(tr_quark const method, tr_variant* params)
+[[nodiscard]] std::pair<tr_variant, int64_t> buildRequest(tr_quark const method, tr_variant::Map params)
 {
     auto const id = nextId();
 
@@ -49,9 +49,9 @@ char constexpr const* const RequestFutureinterfacePropertyKey{ "requestReplyFutu
     req.try_emplace(TR_KEY_jsonrpc, tr_variant::unmanaged_string(JsonRpc::Version));
     req.try_emplace(TR_KEY_method, tr_variant::unmanaged_string(method));
     req.try_emplace(TR_KEY_id, id);
-    if (params != nullptr)
+    if (!std::empty(params))
     {
-        req.try_emplace(TR_KEY_params, params->clone());
+        req.try_emplace(TR_KEY_params, std::move(params));
     }
 
     return { std::move(req), id };
@@ -87,9 +87,9 @@ void RpcClient::start(QUrl const& url)
     url_is_loopback_ = QHostAddress{ url_.host() }.isLoopback();
 }
 
-RpcResponseFuture RpcClient::exec(tr_quark const method, tr_variant* args)
+RpcResponseFuture RpcClient::exec(tr_quark const method, tr_variant::Map args)
 {
-    auto [req, id] = buildRequest(method, args);
+    auto [req, id] = buildRequest(method, std::move(args));
 
     auto promise = QFutureInterface<RpcResponse>{};
     promise.setExpectedResultCount(1);
@@ -110,6 +110,19 @@ RpcResponseFuture RpcClient::exec(tr_quark const method, tr_variant* args)
     }
 
     return promise.future();
+}
+
+RpcResponseFuture RpcClient::exec(tr_quark const method, tr_variant* args)
+{
+    if (args != nullptr)
+    {
+        if (auto* const args_map = args->get_if<tr_variant::Map>())
+        {
+            return exec(method, args_map->clone());
+        }
+    }
+
+    return exec(method);
 }
 
 void RpcClient::sendNetworkRequest(QByteArray const& body, QFutureInterface<RpcResponse> const& promise)

--- a/qt/RpcClient.h
+++ b/qt/RpcClient.h
@@ -74,6 +74,7 @@ public:
     void start(tr_session* session);
     void start(QUrl const& url);
 
+    RpcResponseFuture exec(tr_quark method, tr_variant::Map args = {});
     RpcResponseFuture exec(tr_quark method, tr_variant* args);
 
 signals:

--- a/qt/RpcQueue.h
+++ b/qt/RpcQueue.h
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <queue>
 #include <type_traits>
 #include <utility>
@@ -41,15 +42,17 @@ public:
     }
 
     template<typename Func>
-    void add(Func const& func)
+    void add(Func&& func)
     {
-        queue_.emplace(normalizeFunc(func), ErrorHandlerFunction());
+        queue_.emplace(normalizeFunc(std::forward<Func>(func)), ErrorHandlerFunction{});
     }
 
     template<typename Func, typename ErrorHandler>
-    void add(Func const& func, ErrorHandler const& error_handler)
+    void add(Func&& func, ErrorHandler&& error_handler)
     {
-        queue_.emplace(normalizeFunc(func), normalizeErrorHandler(error_handler));
+        queue_.emplace(
+            normalizeFunc(std::forward<Func>(func)),
+            normalizeErrorHandler(std::forward<ErrorHandler>(error_handler)));
     }
 
     // The first function in queue is ran synchronously
@@ -75,65 +78,82 @@ private:
 
     // These overloads convert various forms of input closures to what we store internally.
 
+    template<typename Func>
+    static auto makeCopyable(Func&& func)
+    {
+        using FuncType = std::remove_cvref_t<Func>;
+        auto shared_func = std::make_shared<FuncType>(std::forward<Func>(func));
+        return [shared_func](auto&&... args) -> decltype(auto)
+        {
+            return std::invoke(*shared_func, std::forward<decltype(args)>(args)...);
+        };
+    }
+
     // normal closure, takes response and returns new future
     template<detail::invoke_result_is<RpcResponseFuture, RpcResponse const&> Func>
-    static QueuedFunction normalizeFunc(Func const& func)
+    static QueuedFunction normalizeFunc(Func&& func)
     {
-        return [func](RpcResponseFuture const& r)
+        auto copyable_func = makeCopyable(std::forward<Func>(func));
+        return [func = std::move(copyable_func)](RpcResponseFuture const& r) mutable
         {
-            return func(r.result());
+            return std::invoke(func, r.result());
         };
     }
 
     // closure without argument (first step), takes nothing and returns new future
     template<detail::invoke_result_is<RpcResponseFuture> Func>
-    static QueuedFunction normalizeFunc(Func const& func)
+    static QueuedFunction normalizeFunc(Func&& func)
     {
-        return [func](RpcResponseFuture const&)
+        auto copyable_func = makeCopyable(std::forward<Func>(func));
+        return [func = std::move(copyable_func)](RpcResponseFuture const&) mutable
         {
-            return func();
+            return std::invoke(func);
         };
     }
 
     // closure without return value ("auxiliary"), takes response and returns nothing
     template<detail::invoke_result_is<void, RpcResponse const&> Func>
-    static QueuedFunction normalizeFunc(Func const& func)
+    static QueuedFunction normalizeFunc(Func&& func)
     {
-        return [func](RpcResponseFuture const& r)
+        auto copyable_func = makeCopyable(std::forward<Func>(func));
+        return [func = std::move(copyable_func)](RpcResponseFuture const& r) mutable
         {
-            func(r.result());
+            std::invoke(func, r.result());
             return createFinishedFuture();
         };
     }
 
     // closure without argument and return value, takes nothing and returns nothing -- next function will also get nothing
     template<detail::invoke_result_is<void> Func>
-    static QueuedFunction normalizeFunc(Func const& func)
+    static QueuedFunction normalizeFunc(Func&& func)
     {
-        return [func](RpcResponseFuture const&)
+        auto copyable_func = makeCopyable(std::forward<Func>(func));
+        return [func = std::move(copyable_func)](RpcResponseFuture const&) mutable
         {
-            func();
+            std::invoke(func);
             return createFinishedFuture();
         };
     }
 
     // normal error handler, takes last response
     template<detail::invoke_result_is<void, RpcResponse const&> Func>
-    static ErrorHandlerFunction normalizeErrorHandler(Func const& func)
+    static ErrorHandlerFunction normalizeErrorHandler(Func&& func)
     {
-        return [func](RpcResponseFuture const& r)
+        auto copyable_func = makeCopyable(std::forward<Func>(func));
+        return [func = std::move(copyable_func)](RpcResponseFuture const& r) mutable
         {
-            func(r.result());
+            std::invoke(func, r.result());
         };
     }
 
     // error handler without an argument, takes nothing
     template<detail::invoke_result_is<void> Func>
-    static ErrorHandlerFunction normalizeErrorHandler(Func const& func)
+    static ErrorHandlerFunction normalizeErrorHandler(Func&& func)
     {
-        return [func](RpcResponseFuture const&)
+        auto copyable_func = makeCopyable(std::forward<Func>(func));
+        return [func = std::move(copyable_func)](RpcResponseFuture const&) mutable
         {
-            func();
+            std::invoke(func);
         };
     }
 

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -48,7 +48,6 @@
 using namespace std::literals;
 
 using ::tr::serializer::to_variant;
-using ::trqt::variant_helpers::dictAdd;
 using ::trqt::variant_helpers::dictFind;
 
 /***
@@ -102,16 +101,15 @@ bool Session::portTestPending(Session::PortTestIpProtocol const ip_protocol) con
 
 void Session::copyMagnetLinkToClipboard(int torrent_id)
 {
-    static auto const Fields = std::array{ tr_quark_get_string_view(TR_KEY_magnet_link) };
-
-    tr_variant args;
-    tr_variantInitDict(&args, 2);
-    dictAdd(&args, TR_KEY_ids, std::array<int, 1>{ torrent_id });
-    dictAdd(&args, TR_KEY_fields, Fields);
+    auto params = makeParams(TR_KEY_ids, torrent_ids_t{ torrent_id });
+    auto fields = tr_variant::Vector{};
+    fields.reserve(1U);
+    fields.emplace_back(tr_variant::unmanaged_string(TR_KEY_magnet_link));
+    params.insert_or_assign(TR_KEY_fields, std::move(fields));
 
     auto* q = new RpcQueue{};
 
-    q->add([this, &args]() { return exec(TR_KEY_torrent_get, &args); });
+    q->add([this, params = std::move(params)]() mutable { return exec(TR_KEY_torrent_get, std::move(params)); });
 
     q->add(
         [](RpcResponse const& r)
@@ -951,13 +949,15 @@ void Session::addNewlyCreatedTorrent(QString const& filename, QString const& loc
 {
     QByteArray const b64 = AddData(filename).toBase64();
 
-    tr_variant args;
-    tr_variantInitDict(&args, 3);
-    dictAdd(&args, TR_KEY_download_dir, local_path);
-    dictAdd(&args, TR_KEY_paused, !prefs_.get<bool>(TR_KEY_start_added_torrents));
-    dictAdd(&args, TR_KEY_metainfo, b64);
-
-    exec(TR_KEY_torrent_add, &args);
+    exec(
+        TR_KEY_torrent_add,
+        makeParams(
+            TR_KEY_download_dir,
+            local_path,
+            TR_KEY_paused,
+            !prefs_.get<bool>(TR_KEY_start_added_torrents),
+            TR_KEY_metainfo,
+            b64.toStdString()));
 }
 
 void Session::removeTorrents(torrent_ids_t const& ids, bool delete_files)

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -832,30 +832,27 @@ void Session::setBlocklistSize(int64_t i)
     emit blocklistUpdated(i);
 }
 
-void Session::addTorrent(AddData const& add_me, tr_variant* args_dict)
+void Session::addTorrent(AddData const& add_me, tr_variant::Map args_dict)
 {
-    assert(tr_variantDictFind(args_dict, TR_KEY_filename) == nullptr);
-    assert(tr_variantDictFind(args_dict, TR_KEY_metainfo) == nullptr);
+    assert(!args_dict.contains(TR_KEY_filename));
+    assert(!args_dict.contains(TR_KEY_metainfo));
 
-    if (tr_variantDictFind(args_dict, TR_KEY_paused) == nullptr)
-    {
-        dictAdd(args_dict, TR_KEY_paused, !prefs_.get<bool>(TR_KEY_start_added_torrents));
-    }
+    args_dict.try_emplace(TR_KEY_paused, !prefs_.get<bool>(TR_KEY_start_added_torrents));
 
     switch (add_me.type)
     {
     case AddData::MAGNET:
-        dictAdd(args_dict, TR_KEY_filename, add_me.magnet);
+        args_dict.insert_or_assign(TR_KEY_filename, add_me.magnet.toStdString());
         break;
 
     case AddData::URL:
-        dictAdd(args_dict, TR_KEY_filename, add_me.url.toString());
+        args_dict.insert_or_assign(TR_KEY_filename, add_me.url.toString().toStdString());
         break;
 
     case AddData::FILENAME:
         [[fallthrough]];
     case AddData::METAINFO:
-        dictAdd(args_dict, TR_KEY_metainfo, add_me.toBase64());
+        args_dict.insert_or_assign(TR_KEY_metainfo, add_me.toBase64().toStdString());
         break;
 
     default:
@@ -866,7 +863,7 @@ void Session::addTorrent(AddData const& add_me, tr_variant* args_dict)
     auto* q = new RpcQueue{};
 
     q->add(
-        [this, args_dict]() { return exec(TR_KEY_torrent_add, args_dict); },
+        [this, args_dict = std::move(args_dict)]() mutable { return exec(TR_KEY_torrent_add, std::move(args_dict)); },
         [add_me](RpcResponse const& r)
         {
             auto* d = new QMessageBox{ QMessageBox::Warning,
@@ -881,18 +878,26 @@ void Session::addTorrent(AddData const& add_me, tr_variant* args_dict)
     q->add(
         [this, add_me](RpcResponse const& r)
         {
-            if (tr_variant* dup = nullptr; tr_variantDictFindDict(r.args.get(), TR_KEY_torrent_added, &dup))
+            if (auto const* const args = r.args->get_if<tr_variant::Map>(); args != nullptr)
             {
-                add_me.disposeSourceFile();
-            }
-            else if (tr_variantDictFindDict(r.args.get(), TR_KEY_torrent_duplicate, &dup))
-            {
-                add_me.disposeSourceFile();
-
-                if (auto const hash = dictFind<QString>(dup, TR_KEY_hash_string))
+                if (args->contains(TR_KEY_torrent_added))
                 {
-                    duplicates_.try_emplace(add_me.readableShortName(), *hash);
-                    duplicates_timer_.start(1000);
+                    add_me.disposeSourceFile();
+                }
+                else if (auto const* const dup = args->find_if<tr_variant::Map>(TR_KEY_torrent_duplicate); dup != nullptr)
+                {
+                    add_me.disposeSourceFile();
+
+                    if (auto const iter = dup->find(TR_KEY_hash_string); iter != dup->end())
+                    {
+                        if (auto const hash = iter->second.value_if<std::string_view>())
+                        {
+                            duplicates_.try_emplace(
+                                add_me.readableShortName(),
+                                QString::fromUtf8(std::data(*hash), static_cast<IF_QT6(qsizetype, int)>(std::size(*hash))));
+                            duplicates_timer_.start(1000);
+                        }
+                    }
                 }
             }
         });
@@ -935,9 +940,7 @@ void Session::onDuplicatesTimer()
 
 void Session::addTorrent(AddData const& add_me)
 {
-    tr_variant args;
-    tr_variantInitDict(&args, 3);
-    addTorrent(add_me, &args);
+    addTorrent(add_me, tr_variant::Map{ 3U });
 }
 
 void Session::addNewlyCreatedTorrent(QString const& filename, QString const& local_path)

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -362,18 +362,6 @@ void Session::addOptionalIds(tr_variant::Map& params, torrent_ids_t const& torre
     }
 }
 
-void Session::addOptionalIds(tr_variant* args_dict, torrent_ids_t const& torrent_ids) const
-{
-    if (&torrent_ids == &RecentlyActiveIDs)
-    {
-        dictAdd(args_dict, TR_KEY_ids, tr_quark_get_string_view(TR_KEY_recently_active));
-    }
-    else if (!std::empty(torrent_ids))
-    {
-        dictAdd(args_dict, TR_KEY_ids, torrent_ids);
-    }
-}
-
 Session::Tag Session::torrentSetImpl(tr_variant::Map params)
 {
     auto* const q = new RpcQueue{};
@@ -389,27 +377,23 @@ Session::Tag Session::torrentSetImpl(tr_variant::Map params)
 
 void Session::torrentSetLocation(torrent_ids_t const& torrent_ids, QString const& path, bool do_move)
 {
-    tr_variant args;
-    tr_variantInitDict(&args, 3);
-    addOptionalIds(&args, torrent_ids);
-    dictAdd(&args, TR_KEY_location, path);
-    dictAdd(&args, TR_KEY_move, do_move);
-
-    exec(TR_KEY_torrent_set_location, &args);
+    if (!torrent_ids.empty())
+    {
+        exec(TR_KEY_torrent_set_location, makeParams(torrent_ids, TR_KEY_location, path, TR_KEY_move, do_move));
+    }
 }
 
 void Session::torrentRenamePath(torrent_ids_t const& torrent_ids, QString const& oldpath, QString const& newname)
 {
-    tr_variant args;
-    tr_variantInitDict(&args, 2);
-    addOptionalIds(&args, torrent_ids);
-    dictAdd(&args, TR_KEY_path, oldpath);
-    dictAdd(&args, TR_KEY_name, newname);
+    if (torrent_ids.empty())
+    {
+        return;
+    }
 
     auto* q = new RpcQueue{};
-
     q->add(
-        [this, &args]() { return exec(TR_KEY_torrent_rename_path, &args); },
+        [this, params = makeParams(torrent_ids, TR_KEY_path, oldpath, TR_KEY_name, newname)]() mutable
+        { return exec(TR_KEY_torrent_rename_path, std::move(params)); },
         [](RpcResponse const& r)
         {
             auto const path = dictFind<QString>(r.args.get(), TR_KEY_path).value_or(QStringLiteral("(unknown)"));
@@ -642,13 +626,9 @@ void Session::refreshExtraStats(torrent_ids_t const& ids)
 
 void Session::sendTorrentRequest(tr_quark const method, torrent_ids_t const& torrent_ids)
 {
-    tr_variant args;
-    tr_variantInitDict(&args, 1);
-    addOptionalIds(&args, torrent_ids);
-
     auto* q = new RpcQueue{};
 
-    q->add([this, method, &args]() { return exec(method, &args); });
+    q->add([this, method, params = makeParams(torrent_ids)]() mutable { return exec(method, std::move(params)); });
 
     q->add([this, torrent_ids]() { refreshTorrents(torrent_ids, TorrentProperties::MainStats); });
 
@@ -977,12 +957,7 @@ void Session::removeTorrents(torrent_ids_t const& ids, bool delete_files)
 {
     if (!ids.empty())
     {
-        tr_variant args;
-        tr_variantInitDict(&args, 2);
-        addOptionalIds(&args, ids);
-        dictAdd(&args, TR_KEY_delete_local_data, delete_files);
-
-        exec(TR_KEY_torrent_remove, &args);
+        exec(TR_KEY_torrent_remove, makeParams(ids, TR_KEY_delete_local_data, delete_files));
     }
 }
 
@@ -990,11 +965,7 @@ void Session::verifyTorrents(torrent_ids_t const& ids)
 {
     if (!ids.empty())
     {
-        tr_variant args;
-        tr_variantInitDict(&args, 1);
-        addOptionalIds(&args, ids);
-
-        exec(TR_KEY_torrent_verify, &args);
+        exec(TR_KEY_torrent_verify, makeParams(ids));
     }
 }
 
@@ -1002,11 +973,7 @@ void Session::reannounceTorrents(torrent_ids_t const& ids)
 {
     if (!ids.empty())
     {
-        tr_variant args;
-        tr_variantInitDict(&args, 1);
-        addOptionalIds(&args, ids);
-
-        exec(TR_KEY_torrent_reannounce, &args);
+        exec(TR_KEY_torrent_reannounce, makeParams(ids));
     }
 }
 

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -350,16 +350,20 @@ void Session::start()
 
 // ---
 
-void Session::addOptionalIds(tr_variant::Map& params, torrent_ids_t const& torrent_ids) const
+// static
+tr_variant Session::getTorrentIdsVariant(torrent_ids_t const& torrent_ids)
 {
     if (&torrent_ids == &RecentlyActiveIDs)
     {
-        params.try_emplace(TR_KEY_ids, tr_variant::unmanaged_string(TR_KEY_recently_active));
+        return tr_variant::unmanaged_string(TR_KEY_recently_active);
     }
-    else if (!std::empty(torrent_ids))
+
+    if (!std::empty(torrent_ids))
     {
-        params.try_emplace(TR_KEY_ids, to_variant(torrent_ids));
+        return tr::serializer::to_variant(torrent_ids);
     }
+
+    return {};
 }
 
 Session::Tag Session::torrentSetImpl(tr_variant::Map params)
@@ -379,7 +383,7 @@ void Session::torrentSetLocation(torrent_ids_t const& torrent_ids, QString const
 {
     if (!torrent_ids.empty())
     {
-        exec(TR_KEY_torrent_set_location, makeParams(torrent_ids, TR_KEY_location, path, TR_KEY_move, do_move));
+        exec(TR_KEY_torrent_set_location, makeParams(TR_KEY_ids, torrent_ids, TR_KEY_location, path, TR_KEY_move, do_move));
     }
 }
 
@@ -392,7 +396,7 @@ void Session::torrentRenamePath(torrent_ids_t const& torrent_ids, QString const&
 
     auto* q = new RpcQueue{};
     q->add(
-        [this, params = makeParams(torrent_ids, TR_KEY_path, oldpath, TR_KEY_name, newname)]() mutable
+        [this, params = makeParams(TR_KEY_ids, torrent_ids, TR_KEY_path, oldpath, TR_KEY_name, newname)]() mutable
         { return exec(TR_KEY_torrent_rename_path, std::move(params)); },
         [](RpcResponse const& r)
         {
@@ -586,7 +590,7 @@ void Session::refreshTorrents(torrent_ids_t const& torrent_ids, TorrentPropertie
     auto map = tr_variant::Map{ 3U };
     map.try_emplace(TR_KEY_format, tr_variant::unmanaged_string("table"sv));
     map.try_emplace(TR_KEY_fields, std::move(fields));
-    addOptionalIds(map, torrent_ids);
+    addParamPair(map, TR_KEY_ids, torrent_ids);
 
     auto* q = new RpcQueue{};
 
@@ -628,7 +632,7 @@ void Session::sendTorrentRequest(tr_quark const method, torrent_ids_t const& tor
 {
     auto* q = new RpcQueue{};
 
-    q->add([this, method, params = makeParams(torrent_ids)]() mutable { return exec(method, std::move(params)); });
+    q->add([this, method, params = makeParams(TR_KEY_ids, torrent_ids)]() mutable { return exec(method, std::move(params)); });
 
     q->add([this, torrent_ids]() { refreshTorrents(torrent_ids, TorrentProperties::MainStats); });
 
@@ -960,7 +964,7 @@ void Session::removeTorrents(torrent_ids_t const& ids, bool delete_files)
 {
     if (!ids.empty())
     {
-        exec(TR_KEY_torrent_remove, makeParams(ids, TR_KEY_delete_local_data, delete_files));
+        exec(TR_KEY_torrent_remove, makeParams(TR_KEY_ids, ids, TR_KEY_delete_local_data, delete_files));
     }
 }
 
@@ -968,7 +972,7 @@ void Session::verifyTorrents(torrent_ids_t const& ids)
 {
     if (!ids.empty())
     {
-        exec(TR_KEY_torrent_verify, makeParams(ids));
+        exec(TR_KEY_torrent_verify, makeParams(TR_KEY_ids, ids));
     }
 }
 
@@ -976,7 +980,7 @@ void Session::reannounceTorrents(torrent_ids_t const& ids)
 {
     if (!ids.empty())
     {
-        exec(TR_KEY_torrent_reannounce, makeParams(ids));
+        exec(TR_KEY_torrent_reannounce, makeParams(TR_KEY_ids, ids));
     }
 }
 

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -374,71 +374,17 @@ void Session::addOptionalIds(tr_variant* args_dict, torrent_ids_t const& torrent
     }
 }
 
-Session::Tag Session::torrentSetImpl(tr_variant* args)
+Session::Tag Session::torrentSetImpl(tr_variant::Map params)
 {
     auto* const q = new RpcQueue{};
     auto const tag = q->tag();
 
-    q->add([this, args]() { return rpc_.exec(TR_KEY_torrent_set, args); });
+    q->add([this, params = std::move(params)]() mutable { return rpc_.exec(TR_KEY_torrent_set, std::move(params)); });
     q->add([this, tag]() { emit sessionCalled(tag); });
     q->setTolerateErrors();
     q->run();
 
     return tag;
-}
-
-Session::Tag Session::torrentSet(torrent_ids_t const& torrent_ids, tr_quark const key, double value)
-{
-    tr_variant args;
-    tr_variantInitDict(&args, 2);
-    addOptionalIds(&args, torrent_ids);
-    dictAdd(&args, key, value);
-    return torrentSetImpl(&args);
-}
-
-Session::Tag Session::torrentSet(torrent_ids_t const& torrent_ids, tr_quark const key, int value)
-{
-    tr_variant args;
-    tr_variantInitDict(&args, 2);
-    addOptionalIds(&args, torrent_ids);
-    dictAdd(&args, key, value);
-    return torrentSetImpl(&args);
-}
-
-Session::Tag Session::torrentSet(torrent_ids_t const& torrent_ids, tr_quark const key, bool value)
-{
-    tr_variant args;
-    tr_variantInitDict(&args, 2);
-    addOptionalIds(&args, torrent_ids);
-    dictAdd(&args, key, value);
-    return torrentSetImpl(&args);
-}
-
-Session::Tag Session::torrentSet(torrent_ids_t const& torrent_ids, tr_quark const key, QString const& value)
-{
-    tr_variant args;
-    tr_variantInitDict(&args, 2);
-    addOptionalIds(&args, torrent_ids);
-    dictAdd(&args, key, value);
-    return torrentSetImpl(&args);
-}
-
-Session::Tag Session::torrentSet(torrent_ids_t const& torrent_ids, tr_quark const key, QStringList const& value)
-{
-    tr_variant args;
-    tr_variantInitDict(&args, 2);
-    addOptionalIds(&args, torrent_ids);
-    dictAdd(&args, key, value);
-    return torrentSetImpl(&args);
-}
-
-Session::Tag Session::torrentSet(torrent_ids_t const& torrent_ids, tr_quark const key, std::vector<int> const& value)
-{
-    tr_variant args;
-    tr_variantInitDict(&args, 2);
-    addOptionalIds(&args, torrent_ids);
-    dictAdd(&args, key, value);
-    return torrentSetImpl(&args);
 }
 
 void Session::torrentSetLocation(torrent_ids_t const& torrent_ids, QString const& path, bool do_move)
@@ -809,6 +755,11 @@ void Session::updateBlocklist()
 RpcResponseFuture Session::exec(tr_quark method, tr_variant* args)
 {
     return rpc_.exec(method, args);
+}
+
+RpcResponseFuture Session::exec(tr_quark method, tr_variant::Map params)
+{
+    return rpc_.exec(method, std::move(params));
 }
 
 void Session::updateStats(tr_variant const& args_dict, tr_session_stats& stats)

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -47,7 +47,6 @@
 
 using namespace std::literals;
 
-using ::tr::serializer::to_variant;
 using ::trqt::variant_helpers::dictFind;
 
 /***

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -115,7 +115,7 @@ public:
 
     void torrentSetLocation(torrent_ids_t const& torrent_ids, QString const& path, bool do_move);
     void torrentRenamePath(torrent_ids_t const& torrent_ids, QString const& oldpath, QString const& newname);
-    void addTorrent(AddData const& add_me, tr_variant* args_dict);
+    void addTorrent(AddData const& add_me, tr_variant::Map args_dict);
     void initTorrents(torrent_ids_t const& ids = {});
     void pauseTorrents(torrent_ids_t const& torrent_ids = {});
     void startTorrents(torrent_ids_t const& torrent_ids = {});

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -101,14 +101,18 @@ public:
     }
 
     RpcResponseFuture exec(tr_quark method, tr_variant* args);
+    RpcResponseFuture exec(tr_quark method, tr_variant::Map params);
 
     using Tag = RpcQueue::Tag;
-    Tag torrentSet(torrent_ids_t const& torrent_ids, tr_quark key, bool val);
-    Tag torrentSet(torrent_ids_t const& torrent_ids, tr_quark key, int val);
-    Tag torrentSet(torrent_ids_t const& torrent_ids, tr_quark key, double val);
-    Tag torrentSet(torrent_ids_t const& torrent_ids, tr_quark key, QString const& val);
-    Tag torrentSet(torrent_ids_t const& torrent_ids, tr_quark key, std::vector<int> const& val);
-    Tag torrentSet(torrent_ids_t const& torrent_ids, tr_quark key, QStringList const& val);
+
+    template<typename T>
+    Tag torrentSet(torrent_ids_t const& torrent_ids, tr_quark const key, T const& value)
+    {
+        auto params = tr_variant::Map{ 2U };
+        addOptionalIds(params, torrent_ids);
+        params.insert_or_assign(key, tr::serializer::to_variant(value));
+        return torrentSetImpl(std::move(params));
+    }
 
     void torrentSetLocation(torrent_ids_t const& torrent_ids, QString const& path, bool do_move);
     void torrentRenamePath(torrent_ids_t const& torrent_ids, QString const& oldpath, QString const& newname);
@@ -170,7 +174,7 @@ private:
     void updateStats(tr_variant* args_dict);
     void updateInfo(tr_variant* args_dict);
 
-    Tag torrentSetImpl(tr_variant* args);
+    Tag torrentSetImpl(tr_variant::Map params);
     void sessionSet(tr_quark key, tr_variant val);
     void pumpRequests();
     void sendTorrentRequest(tr_quark method, torrent_ids_t const& torrent_ids);

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -11,6 +11,7 @@
 #include <map>
 #include <optional>
 #include <string_view>
+#include <type_traits>
 #include <vector>
 
 #include <QObject>
@@ -110,7 +111,7 @@ public:
     template<typename T, typename... Rest>
     Tag torrentSet(torrent_ids_t const& torrent_ids, tr_quark const key1, T const& val1, Rest const&... rest)
     {
-        return torrentSetImpl(makeParams(torrent_ids, key1, val1, rest...));
+        return torrentSetImpl(makeParams(TR_KEY_ids, torrent_ids, key1, val1, rest...));
     }
 
     void torrentSetLocation(torrent_ids_t const& torrent_ids, QString const& path, bool do_move);
@@ -168,36 +169,42 @@ private slots:
     void onDuplicatesTimer();
 
 private:
-    [[nodiscard]] tr_variant::Map makeParams(torrent_ids_t const& torrent_ids) const
-    {
-        auto params = tr_variant::Map{ 1U };
-        addOptionalIds(params, torrent_ids);
-        return params;
-    }
+    [[nodiscard]] static tr_variant getTorrentIdsVariant(torrent_ids_t const& torrent_ids);
 
-    template<typename T, typename... Rest>
-    static void addTorrentSetParamPairs(tr_variant::Map& params, tr_quark const key, T const& val, Rest const&... rest)
+    template<typename T>
+    static void addParamPair(tr_variant::Map& params, tr_quark const key, T const& val)
     {
-        params.insert_or_assign(key, tr::serializer::to_variant(val));
-
-        if constexpr (sizeof...(rest) != 0U)
+        if constexpr (std::is_same_v<std::remove_cvref_t<T>, torrent_ids_t>)
         {
-            addTorrentSetParamPairs(params, rest...);
+            if (auto var = getTorrentIdsVariant(val); var.has_value())
+            {
+                params.insert_or_assign(key, std::move(var));
+            }
+        }
+        else
+        {
+            params.insert_or_assign(key, tr::serializer::to_variant(val));
         }
     }
 
     template<typename T, typename... Rest>
-    [[nodiscard]] tr_variant::Map makeParams(
-        torrent_ids_t const& torrent_ids,
-        tr_quark const key1,
-        T const& val1,
-        Rest const&... rest) const
+    static void addParamPairs(tr_variant::Map& params, tr_quark const key, T const& val, Rest const&... rest)
+    {
+        addParamPair(params, key, val);
+
+        if constexpr (sizeof...(rest) != 0U)
+        {
+            addParamPairs(params, rest...);
+        }
+    }
+
+    template<typename T, typename... Rest>
+    [[nodiscard]] static tr_variant::Map makeParams(tr_quark const key1, T const& val1, Rest const&... rest)
     {
         static_assert(sizeof...(rest) % 2U == 0U, "Expected key/value argument pairs");
 
-        auto params = tr_variant::Map{ 2U + static_cast<size_t>(sizeof...(rest) / 2U) };
-        addOptionalIds(params, torrent_ids);
-        addTorrentSetParamPairs(params, key1, val1, rest...);
+        auto params = tr_variant::Map{ 1U + static_cast<size_t>(sizeof...(rest) / 2U) };
+        addParamPairs(params, key1, val1, rest...);
 
         return params;
     }
@@ -214,8 +221,6 @@ private:
     void refreshTorrents(torrent_ids_t const& ids, TorrentProperties props);
 
     static void updateStats(tr_variant const& args_dict, tr_session_stats& stats);
-
-    void addOptionalIds(tr_variant::Map& params, torrent_ids_t const& torrent_ids) const;
 
     QString const config_dir_;
     Prefs& prefs_;

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <array>
+#include <cstddef> // size_t
 #include <cstdint> // int64_t
 #include <map>
 #include <optional>
@@ -20,6 +21,7 @@
 
 #include <libtransmission/transmission.h>
 #include <libtransmission/quark.h>
+#include <libtransmission/serializer.h>
 
 #include "Prefs.h"
 #include "RpcClient.h"
@@ -105,13 +107,10 @@ public:
 
     using Tag = RpcQueue::Tag;
 
-    template<typename T>
-    Tag torrentSet(torrent_ids_t const& torrent_ids, tr_quark const key, T const& value)
+    template<typename T, typename... Rest>
+    Tag torrentSet(torrent_ids_t const& torrent_ids, tr_quark const key1, T const& val1, Rest const&... rest)
     {
-        auto params = tr_variant::Map{ 2U };
-        addOptionalIds(params, torrent_ids);
-        params.insert_or_assign(key, tr::serializer::to_variant(value));
-        return torrentSetImpl(std::move(params));
+        return torrentSetImpl(makeParams(torrent_ids, key1, val1, rest...));
     }
 
     void torrentSetLocation(torrent_ids_t const& torrent_ids, QString const& path, bool do_move);
@@ -169,6 +168,40 @@ private slots:
     void onDuplicatesTimer();
 
 private:
+    [[nodiscard]] tr_variant::Map makeParams(torrent_ids_t const& torrent_ids) const
+    {
+        auto params = tr_variant::Map{ 1U };
+        addOptionalIds(params, torrent_ids);
+        return params;
+    }
+
+    template<typename T, typename... Rest>
+    static void addTorrentSetParamPairs(tr_variant::Map& params, tr_quark const key, T const& val, Rest const&... rest)
+    {
+        params.insert_or_assign(key, tr::serializer::to_variant(val));
+
+        if constexpr (sizeof...(rest) != 0U)
+        {
+            addTorrentSetParamPairs(params, rest...);
+        }
+    }
+
+    template<typename T, typename... Rest>
+    [[nodiscard]] tr_variant::Map makeParams(
+        torrent_ids_t const& torrent_ids,
+        tr_quark const key1,
+        T const& val1,
+        Rest const&... rest) const
+    {
+        static_assert(sizeof...(rest) % 2U == 0U, "Expected key/value argument pairs");
+
+        auto params = tr_variant::Map{ 2U + static_cast<size_t>(sizeof...(rest) / 2U) };
+        addOptionalIds(params, torrent_ids);
+        addTorrentSetParamPairs(params, key1, val1, rest...);
+
+        return params;
+    }
+
     void start();
 
     void updateStats(tr_variant* args_dict);
@@ -183,7 +216,6 @@ private:
     static void updateStats(tr_variant const& args_dict, tr_session_stats& stats);
 
     void addOptionalIds(tr_variant::Map& params, torrent_ids_t const& torrent_ids) const;
-    void addOptionalIds(tr_variant* args_dict, torrent_ids_t const& torrent_ids) const;
 
     QString const config_dir_;
     Prefs& prefs_;

--- a/qt/VariantHelpers.cc
+++ b/qt/VariantHelpers.cc
@@ -207,41 +207,6 @@ bool change(TrackerStat& setme, tr_variant const* value)
 
 ///
 
-void variantInit(tr_variant* init_me, bool value)
-{
-    *init_me = value;
-}
-
-void variantInit(tr_variant* init_me, int64_t value)
-{
-    *init_me = value;
-}
-
-void variantInit(tr_variant* init_me, int value)
-{
-    *init_me = value;
-}
-
-void variantInit(tr_variant* init_me, double value)
-{
-    *init_me = value;
-}
-
-void variantInit(tr_variant* init_me, QByteArray const& value)
-{
-    *init_me = std::string_view{ value.constData(), static_cast<size_t>(value.size()) };
-}
-
-void variantInit(tr_variant* init_me, QString const& value)
-{
-    *init_me = value.toStdString();
-}
-
-void variantInit(tr_variant* init_me, std::string_view value)
-{
-    *init_me = value;
-}
-
 namespace
 {
 bool toInt(tr_variant const& src, int* tgt)

--- a/qt/VariantHelpers.h
+++ b/qt/VariantHelpers.h
@@ -202,38 +202,4 @@ auto dictFind(tr_variant* dict, tr_quark key)
 
     return ret;
 }
-
-///
-
-void variantInit(tr_variant* init_me, bool value);
-void variantInit(tr_variant* init_me, int64_t value);
-void variantInit(tr_variant* init_me, int value);
-void variantInit(tr_variant* init_me, double value);
-void variantInit(tr_variant* init_me, QByteArray const& value);
-void variantInit(tr_variant* init_me, QString const& value);
-void variantInit(tr_variant* init_me, std::string_view value);
-void variantInit(tr_variant* init_me, char const* value) = delete; // use string_view
-
-template<typename C, typename T = typename C::value_type>
-void variantInit(tr_variant* init_me, C const& value)
-{
-    tr_variantInitList(init_me, std::size(value));
-    for (auto const& item : value)
-    {
-        variantInit(tr_variantListAdd(init_me), item);
-    }
-}
-
-template<typename T>
-void listAdd(tr_variant* list, T const& value)
-{
-    variantInit(tr_variantListAdd(list), value);
-}
-
-template<typename T>
-void dictAdd(tr_variant* dict, tr_quark key, T const& value)
-{
-    variantInit(tr_variantDictAdd(dict, key), value);
-}
-
 } // namespace trqt::variant_helpers


### PR DESCRIPTION
Continue migrating towards `tr_variant::Map` and away from the deprecated C API.