### PR TITLE
build: update zlib from 1.3.1 to 1.3.2

### DIFF
--- a/dist/msi/components/CommonLibs.wxs
+++ b/dist/msi/components/CommonLibs.wxs
@@ -15,7 +15,7 @@
         <File DiskId="1" KeyPath="yes" Name="$(var.OpenSslSslName)" />
       </Component>
       <Component Id="dll.zlib">
-        <File DiskId="1" KeyPath="yes" Name="zlib.dll" />
+        <File DiskId="1" KeyPath="yes" Name="z.dll" />
       </Component>
     </DirectoryRef>
   </Fragment>

--- a/release/windows/build-transmission.ps1
+++ b/release/windows/build-transmission.ps1
@@ -38,7 +38,7 @@ function global:Build-Transmission(
     }
 
     $OpenSslLibSuffix = if ($Arch -eq 'x86') { '' } else { '-x64' }
-    foreach ($x in @('libcurl', "libcrypto-3${OpenSslLibSuffix}", "libssl-3${OpenSslLibSuffix}", 'zlib', 'dbus-1')) {
+    foreach ($x in @('libcurl', "libcrypto-3${OpenSslLibSuffix}", "libssl-3${OpenSslLibSuffix}", 'z', 'dbus-1')) {
         if ($DepsPrefixDir -ne $PrefixDir) {
             Copy-Item -Path (Join-Path $DepsPrefixDir bin "${x}.dll") -Destination (Join-Path $PrefixDir bin)
         }

--- a/release/windows/build-zlib.ps1
+++ b/release/windows/build-zlib.ps1
@@ -18,5 +18,4 @@ function global:Build-Zlib([string] $PrefixDir, [string] $Arch, [string] $DepsPr
     )
 
     Invoke-CMakeBuildAndInstall $SourceDir $BuildDir $ConfigOptions
-    Copy-Item -Path (Join-Path $BuildDir zlib.pdb) -Destination (Join-Path $PrefixDir bin)
 }

--- a/release/windows/build-zlib.ps1
+++ b/release/windows/build-zlib.ps1
@@ -6,7 +6,7 @@ $global:ZlibDeps = @()
 
 function global:Build-Zlib([string] $PrefixDir, [string] $Arch, [string] $DepsPrefixDir) {
     $Filename = "zlib-${ZlibVersion}.tar.gz"
-    $Url = "https://zlib.net/fossils/${Filename}"
+    $Url = "https://github.com/madler/zlib/releases/download/v${ZlibVersion}/${Filename}"
 
     $SourceDir = Invoke-DownloadAndUnpack $Url $Filename
     $BuildDir = Join-Path $SourceDir .build

--- a/release/windows/build-zlib.ps1
+++ b/release/windows/build-zlib.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 
-$global:ZlibVersion = '1.3.1'
+$global:ZlibVersion = '1.3.2'
 
 $global:ZlibDeps = @()
 


### PR DESCRIPTION
[zlib 1.3.2](https://github.com/madler/zlib/releases/tag/v1.3.2) is a bugfix release that addresses findings of the [7ASecurity audit](https://7asecurity.com/blog/2026/02/zlib-7asecurity-audit/)

*edit:* wild that they renamed the file from `zlib.dll` to `z.dll` in a semver/patch release :shrug: 

Notes: On Windows builds, change to zlib `1.3.2` from `1.3.1` to pick up [7ASecurity audit](https://7asecurity.com/blog/2026/02/zlib-7asecurity-audit/) fixes.