### PR TITLE
refactor: avoid some deprecated `tr_variant` C API in qt's VariantHelper

### DIFF
--- a/libtransmission/serializer.h
+++ b/libtransmission/serializer.h
@@ -8,13 +8,17 @@
 #include <concepts>
 #include <cstddef>
 #include <optional>
+#include <string>
 #include <tuple>
 #include <type_traits>
 #include <utility>
 
 #include "libtransmission/converters.h"
 #include "libtransmission/quark.h"
+#include "libtransmission/types.h"
 #include "libtransmission/variant.h"
+
+struct tr_pex;
 
 namespace tr::serializer
 {

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -291,11 +291,6 @@ tr_variant* tr_variantListChild(tr_variant* const var, size_t pos)
     return {};
 }
 
-bool tr_variantGetInt(tr_variant const* const var, int64_t* setme)
-{
-    return value_if(var, setme);
-}
-
 bool tr_variantGetStrView(tr_variant const* const var, std::string_view* setme)
 {
     return value_if(var, setme);
@@ -304,7 +299,7 @@ bool tr_variantGetStrView(tr_variant const* const var, std::string_view* setme)
 bool tr_variantDictFindInt(tr_variant* const var, tr_quark key, int64_t* setme)
 {
     auto const* const child = tr_variantDictFind(var, key);
-    return tr_variantGetInt(child, setme);
+    return value_if(child, setme);
 }
 
 bool tr_variantDictFindList(tr_variant* const var, tr_quark key, tr_variant** setme)

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -301,11 +301,6 @@ bool tr_variantGetStrView(tr_variant const* const var, std::string_view* setme)
     return value_if(var, setme);
 }
 
-bool tr_variantGetBool(tr_variant const* const var, bool* setme)
-{
-    return value_if(var, setme);
-}
-
 bool tr_variantGetReal(tr_variant const* const var, double* setme)
 {
     return value_if(var, setme);

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -331,13 +331,6 @@ bool tr_variantDictFindDict(tr_variant* const var, tr_quark key, tr_variant** se
 
 // ---
 
-void tr_variantInitList(tr_variant* initme, size_t n_reserve)
-{
-    auto vec = tr_variant::Vector{};
-    vec.reserve(n_reserve);
-    *initme = std::move(vec);
-}
-
 size_t tr_variantListSize(tr_variant const* const var)
 {
     if (var != nullptr)

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -338,11 +338,6 @@ void tr_variantInitList(tr_variant* initme, size_t n_reserve)
     *initme = std::move(vec);
 }
 
-void tr_variantInitDict(tr_variant* initme, size_t n_reserve)
-{
-    *initme = tr_variant::Map{ n_reserve };
-}
-
 size_t tr_variantListSize(tr_variant const* const var)
 {
     if (var != nullptr)

--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -301,11 +301,6 @@ bool tr_variantGetStrView(tr_variant const* const var, std::string_view* setme)
     return value_if(var, setme);
 }
 
-bool tr_variantGetReal(tr_variant const* const var, double* setme)
-{
-    return value_if(var, setme);
-}
-
 bool tr_variantDictFindInt(tr_variant* const var, tr_quark key, int64_t* setme)
 {
     auto const* const child = tr_variantDictFind(var, key);

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -597,7 +597,6 @@ bool tr_variantDictFindDict(tr_variant* var, tr_quark key, tr_variant** setme_va
 bool tr_variantDictFindInt(tr_variant* var, tr_quark key, int64_t* setme);
 bool tr_variantDictFindList(tr_variant* var, tr_quark key, tr_variant** setme);
 bool tr_variantGetInt(tr_variant const* var, int64_t* setme);
-bool tr_variantGetReal(tr_variant const* variant, double* value_setme);
 bool tr_variantGetStrView(tr_variant const* variant, std::string_view* setme);
 size_t tr_variantListSize(tr_variant const* var);
 tr_variant* tr_variantDictAdd(tr_variant* var, tr_quark key);

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -596,7 +596,6 @@ bool tr_variantDictChild(tr_variant* var, size_t pos, tr_quark* setme_key, tr_va
 bool tr_variantDictFindDict(tr_variant* var, tr_quark key, tr_variant** setme_value);
 bool tr_variantDictFindInt(tr_variant* var, tr_quark key, int64_t* setme);
 bool tr_variantDictFindList(tr_variant* var, tr_quark key, tr_variant** setme);
-bool tr_variantGetBool(tr_variant const* variant, bool* setme);
 bool tr_variantGetInt(tr_variant const* var, int64_t* setme);
 bool tr_variantGetReal(tr_variant const* variant, double* value_setme);
 bool tr_variantGetStrView(tr_variant const* variant, std::string_view* setme);

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -596,7 +596,6 @@ bool tr_variantDictChild(tr_variant* var, size_t pos, tr_quark* setme_key, tr_va
 bool tr_variantDictFindDict(tr_variant* var, tr_quark key, tr_variant** setme_value);
 bool tr_variantDictFindInt(tr_variant* var, tr_quark key, int64_t* setme);
 bool tr_variantDictFindList(tr_variant* var, tr_quark key, tr_variant** setme);
-bool tr_variantGetInt(tr_variant const* var, int64_t* setme);
 bool tr_variantGetStrView(tr_variant const* variant, std::string_view* setme);
 size_t tr_variantListSize(tr_variant const* var);
 tr_variant* tr_variantDictAdd(tr_variant* var, tr_quark key);

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -604,7 +604,6 @@ tr_variant* tr_variantDictAddDict(tr_variant* var, tr_quark key, size_t n_reserv
 tr_variant* tr_variantDictAddStrView(tr_variant* var, tr_quark key, std::string_view value);
 tr_variant* tr_variantDictFind(tr_variant* var, tr_quark key);
 tr_variant* tr_variantListChild(tr_variant* var, size_t pos);
-void tr_variantInitList(tr_variant* initme, size_t n_reserve);
 void tr_variantMergeDicts(tr_variant* tgt, tr_variant const* src);
 
 // --- Dictionaries

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -604,7 +604,6 @@ tr_variant* tr_variantDictAddDict(tr_variant* var, tr_quark key, size_t n_reserv
 tr_variant* tr_variantDictAddStrView(tr_variant* var, tr_quark key, std::string_view value);
 tr_variant* tr_variantDictFind(tr_variant* var, tr_quark key);
 tr_variant* tr_variantListChild(tr_variant* var, size_t pos);
-void tr_variantInitDict(tr_variant* initme, size_t n_reserve);
 void tr_variantInitList(tr_variant* initme, size_t n_reserve);
 void tr_variantMergeDicts(tr_variant* tgt, tr_variant const* src);
 

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -55,10 +55,9 @@ using ::trqt::variant_helpers::dictFind;
 
 void Session::sessionSet(tr_quark const key, tr_variant val)
 {
-    auto args = tr_variant{};
-    tr_variantInitDict(&args, 1);
-    *tr_variantDictAdd(&args, key) = std::move(val);
-    exec(TR_KEY_session_set, &args);
+    auto params = tr_variant::Map{ 1U };
+    params.insert_or_assign(key, std::move(val));
+    exec(TR_KEY_session_set, std::move(params));
 }
 
 void Session::portTest(Session::PortTestIpProtocol const ip_protocol)

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -173,6 +173,15 @@ Torrent::fields_t Torrent::update(tr_quark const* keys, tr_variant const* const*
 
         switch (key)
         {
+        case TR_KEY_error:
+            {
+                auto err = static_cast<int64_t>(error_);
+                field_changed = change(err, child);
+                changed.set(TORRENT_ERROR, field_changed);
+                error_ = static_cast<tr_stat::Error>(err);
+                break;
+            }
+
 #define HANDLE_KEY(key, field, bit) \
     case TR_KEY_##key: \
         field_changed = change(field##_, child); \
@@ -189,7 +198,6 @@ Torrent::fields_t Torrent::update(tr_quark const* keys, tr_variant const* const*
             HANDLE_KEY(download_limited, download_limited, DOWNLOAD_LIMITED)
             HANDLE_KEY(downloaded_ever, downloaded_ever, DOWNLOADED_EVER)
             HANDLE_KEY(edit_date, edit_date, EDIT_DATE)
-            HANDLE_KEY(error, error, TORRENT_ERROR)
             HANDLE_KEY(eta, eta, ETA)
             HANDLE_KEY(file_stats, files, FILES)
             HANDLE_KEY(files, files, FILES)

--- a/qt/VariantHelpers.h
+++ b/qt/VariantHelpers.h
@@ -13,6 +13,7 @@
 #include <type_traits>
 #include <vector>
 
+#include <QDateTime>
 #include <QString>
 
 #include <libtransmission/converters.h>
@@ -46,113 +47,23 @@ TR_DECLARE_CONVERTER(QString)
 namespace trqt::variant_helpers
 {
 template<typename T>
-auto getValue(tr_variant const* variant)
-    requires std::is_same_v<T, bool>
+std::optional<T> getValue(tr_variant const* const var)
 {
-    std::optional<T> ret;
-
-    if (auto value = T{}; tr_variantGetBool(variant, &value))
+    if (var == nullptr)
     {
-        ret = value;
+        return std::nullopt;
     }
 
-    return ret;
-}
-
-template<typename T>
-auto getValue(tr_variant const* variant)
-    requires std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t> || std::is_same_v<T, int> || std::is_same_v<T, time_t>
-{
-    std::optional<T> ret;
-
-    if (auto value = int64_t{}; tr_variantGetInt(variant, &value))
+    if constexpr (
+        std::is_same_v<T, bool> || std::is_same_v<T, double> || std::is_same_v<T, int64_t> || std::is_same_v<T, std::string> ||
+        std::is_same_v<T, std::string_view>)
     {
-        ret = value;
+        return var->value_if<T>();
     }
-
-    return ret;
-}
-
-template<typename T>
-auto getValue(tr_variant const* variant)
-    requires std::is_same_v<T, double>
-{
-    std::optional<T> ret;
-
-    if (auto value = T{}; tr_variantGetReal(variant, &value))
+    else
     {
-        ret = value;
+        return tr::serializer::to_value<T>(*var);
     }
-
-    return ret;
-}
-
-template<typename T>
-auto getValue(tr_variant const* variant)
-    requires std::is_same_v<T, QString>
-{
-    std::optional<T> ret;
-
-    if (auto sv = std::string_view{}; tr_variantGetStrView(variant, &sv))
-    {
-        ret = QString::fromUtf8(std::data(sv), static_cast<IF_QT6(qsizetype, int)>(std::size(sv)));
-    }
-
-    return ret;
-}
-
-template<typename T>
-auto getValue(tr_variant const* variant)
-    requires std::is_same_v<T, std::string_view>
-{
-    std::optional<T> ret;
-
-    if (auto sv = std::string_view{}; tr_variantGetStrView(variant, &sv))
-    {
-        ret = std::string_view(std::data(sv), std::size(sv));
-    }
-
-    return ret;
-}
-
-template<typename T>
-auto getValue(tr_variant const* variant)
-    requires std::is_enum_v<T>
-{
-    std::optional<T> ret;
-
-    if (auto const value = getValue<int>(variant); value)
-    {
-        ret = static_cast<T>(*value);
-    }
-
-    return ret;
-}
-
-template<typename C, typename T = typename C::value_type>
-auto getValue(tr_variant const* var)
-    requires std::is_same_v<C, QStringList> || std::is_same_v<C, QList<T>> || std::is_same_v<C, std::vector<T>>
-{
-    std::optional<C> ret;
-
-    if (var != nullptr && var->holds_alternative<tr_variant::Vector>())
-    {
-        auto list = C{};
-
-        for (size_t i = 0, n = tr_variantListSize(var); i < n; ++i)
-        {
-            tr_variant* const child = tr_variantListChild(const_cast<tr_variant*>(var), i);
-            auto const value = getValue<T>(child);
-            if (value)
-            {
-                list.push_back(*value);
-            }
-        }
-
-        ret = list;
-    }
-
-    return ret;
 }
 
 template<typename T>
@@ -176,9 +87,9 @@ bool change(TorrentHash& setme, tr_variant const* value);
 bool change(TrackerStat& setme, tr_variant const* value);
 
 template<typename T>
-bool change(T& setme, tr_variant const* variant)
+bool change(T& setme, tr_variant const* const var)
 {
-    auto const value = getValue<T>(variant);
+    auto const value = getValue<T>(var);
     return value && change(setme, *value);
 }
 


### PR DESCRIPTION
Part 2 of a small [series](https://github.com/transmissiontorrent/transmission/pull/5) to migrate away from `tr_variant`'s deprecated C API. This PR removes usage from the Qt client's variantHelper code.