### PR TITLE
build: define `QT_NO_CAST_FROM_ASCII` as `PUBLIC`

### DIFF
--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -221,9 +221,9 @@ target_compile_definitions(${TR_NAME}-qt-lib
     PUBLIC
         $<$<BOOL:${ENABLE_QT_COM_INTEROP}>:ENABLE_COM_INTEROP>
         $<$<BOOL:${ENABLE_QT_DBUS_INTEROP}>:ENABLE_DBUS_INTEROP>
+        QT_NO_CAST_FROM_ASCII
     PRIVATE
-        "TRANSLATIONS_DIR=\"${CMAKE_INSTALL_FULL_DATADIR}/${TR_NAME}/translations\""
-        QT_NO_CAST_FROM_ASCII)
+        "TRANSLATIONS_DIR=\"${CMAKE_INSTALL_FULL_DATADIR}/${TR_NAME}/translations\"")
 
 set_target_properties(
     ${TR_NAME}-qt-lib


### PR DESCRIPTION
Define [`QT_NO_CAST_FROM_ASCII`](https://doc.qt.io/qt-6/qstring.html) as `PUBLIC` so that the behaviour is consistent across all qt of our code.