### PR TITLE
fix: qt tests FTBFS

### DIFF
--- a/tests/qt/rpcclient-test.cc
+++ b/tests/qt/rpcclient-test.cc
@@ -27,10 +27,6 @@ Q_DECLARE_METATYPE(Style)
 
 namespace
 {
-auto const tr4_session_get_payload_re = QRegularExpression{ R"(^\{"method":"session-get","tag":[0-9]+\}$)" };
-auto const tr5_session_get_payload_re = QRegularExpression{ R"(^\{"id":[0-9]+,"jsonrpc":"2\.0","method":"session_get"\}$)" };
-} // namespace
-
 class RpcClientTest : public QObject
 {
     Q_OBJECT
@@ -43,7 +39,9 @@ class RpcClientTest : public QObject
 
     static void QVERIFY_is_session_get_request(Style style, QByteArray const& bytes)
     {
-        auto const payload_re = style == Style::Tr4 ? tr4_session_get_payload_re : tr5_session_get_payload_re;
+        auto const payload_re = style == Style::Tr4 ?
+            QRegularExpression{ QString::fromUtf8(R"(^\{"method":"session-get","tag":[0-9]+\}$)") } :
+            QRegularExpression{ QString::fromUtf8(R"(^\{"id":[0-9]+,"jsonrpc":"2\.0","method":"session_get"\}$)") };
         QVERIFY_re_matches(payload_re, bytes);
     }
 
@@ -78,7 +76,7 @@ private slots:
         // setup: create & start `client`
         auto nam = FakeNetworkAccessManager{};
         auto client = RpcClient{ nam };
-        auto const url = QUrl{ "http://example.invalid:9091/transmission/rpc" };
+        auto const url = QUrl{ QString::fromUtf8("http://example.invalid:9091/transmission/rpc") };
         client.start(url);
         QCOMPARE_EQ(client.url(), url);
 
@@ -109,7 +107,7 @@ private slots:
         api_compat::set_default_style(initial_style);
 
         // setup: create & start `client`
-        auto const url = QUrl{ "http://example.invalid:9091/transmission/rpc" };
+        auto const url = QUrl{ QString::fromUtf8("http://example.invalid:9091/transmission/rpc") };
         auto nam = FakeNetworkAccessManager{};
         auto client = RpcClient{ nam };
         client.start(url);
@@ -145,10 +143,10 @@ private slots:
         api_compat::set_default_style(initial_style);
 
         // setup: create & start `client`
-        auto const url = QUrl{ "http://example.invalid:9091/transmission/rpc" };
+        auto const url = QUrl{ QString::fromUtf8("http://example.invalid:9091/transmission/rpc") };
         auto nam = FakeNetworkAccessManager{};
         auto client = RpcClient{ nam };
-        client.start(QUrl{ "http://example.invalid:9091/transmission/rpc" });
+        client.start(url);
 
         // setup: post initial request
         client.exec(TR_KEY_session_get, nullptr);
@@ -174,6 +172,7 @@ private slots:
 private:
     Style const initial_style_ = api_compat::default_style();
 };
+} // namespace
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
Regression from #19.

```
FAILED: [code=1] tests/qt/CMakeFiles/qt-test-rpcclient.dir/rpcclient-test.cc.o 
/usr/sbin/c++ -DENABLE_DBUS_INTEROP -DENABLE_GETTEXT -DFMT_EXCEPTIONS=0 -DFMT_HEADER_ONLY=1 -DFMT_USE_EXCEPTIONS=0 -DQT_CORE_LIB -DQT_DBUS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_CAST_FROM_ASCII -DQT_NO_DEBUG -DQT_SVG_LIB -DQT_TESTCASE_BUILDDIR=\"/__w/transmission/transmission/obj/tests/qt\" -DQT_TESTCASE_SOURCEDIR=\"/__w/transmission/transmission/src/tests/qt\" -DQT_TESTLIB_LIB -DQT_WIDGETS_LIB -DSMALL_DISABLE_EXCEPTIONS=1 -DWITH_OPENSSL -I/__w/transmission/transmission/obj/tests/qt/qt-test-rpcclient_autogen/include -I/__w/transmission/transmission/obj/qt/transmission-qt-lib_autogen/include -I/__w/transmission/transmission/src/qt -I/__w/transmission/transmission/src/libtransmission-app/.. -I/__w/transmission/transmission/obj/libtransmission-app/.. -I/__w/transmission/transmission/src/libtransmission/.. -I/__w/transmission/transmission/obj/libtransmission/.. -isystem /__w/transmission/transmission/src/third-party/sigslot/include -isystem /__w/transmission/transmission/src/third-party/small/include -isystem /usr/include/qt6/QtCore -isystem /usr/include/qt6 -isystem /usr/lib64/qt6/mkspecs/linux-g++ -isystem /usr/include/qt6/QtGui -isystem /usr/include/qt6/QtWidgets -isystem /usr/include/qt6/QtNetwork -isystem /usr/include/qt6/QtSvg -isystem /usr/include/qt6/QtDBus -isystem /usr/include/qt6/QtTest -O2 -g -DNDEBUG -std=gnu++20 -flto=auto -fno-fat-lto-objects -W -Wall -Wextra -Wcast-align -Wduplicated-cond -Wextra-semi -Wfloat-equal -Winit-self -Wint-in-bool-context -Wlogical-op -Wmissing-format-attribute -Wnull-dereference -Wpointer-arith -Wredundant-decls -Wredundant-move -Wrestrict -Wself-move -Wshadow -Wsign-compare -Wsuggest-override -Wuninitialized -Wunreachable-code -Wunused -Wunused-const-variable -Wunused-parameter -Wunused-result -Wwrite-strings -MD -MT tests/qt/CMakeFiles/qt-test-rpcclient.dir/rpcclient-test.cc.o -MF tests/qt/CMakeFiles/qt-test-rpcclient.dir/rpcclient-test.cc.o.d -o tests/qt/CMakeFiles/qt-test-rpcclient.dir/rpcclient-test.cc.o -c /__w/transmission/transmission/src/tests/qt/rpcclient-test.cc
/__w/transmission/transmission/src/tests/qt/rpcclient-test.cc:30:61: error: use of deleted function 'QString::QString(const char*)'
   30 | auto const tr4_session_get_payload_re = QRegularExpression{ R"(^\{"method":"session-get","tag":[0-9]+\}$)" };
      |                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/qt6/QtCore/qcoreapplication.h:9,
                 from /usr/include/qt6/QtWidgets/qapplication.h:9,
                 from /usr/include/qt6/QtWidgets/QApplication:1,
                 from /__w/transmission/transmission/src/tests/qt/rpcclient-test.cc:6:
/usr/include/qt6/QtCore/qstring.h:1143:5: note: declared here
 1143 |     QString(const char *ch) QSTRING_DECL_DELETED_ASCII_OP;
      |     ^~~~~~~
/__w/transmission/transmission/src/tests/qt/rpcclient-test.cc:30:61: note: use '-fdiagnostics-all-candidates' to display considered candidates
   30 | auto const tr4_session_get_payload_re = QRegularExpression{ R"(^\{"method":"session-get","tag":[0-9]+\}$)" };
      |                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/__w/transmission/transmission/src/tests/qt/rpcclient-test.cc:31:61: error: use of deleted function 'QString::QString(const char*)'
   31 | auto const tr5_session_get_payload_re = QRegularExpression{ R"(^\{"id":[0-9]+,"jsonrpc":"2\.0","method":"session_get"\}$)" };
      |                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/qt6/QtCore/qstring.h:1143:5: note: declared here
 1143 |     QString(const char *ch) QSTRING_DECL_DELETED_ASCII_OP;
      |     ^~~~~~~
/__w/transmission/transmission/src/tests/qt/rpcclient-test.cc:31:61: note: use '-fdiagnostics-all-candidates' to display considered candidates
   31 | auto const tr5_session_get_payload_re = QRegularExpression{ R"(^\{"id":[0-9]+,"jsonrpc":"2\.0","method":"session_get"\}$)" };
      |                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/__w/transmission/transmission/src/tests/qt/rpcclient-test.cc: In static member function 'static void RpcClientTest::first_post_is_in_default_style()':
/__w/transmission/transmission/src/tests/qt/rpcclient-test.cc:81:32: error: use of deleted function 'QString::QString(const char*)'
   81 |         auto const url = QUrl{ "http://example.invalid:9091/transmission/rpc" };
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/qt6/QtCore/qstring.h:1143:5: note: declared here
 1143 |     QString(const char *ch) QSTRING_DECL_DELETED_ASCII_OP;
      |     ^~~~~~~
/__w/transmission/transmission/src/tests/qt/rpcclient-test.cc:81:32: note: use '-fdiagnostics-all-candidates' to display considered candidates
   81 |         auto const url = QUrl{ "http://example.invalid:9091/transmission/rpc" };
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/__w/transmission/transmission/src/tests/qt/rpcclient-test.cc: In static member function 'static void RpcClientTest::exec_posts_tr5_after_409_sets_style()':
/__w/transmission/transmission/src/tests/qt/rpcclient-test.cc:112:32: error: use of deleted function 'QString::QString(const char*)'
  112 |         auto const url = QUrl{ "http://example.invalid:9091/transmission/rpc" };
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/qt6/QtCore/qstring.h:1143:5: note: declared here
 1143 |     QString(const char *ch) QSTRING_DECL_DELETED_ASCII_OP;
      |     ^~~~~~~
/__w/transmission/transmission/src/tests/qt/rpcclient-test.cc:112:32: note: use '-fdiagnostics-all-candidates' to display considered candidates
  112 |         auto const url = QUrl{ "http://example.invalid:9091/transmission/rpc" };
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/__w/transmission/transmission/src/tests/qt/rpcclient-test.cc: In static member function 'static void RpcClientTest::exec_post_tr4_after_409_without_rpc_version_header()':
/__w/transmission/transmission/src/tests/qt/rpcclient-test.cc:148:32: error: use of deleted function 'QString::QString(const char*)'
  148 |         auto const url = QUrl{ "http://example.invalid:9091/transmission/rpc" };
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/qt6/QtCore/qstring.h:1143:5: note: declared here
 1143 |     QString(const char *ch) QSTRING_DECL_DELETED_ASCII_OP;
      |     ^~~~~~~
/__w/transmission/transmission/src/tests/qt/rpcclient-test.cc:148:32: note: use '-fdiagnostics-all-candidates' to display considered candidates
  148 |         auto const url = QUrl{ "http://example.invalid:9091/transmission/rpc" };
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/__w/transmission/transmission/src/tests/qt/rpcclient-test.cc:151:28: error: use of deleted function 'QString::QString(const char*)'
  151 |         client.start(QUrl{ "http://example.invalid:9091/transmission/rpc" });
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/qt6/QtCore/qstring.h:1143:5: note: declared here
 1143 |     QString(const char *ch) QSTRING_DECL_DELETED_ASCII_OP;
      |     ^~~~~~~
/__w/transmission/transmission/src/tests/qt/rpcclient-test.cc:151:28: note: use '-fdiagnostics-all-candidates' to display considered candidates
  151 |         client.start(QUrl{ "http://example.invalid:9091/transmission/rpc" });
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```