### PR TITLE
refactor: remove `tr_lib_init()`

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -326,8 +326,6 @@ void sigHandler(int signal)
 
 int tr_main(int argc, char* argv[])
 {
-    tr_lib_init();
-
     tr_locale_set_global("");
 
     printf("%s %s\n", MyReadableName, LONG_VERSION_STRING);

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -1069,8 +1069,6 @@ void tr_daemon::handle_error(tr_error const& error) const
 
 int tr_main(int argc, char* argv[])
 {
-    tr_lib_init();
-
     tr_locale_set_global("");
 
     auto foreground = bool{};

--- a/libtransmission-app/app.cc
+++ b/libtransmission-app/app.cc
@@ -3,7 +3,7 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <libtransmission/utils.h> // tr_lib_init()
+#include "libtransmission/utils.h"
 
 #include "libtransmission-app/app.h"
 
@@ -11,7 +11,6 @@ namespace tr::app
 {
 void init()
 {
-    tr_lib_init();
     tr_locale_set_global("");
 }
 } // namespace tr::app

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -374,58 +374,6 @@ uint64_t tr_ntohll(uint64_t netlonglong)
 #endif
 }
 
-// ---
-
-namespace
-{
-namespace tr_net_init_impl
-{
-class tr_net_init_mgr
-{
-private:
-    tr_net_init_mgr()
-    {
-        // try to init curl with default settings (currently ssl support + win32 sockets)
-        // but if that fails, we need to init win32 sockets as a bare minimum
-        if (curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK)
-        {
-            curl_global_init(CURL_GLOBAL_WIN32);
-        }
-    }
-
-public:
-    tr_net_init_mgr(tr_net_init_mgr const&) = delete;
-    tr_net_init_mgr(tr_net_init_mgr&&) = delete;
-    tr_net_init_mgr& operator=(tr_net_init_mgr const&) = delete;
-    tr_net_init_mgr& operator=(tr_net_init_mgr&&) = delete;
-    ~tr_net_init_mgr()
-    {
-        curl_global_cleanup();
-    }
-
-    static void create()
-    {
-        if (!instance)
-        {
-            instance = std::unique_ptr<tr_net_init_mgr>{ new tr_net_init_mgr };
-        }
-    }
-
-private:
-    static std::unique_ptr<tr_net_init_mgr> instance;
-};
-
-std::unique_ptr<tr_net_init_mgr> tr_net_init_mgr::instance;
-
-} // namespace tr_net_init_impl
-} // namespace
-
-void tr_lib_init()
-{
-    static auto once = std::once_flag{};
-    std::call_once(once, [] { tr_net_init_impl::tr_net_init_mgr::create(); });
-}
-
 // --- mime-type
 
 std::string_view tr_get_mime_type_for_filename(std::string_view filename)

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -152,8 +152,3 @@ constexpr void tr_timeUpdate(time_t now) noexcept
 
 /** @brief Portability wrapper for `ntohll()` that uses the system implementation if available */
 [[nodiscard]] uint64_t tr_ntohll(uint64_t netlonglong);
-
-// ---
-
-/** @brief Initialise libtransmission for each app */
-void tr_lib_init();

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -52,6 +52,34 @@ using namespace std::literals;
 
 namespace
 {
+class CurlGlobal
+{
+public:
+    CurlGlobal()
+    {
+        // try to init curl with default settings (currently ssl support + win32 sockets)
+        // but if that fails, we need to init win32 sockets as a bare minimum
+        if (curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK)
+        {
+            curl_global_init(CURL_GLOBAL_WIN32);
+        }
+    }
+    ~CurlGlobal()
+    {
+        curl_global_cleanup();
+    }
+    CurlGlobal(CurlGlobal const&) = delete;
+    CurlGlobal(CurlGlobal&&) = delete;
+    CurlGlobal& operator=(CurlGlobal const&) = delete;
+    CurlGlobal& operator=(CurlGlobal&&) = delete;
+};
+
+auto& curlGlobal()
+{
+    static CurlGlobal instance;
+    return instance;
+}
+
 namespace curl_helpers
 {
 
@@ -166,6 +194,8 @@ public:
     explicit Impl(Mediator& mediator_in)
         : mediator{ mediator_in }
     {
+        curlGlobal();
+
         auto const curl_version_num = get_curl_version();
         if (curl_version_num == 0x080901)
         {

--- a/macosx/main.mm
+++ b/macosx/main.mm
@@ -10,12 +10,8 @@
 
 #include <libtransmission/transmission.h>
 
-#include <libtransmission/utils.h>
-
 int main(int argc, char** argv)
 {
-    tr_lib_init();
-
     tr_locale_set_global("");
 
     return NSApplicationMain(argc, (char const**)argv);

--- a/tests/libtransmission/json-test.cc
+++ b/tests/libtransmission/json-test.cc
@@ -23,11 +23,6 @@ using namespace std::literals;
 class JSONTest : public ::testing::TestWithParam<char const*>
 {
 protected:
-    static void SetUpTestSuite()
-    {
-        tr_lib_init();
-    }
-
     void SetUp() override
     {
         ::testing::TestWithParam<char const*>::SetUp();

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -122,14 +122,7 @@ inline bool waitFor(
     }
 }
 
-class TransmissionTest : public ::testing::Test
-{
-protected:
-    static void SetUpTestSuite()
-    {
-        tr_lib_init();
-    }
-};
+using TransmissionTest = ::testing::Test;
 
 class Sandbox
 {

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -3622,8 +3622,6 @@ void get_host_and_port_and_rpc_url(
 
 int tr_main(int argc, char* argv[])
 {
-    tr_lib_init();
-
     tr_locale_set_global("");
 
     auto config = RemoteConfig{};

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -409,8 +409,6 @@ void doScrape(tr_torrent_metainfo const& metainfo)
 
 int tr_main(int argc, char* argv[])
 {
-    tr_lib_init();
-
     tr_locale_set_global("");
 
     tr_logSetQueueEnabled(false);


### PR DESCRIPTION
`tr_lib_init()` is only there to ensure that curl gets initialized. Let's just lazy-load it instead when we're about to use curl for the first time.