### PR TITLE
fix: empty InteropHelper in qt-main

### DIFF
--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -218,11 +218,12 @@ target_link_libraries(${TR_NAME}-qt-lib
         transmission::qt_impl)
 
 target_compile_definitions(${TR_NAME}-qt-lib
+    PUBLIC
+        $<$<BOOL:${ENABLE_QT_COM_INTEROP}>:ENABLE_COM_INTEROP>
+        $<$<BOOL:${ENABLE_QT_DBUS_INTEROP}>:ENABLE_DBUS_INTEROP>
     PRIVATE
         "TRANSLATIONS_DIR=\"${CMAKE_INSTALL_FULL_DATADIR}/${TR_NAME}/translations\""
-        QT_NO_CAST_FROM_ASCII
-        $<$<BOOL:${ENABLE_QT_COM_INTEROP}>:ENABLE_COM_INTEROP>
-        $<$<BOOL:${ENABLE_QT_DBUS_INTEROP}>:ENABLE_DBUS_INTEROP>)
+        QT_NO_CAST_FROM_ASCII)
 
 set_target_properties(
     ${TR_NAME}-qt-lib


### PR DESCRIPTION
Regression from d177f9f903d531c5fab3b306241626320d917836.

Upstream issue 7629 was re-introduced by the regression commit, because the `InteropHelper` class was no-op in `qt/main.cc`. That in turn was because macros `ENABLE_COM_INTEROP` and `ENABLE_DBUS_INTEROP` was defined as `PRIVATE` in the qt-lib CMake target.