### PR TITLE
refactor: use std::to_array()

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -52,7 +52,7 @@ char const* torrentPath = nullptr;
 using Arg = tr_option::Arg;
 static_assert(TrDefaultPeerPort == 51413, "update 'port' desc");
 static_assert(TrDefaultPeerSocketTos == "le", "update 'tos' desc");
-auto constexpr Options = std::array<tr_option, 20>{ {
+auto constexpr Options = std::to_array<tr_option>({
     { 'b', "blocklist", "Enable peer blocklists", "b", Arg::None, nullptr },
     { 'B', "no-blocklist", "Disable peer blocklists", "B", Arg::None, nullptr },
     { 'd', "downlimit", "Set max download speed in " SPEED_K_STR, "d", Arg::Required, "<speed>" },
@@ -79,7 +79,7 @@ auto constexpr Options = std::array<tr_option, 20>{ {
     { 500, "sequential-download", "Download pieces sequentially", "seq", Arg::None, nullptr },
 
     { 0, nullptr, nullptr, nullptr, Arg::None, nullptr },
-} };
+});
 static_assert(Options[std::size(Options) - 2].val != 0);
 } // namespace
 

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -87,7 +87,7 @@ static_assert(TrDefaultPeerPort == 51413, "update 'peerport' desc");
 static_assert(TrDefaultPeerLimitTorrent == 50, "update 'peerlimit-torrent' desc");
 static_assert(TrDefaultPeerLimitGlobal == 200, "update 'peerlimit-global' desc");
 static_assert(TrDefaultRpcPort == 9091 && R"(update "port" desc)");
-auto constexpr Options = std::array<tr_option, 48>{ {
+auto constexpr Options = std::to_array<tr_option>({
     { 'a', "allowed", "Allowed IP addresses. (Default: '127.0.0.1,::1')", "a", Arg::Required, "<list>" },
     { 'b', "blocklist", "Enable peer blocklists", "b", Arg::None, nullptr },
     { 'B', "no-blocklist", "Disable peer blocklists", "B", Arg::None, nullptr },
@@ -156,7 +156,7 @@ auto constexpr Options = std::array<tr_option, 48>{ {
     { 995, "no-sequential-download", "Disable sequential download by default", "SEQ", Arg::None, nullptr },
     { 'x', "pid-file", "Enable PID file", "x", Arg::Required, "<pid-file>" },
     { 0, nullptr, nullptr, nullptr, Arg::None, nullptr },
-} };
+});
 static_assert(Options[std::size(Options) - 2].val != 0);
 } // namespace
 

--- a/gtk/Actions.cc
+++ b/gtk/Actions.cc
@@ -69,14 +69,14 @@ void toggle_pref_cb(Gio::SimpleAction& action, gpointer prefs_key)
 }
 
 // action-name, prefs_name
-constexpr auto PrefToggleEntries = std::array<std::pair<std::string_view, tr_quark>, 6>{ {
+constexpr auto PrefToggleEntries = std::to_array<std::pair<std::string_view, tr_quark>>({
     { "alt-speed-enabled"sv, TR_KEY_alt_speed_enabled },
     { "compact-view"sv, TR_KEY_compact_view },
     { "show-filterbar"sv, TR_KEY_show_filterbar },
     { "show-statusbar"sv, TR_KEY_show_statusbar },
     { "show-toolbar"sv, TR_KEY_show_toolbar },
     { "sort-reversed"sv, TR_KEY_sort_reversed },
-} };
+});
 
 constexpr auto Entries = std::array{
     "copy-magnet-link-to-clipboard"sv,

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -106,13 +106,13 @@ private:
     bool isPaused_ = false;
     sigc::connection refresh_tag_;
 
-    static auto constexpr level_names_ = std::array<std::pair<tr_log_level, char const*>, 5U>{ {
+    static auto constexpr level_names_ = std::to_array<std::pair<tr_log_level, char const*>>({
         { TR_LOG_CRITICAL, NC_("Logging level", "Critical") },
         { TR_LOG_ERROR, NC_("Logging level", "Error") },
         { TR_LOG_WARN, NC_("Logging level", "Warning") },
         { TR_LOG_INFO, NC_("Logging level", "Information") },
         { TR_LOG_DEBUG, NC_("Logging level", "Debug") },
-    } };
+    });
 };
 
 namespace

--- a/gtk/TorrentFilter.cc
+++ b/gtk/TorrentFilter.cc
@@ -134,7 +134,7 @@ void TorrentFilter::update(Torrent::ChangeFlags changes)
 
     if (show_mode_ != ShowMode::ShowAll)
     {
-        static auto TR_CONSTEXPR23 ShowModeFlags = std::array<std::pair<ShowMode, Torrent::ChangeFlags>, 7U>{ {
+        static auto TR_CONSTEXPR23 ShowModeFlags = std::to_array<std::pair<ShowMode, Torrent::ChangeFlags>>({
             { ShowMode::ShowActive, Flag::ACTIVE_PEER_COUNT | Flag::ACTIVITY },
             { ShowMode::ShowDownloading, Flag::ACTIVITY },
             { ShowMode::ShowError, Flag::ERROR_CODE },
@@ -142,7 +142,7 @@ void TorrentFilter::update(Torrent::ChangeFlags changes)
             { ShowMode::ShowPaused, Flag::ACTIVITY },
             { ShowMode::ShowSeeding, Flag::ACTIVITY },
             { ShowMode::ShowVerifying, Flag::ACTIVITY },
-        } };
+        });
 
         auto const iter = std::ranges::find_if(ShowModeFlags, [key = show_mode_](auto const& row) { return row.first == key; });
         refilter_needed = iter != std::ranges::end(ShowModeFlags) && changes.test(iter->second);

--- a/gtk/TorrentSorter.cc
+++ b/gtk/TorrentSorter.cc
@@ -237,7 +237,7 @@ int TorrentSorter::compare(Torrent const& lhs, Torrent const& rhs) const
 void TorrentSorter::update(Torrent::ChangeFlags changes)
 {
     using Flag = Torrent::ChangeFlag;
-    static auto TR_CONSTEXPR23 CompareFlags = std::array<std::pair<CompareFunc, Torrent::ChangeFlags>, 9U>{ {
+    static auto TR_CONSTEXPR23 CompareFlags = std::to_array<std::pair<CompareFunc, Torrent::ChangeFlags>>({
         { &compare_by_activity, Flag::ACTIVE_PEER_COUNT | Flag::QUEUE_POSITION | Flag::SPEED_DOWN | Flag::SPEED_UP },
         { &compare_by_age, Flag::ADDED_DATE | Flag::NAME },
         { &compare_by_eta, Flag::ETA | Flag::NAME },
@@ -247,7 +247,7 @@ void TorrentSorter::update(Torrent::ChangeFlags changes)
         { &compare_by_ratio, Flag::QUEUE_POSITION | Flag::RATIO },
         { &compare_by_size, Flag::NAME | Flag::TOTAL_SIZE },
         { &compare_by_state, Flag::ACTIVITY | Flag::QUEUE_POSITION },
-    } };
+    });
 
     if (auto const iter = std::ranges::find_if(
             CompareFlags,

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -1240,11 +1240,11 @@ namespace on_scrape_done_helpers
 {
     /* Found a tracker that returns some bespoke string for this case?
        Add your patch here and open a PR */
-    auto too_long_errors = std::array<std::string_view, 3>{
+    auto too_long_errors = std::to_array<std::string_view>({
         "Bad Request",
         "GET string too long",
         "Request-URI Too Long",
-    };
+    });
 
     return std::ranges::any_of(too_long_errors, [&errmsg](auto const& substr) { return tr_strv_contains(errmsg, substr); });
 }

--- a/libtransmission/api-compat.cc
+++ b/libtransmission/api-compat.cc
@@ -59,7 +59,7 @@ struct KeyLookupTable
     }
 };
 
-auto constexpr RpcKeys = std::array<ApiKey, 212U>{ {
+auto constexpr RpcKeys = std::to_array<ApiKey>({
     { .current = TR_KEY_active_torrent_count, .legacy = TR_KEY_active_torrent_count_camel_APICOMPAT },
     { .current = TR_KEY_activity_date, .legacy = TR_KEY_activity_date_camel_APICOMPAT },
     { .current = TR_KEY_added_date, .legacy = TR_KEY_added_date_camel_APICOMPAT },
@@ -275,9 +275,9 @@ auto constexpr RpcKeys = std::array<ApiKey, 212U>{ {
     { .current = TR_KEY_torrent_start_now, .legacy = TR_KEY_torrent_start_now_kebab_APICOMPAT },
     { .current = TR_KEY_torrent_stop, .legacy = TR_KEY_torrent_stop_kebab_APICOMPAT },
     { .current = TR_KEY_torrent_verify, .legacy = TR_KEY_torrent_verify_kebab_APICOMPAT },
-} };
+});
 
-auto constexpr SessionKeys = std::array<ApiKey, 139U>{ {
+auto constexpr SessionKeys = std::to_array<ApiKey>({
     { .current = TR_KEY_activity_date, .legacy = TR_KEY_activity_date_kebab_APICOMPAT },
     { .current = TR_KEY_added_date, .legacy = TR_KEY_added_date_kebab_APICOMPAT },
     { .current = TR_KEY_alt_speed_down, .legacy = TR_KEY_alt_speed_down_kebab_APICOMPAT },
@@ -422,7 +422,7 @@ auto constexpr SessionKeys = std::array<ApiKey, 139U>{ {
     { .current = TR_KEY_watch_dir, .legacy = TR_KEY_watch_dir_kebab_APICOMPAT },
     { .current = TR_KEY_watch_dir_enabled, .legacy = TR_KEY_watch_dir_enabled_kebab_APICOMPAT },
     { .current = TR_KEY_watch_dir_force_generic, .legacy = TR_KEY_watch_dir_force_generic_kebab_APICOMPAT },
-} };
+});
 
 [[nodiscard]] consteval size_t lookup_table_size()
 {
@@ -531,7 +531,7 @@ auto constexpr PreferClearLegacy = std::string_view{ "tolerated" };
         return Error::SUCCESS;
     }
 
-    static auto constexpr Phrases = std::array<std::pair<std::string_view, Error::Code>, 14U>{ {
+    static auto constexpr Phrases = std::to_array<std::pair<std::string_view, Error::Code>>({
         { "absolute", Error::PATH_NOT_ABSOLUTE },
         { "couldn't fetch blocklist", Error::HTTP_ERROR },
         { "couldn't save", Error::SYSTEM_ERROR },
@@ -546,7 +546,7 @@ auto constexpr PreferClearLegacy = std::string_view{ "tolerated" };
         { "torrent-rename-path requires 1 torrent", Error::INVALID_PARAMS },
         { "unrecognized info", Error::UNRECOGNIZED_INFO },
         { MethodNotFoundLegacyErrmsg, Error::METHOD_NOT_FOUND },
-    } };
+    });
 
     for (auto const& [substr, code] : Phrases)
     {
@@ -692,7 +692,7 @@ struct State
 {
     if (state.is_settings && state.current_key_is_any_of({ TR_KEY_sort_mode, TR_KEY_sort_mode_kebab_APICOMPAT }))
     {
-        static auto constexpr Strings = std::array<std::pair<std::string_view /*Tr5*/, std::string_view /*Tr4*/>, 10U>{ {
+        static auto constexpr Strings = std::to_array<std::pair<std::string_view /*Tr5*/, std::string_view /*Tr4*/>>({
             { "sort_by_activity", "sort-by-activity" },
             { "sort_by_age", "sort-by-age" },
             { "sort_by_eta", "sort-by-eta" },
@@ -703,7 +703,7 @@ struct State
             { "sort_by_ratio", "sort-by-ratio" },
             { "sort_by_size", "sort-by-size" },
             { "sort_by_state", "sort-by-state" },
-        } };
+        });
         for (auto const& [current, legacy] : Strings)
         {
             if (src == current || src == legacy)
@@ -715,7 +715,7 @@ struct State
 
     if (state.is_settings && state.current_key_is_any_of({ TR_KEY_filter_mode, TR_KEY_filter_mode_kebab_APICOMPAT }))
     {
-        static auto constexpr Strings = std::array<std::pair<std::string_view, std::string_view>, 8U>{ {
+        static auto constexpr Strings = std::to_array<std::pair<std::string_view, std::string_view>>({
             { "show_active", "show-active" },
             { "show_all", "show-all" },
             { "show_downloading", "show-downloading" },
@@ -724,7 +724,7 @@ struct State
             { "show_paused", "show-paused" },
             { "show_seeding", "show-seeding" },
             { "show_verifying", "show-verifying" },
-        } };
+        });
         for (auto const& [current, legacy] : Strings)
         {
             if (src == current || src == legacy)
@@ -736,12 +736,12 @@ struct State
 
     if (state.is_settings && state.current_key_is_any_of({ TR_KEY_statusbar_stats, TR_KEY_statusbar_stats_kebab_APICOMPAT }))
     {
-        static auto constexpr Strings = std::array<std::pair<std::string_view, std::string_view>, 4U>{ {
+        static auto constexpr Strings = std::to_array<std::pair<std::string_view, std::string_view>>({
             { "total_ratio", "total-ratio" },
             { "total_transfer", "total-transfer" },
             { "session_ratio", "session-ratio" },
             { "session_transfer", "session-transfer" },
-        } };
+        });
         for (auto const& [current, legacy] : Strings)
         {
             if (src == current || src == legacy)

--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -501,7 +501,7 @@ struct Client
     format_func formatter;
 };
 
-auto constexpr Clients = std::array<Client, 131>{ {
+auto constexpr Clients = std::to_array<Client>({
     { .begins_with = "-AD", .name = "Advanced Download Manager", .formatter = three_digit_formatter },
     { .begins_with = "-AG", .name = "Ares", .formatter = four_digit_formatter },
     { .begins_with = "-AR", .name = "Arctic", .formatter = four_digit_formatter },
@@ -633,7 +633,7 @@ auto constexpr Clients = std::array<Client, 131>{ {
     { .begins_with = "btpd", .name = "BT Protocol Daemon", .formatter = btpd_formatter },
     { .begins_with = "eX", .name = "eXeem", .formatter = no_version_formatter },
     { .begins_with = "martini", .name = "Martini Man", .formatter = no_version_formatter },
-} };
+});
 
 } // namespace
 

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -447,7 +447,7 @@ tr_sys_file_t tr_sys_file_open(std::string_view path, int const flags, int const
         int native_value;
     };
 
-    auto constexpr NativeMap = std::array<native_map_item, 7U>{ {
+    auto constexpr NativeMap = std::to_array<native_map_item>({
         {
             .symbolic_mask = TR_SYS_FILE_READ | TR_SYS_FILE_WRITE,
             .symbolic_value = TR_SYS_FILE_READ | TR_SYS_FILE_WRITE,
@@ -478,7 +478,7 @@ tr_sys_file_t tr_sys_file_open(std::string_view path, int const flags, int const
             .symbolic_value = TR_SYS_FILE_SEQUENTIAL,
             .native_value = O_SEQUENTIAL,
         },
-    } };
+    });
 
     int native_flags = O_BINARY | O_LARGEFILE | O_CLOEXEC; // NOLINT(misc-redundant-expression)
 

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -279,13 +279,13 @@ void tr_logAddMessage(char const* file, long line, tr_log_level level, std::stri
 namespace
 {
 
-auto constexpr LogKeys = std::array<std::pair<std::string_view, tr_log_level>, 7>{ { { "off", TR_LOG_OFF },
-                                                                                     { "critical", TR_LOG_CRITICAL },
-                                                                                     { "error", TR_LOG_ERROR },
-                                                                                     { "warn", TR_LOG_WARN },
-                                                                                     { "info", TR_LOG_INFO },
-                                                                                     { "debug", TR_LOG_DEBUG },
-                                                                                     { "trace", TR_LOG_TRACE } } };
+auto constexpr LogKeys = std::to_array<std::pair<std::string_view, tr_log_level>>({ { "off", TR_LOG_OFF },
+                                                                                    { "critical", TR_LOG_CRITICAL },
+                                                                                    { "error", TR_LOG_ERROR },
+                                                                                    { "warn", TR_LOG_WARN },
+                                                                                    { "info", TR_LOG_INFO },
+                                                                                    { "debug", TR_LOG_DEBUG },
+                                                                                    { "trace", TR_LOG_TRACE } });
 
 bool constexpr keysAreOrdered()
 {

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -285,7 +285,7 @@ auto constexpr LogKeys = std::to_array<std::pair<std::string_view, tr_log_level>
                                                                                     { "warn", TR_LOG_WARN },
                                                                                     { "info", TR_LOG_INFO },
                                                                                     { "debug", TR_LOG_DEBUG },
-                                                                                    { "trace", TR_LOG_TRACE } });
+                                                                                    { "trace", TR_LOG_TRACE }, });
 
 bool constexpr keysAreOrdered()
 {

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -279,13 +279,15 @@ void tr_logAddMessage(char const* file, long line, tr_log_level level, std::stri
 namespace
 {
 
-auto constexpr LogKeys = std::to_array<std::pair<std::string_view, tr_log_level>>({ { "off", TR_LOG_OFF },
-                                                                                    { "critical", TR_LOG_CRITICAL },
-                                                                                    { "error", TR_LOG_ERROR },
-                                                                                    { "warn", TR_LOG_WARN },
-                                                                                    { "info", TR_LOG_INFO },
-                                                                                    { "debug", TR_LOG_DEBUG },
-                                                                                    { "trace", TR_LOG_TRACE }, });
+auto constexpr LogKeys = std::to_array<std::pair<std::string_view, tr_log_level>>({
+    { "off", TR_LOG_OFF },
+    { "critical", TR_LOG_CRITICAL },
+    { "error", TR_LOG_ERROR },
+    { "warn", TR_LOG_WARN },
+    { "info", TR_LOG_INFO },
+    { "debug", TR_LOG_DEBUG },
+    { "trace", TR_LOG_TRACE },
+});
 
 bool constexpr keysAreOrdered()
 {

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -253,11 +253,11 @@ std::string tr_getWebClientDir([[maybe_unused]] tr_session const* session)
     /* Generally, Web interface should be stored in a Web subdir of
      * calling executable dir. */
 
-    static auto constexpr KnownFolderIds = std::array<KNOWNFOLDERID const* const, 3>{
+    static auto constexpr KnownFolderIds = std::to_array<KNOWNFOLDERID const* const>({
         &FOLDERID_LocalAppData,
         &FOLDERID_RoamingAppData,
         &FOLDERID_ProgramData,
-    };
+    });
 
     for (auto const* const folder_id : KnownFolderIds)
     {

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -209,7 +209,7 @@ void send_simple_response(struct evhttp_request* req, int code, char const* text
 [[nodiscard]] constexpr char const* mimetype_guess(std::string_view path)
 {
     // these are the ones we need for serving the web client's files...
-    auto constexpr Types = std::array<std::pair<std::string_view, char const*>, 7>{ {
+    auto constexpr Types = std::to_array<std::pair<std::string_view, char const*>>({
         { ".css"sv, "text/css" },
         { ".gif"sv, "image/gif" },
         { ".html"sv, "text/html" },
@@ -217,7 +217,7 @@ void send_simple_response(struct evhttp_request* req, int code, char const* text
         { ".js"sv, "application/javascript" },
         { ".png"sv, "image/png" },
         { ".svg"sv, "image/svg+xml" },
-    } };
+    });
 
     for (auto const& [suffix, mime_type] : Types)
     {

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1676,11 +1676,11 @@ void add_torrent_impl(struct tr_rpc_idle_data* data, tr_ctor& ctor)
         return;
     }
 
-    static auto constexpr Fields = std::array<tr_quark, 3U>{
+    static auto constexpr Fields = std::to_array<tr_quark>({
         TR_KEY_id,
         TR_KEY_name,
         TR_KEY_hash_string,
-    };
+    });
     if (duplicate_of != nullptr)
     {
         data->args_out.try_emplace(
@@ -1742,7 +1742,7 @@ void onMetadataFetched(tr_web::FetchResponse const& web_response)
 
 bool isCurlURL(std::string_view url)
 {
-    auto constexpr Schemes = std::array<std::string_view, 4>{ "http"sv, "https"sv, "ftp"sv, "sftp"sv };
+    auto constexpr Schemes = std::to_array<std::string_view>({ "http"sv, "https"sv, "ftp"sv, "sftp"sv });
     auto const parsed = tr_urlParse(url);
     return parsed && std::ranges::find(Schemes, parsed->scheme) != std::ranges::end(Schemes);
 }

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -105,11 +105,11 @@ bool is_junk_file(std::string_view filename)
     }
 #endif
 
-    auto constexpr Files = std::array<std::string_view, 3>{
+    auto constexpr Files = std::to_array<std::string_view>({
         ".DS_Store"sv,
         "Thumbs.db"sv,
         "desktop.ini"sv,
-    };
+    });
 
     return std::ranges::find(Files, base) != std::ranges::end(Files);
 }
@@ -206,7 +206,7 @@ bool tr_torrent_files::move(
         return false;
     }
 
-    auto const paths = std::array<std::string_view, 1>{ old_parent.sv() };
+    auto const paths = std::to_array<std::string_view>({ old_parent.sv() });
 
     auto err = bool{};
 
@@ -298,7 +298,7 @@ void tr_torrent_files::remove(
     }
 
     // move the local data to the tmpdir
-    auto const paths = std::array<std::string_view, 1>{ parent.sv() };
+    auto const paths = std::to_array<std::string_view>({ parent.sv() });
     for (tr_file_index_t idx = 0, n_files = file_count(); idx < n_files; ++idx)
     {
         if (auto const found = find(idx, std::data(paths), std::size(paths)); found)
@@ -366,10 +366,10 @@ namespace
 // for potential support of different filesystems on the same OS
 [[nodiscard, maybe_unused]] bool is_unix_reserved_file(std::string_view in) noexcept
 {
-    static auto constexpr ReservedNames = std::array<std::string_view, 2>{
+    static auto constexpr ReservedNames = std::to_array<std::string_view>({
         "."sv,
         ".."sv,
-    };
+    });
     return (std::ranges::find(ReservedNames, in) != std::ranges::end(ReservedNames));
 }
 
@@ -398,21 +398,21 @@ namespace
     std::ranges::for_each(in_upper, [](auto& ch) { ch = static_cast<char>(toupper(ch)); });
     auto const in_upper_sv = in_upper.sv();
 
-    static auto constexpr ReservedNames = std::array<std::string_view, 22>{
+    static auto constexpr ReservedNames = std::to_array<std::string_view>({
         "AUX"sv,  "CON"sv,  "NUL"sv,  "PRN"sv, //
         "COM1"sv, "COM2"sv, "COM3"sv, "COM4"sv, "COM5"sv, "COM6"sv, "COM7"sv, "COM8"sv, "COM9"sv, //
         "LPT1"sv, "LPT2"sv, "LPT3"sv, "LPT4"sv, "LPT5"sv, "LPT6"sv, "LPT7"sv, "LPT8"sv, "LPT9"sv, //
-    };
+    });
     if (std::ranges::find(ReservedNames, in_upper_sv) != std::ranges::end(ReservedNames))
     {
         return true;
     }
 
-    static auto constexpr ReservedPrefixes = std::array<std::string_view, 22>{
+    static auto constexpr ReservedPrefixes = std::to_array<std::string_view>({
         "AUX."sv,  "CON."sv,  "NUL."sv,  "PRN."sv, //
         "COM1."sv, "COM2."sv, "COM3."sv, "COM4."sv, "COM5."sv, "COM6."sv, "COM7."sv, "COM8."sv, "COM9."sv, //
         "LPT1."sv, "LPT2."sv, "LPT3."sv, "LPT4."sv, "LPT5."sv, "LPT6."sv, "LPT7."sv, "LPT8."sv, "LPT9."sv, //
-    };
+    });
     return std::ranges::any_of(
         ReservedPrefixes,
         [in_upper_sv](auto const& prefix) { return tr_strv_starts_with(in_upper_sv, prefix); });

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -407,7 +407,7 @@ void torrentCallScript(tr_torrent const* tor, std::string const& script)
     auto torrent_dir = tr_pathbuf{ tor->current_dir() };
     tr_sys_path_native_separators(std::data(torrent_dir));
 
-    auto const cmd = std::array<char const*, 2>{ script.c_str(), nullptr };
+    auto const cmd = std::to_array<char const*>({ script.c_str(), nullptr });
 
     auto const id_str = std::to_string(tr_torrentId(tor));
     auto const labels_str = build_labels_string(tor->labels());

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -180,13 +180,13 @@ namespace
 
 constexpr std::optional<uint16_t> getPortForScheme(std::string_view scheme)
 {
-    auto constexpr KnownSchemes = std::array<std::pair<std::string_view, uint16_t>, 5>{ {
+    auto constexpr KnownSchemes = std::to_array<std::pair<std::string_view, uint16_t>>({
         { "ftp"sv, 21U },
         { "http"sv, 80U },
         { "https"sv, 443U },
         { "sftp"sv, 22U },
         { "udp"sv, 80U },
-    } };
+    });
 
     for (auto const& [known_scheme, port] : KnownSchemes)
     {
@@ -217,7 +217,7 @@ constexpr bool urlCharsAreValid(std::string_view url)
 
 bool tr_isValidTrackerScheme(std::string_view scheme)
 {
-    auto constexpr Schemes = std::array<std::string_view, 3>{ "http"sv, "https"sv, "udp"sv };
+    auto constexpr Schemes = std::to_array<std::string_view>({ "http"sv, "https"sv, "udp"sv });
     return std::ranges::find(Schemes, scheme) != std::ranges::end(Schemes);
 }
 
@@ -430,7 +430,7 @@ bool tr_urlIsValidTracker(std::string_view url)
 
 bool tr_urlIsValid(std::string_view url)
 {
-    auto constexpr Schemes = std::array<std::string_view, 5>{ "http"sv, "https"sv, "ftp"sv, "sftp"sv, "udp"sv };
+    auto constexpr Schemes = std::to_array<std::string_view>({ "http"sv, "https"sv, "ftp"sv, "sftp"sv, "udp"sv });
     auto const parsed = tr_urlParse(url);
     return parsed && std::ranges::find(Schemes, parsed->scheme) != std::ranges::end(Schemes);
 }
@@ -477,7 +477,7 @@ std::string tr_urlPercentDecode(std::string_view in)
         in.remove_prefix(pos);
         if (std::size(in) >= 3 && in[0] == '%' && (std::isxdigit(in[1]) != 0) && (std::isxdigit(in[2]) != 0))
         {
-            auto hexstr = std::array<char, 3>{ in[1], in[2], '\0' };
+            auto hexstr = std::to_array<char>({ in[1], in[2], '\0' });
             auto const hex = strtoul(std::data(hexstr), nullptr, 16);
             out += char(hex);
             in.remove_prefix(3);

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -117,10 +117,10 @@ CURLcode ssl_context_func(CURL* /*curl*/, void* ssl_ctx, void* /*user_data*/)
         return CURLE_OK;
     }
 
-    static auto constexpr SysStoreNames = std::array<LPCWSTR, 2>{
+    static auto constexpr SysStoreNames = std::to_array<LPCWSTR>({
         L"CA",
         L"ROOT",
-    };
+    });
 
     for (auto& sys_store_name : SysStoreNames)
     {

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -158,7 +158,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
     ui_.listView->setModel(&filter_model_);
     connect(ui_.listView->selectionModel(), &QItemSelectionModel::selectionChanged, refresh_action_sensitivity_soon);
 
-    auto const sort_modes = std::array<std::pair<QAction*, SortMode>, 9U>{ {
+    auto const sort_modes = std::to_array<std::pair<QAction*, SortMode>>({
         { ui_.action_SortByActivity, SortMode::SortByActivity },
         { ui_.action_SortByAge, SortMode::SortByAge },
         { ui_.action_SortByETA, SortMode::SortByEta },
@@ -168,7 +168,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
         { ui_.action_SortByRatio, SortMode::SortByRatio },
         { ui_.action_SortBySize, SortMode::SortBySize },
         { ui_.action_SortByState, SortMode::SortByState },
-    } };
+    });
 
     // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     auto* action_group = new QActionGroup{ this };

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -108,11 +108,11 @@ void PrefsDialog::initAltSpeedDaysCombo(QComboBox* const w, tr_quark const key)
 
 void PrefsDialog::initEncryptionCombo(QComboBox* const w, tr_quark const key)
 {
-    static auto const Items = std::array<std::pair<QString, tr_encryption_mode>, 3U>{ {
+    static auto const Items = std::to_array<std::pair<QString, tr_encryption_mode>>({
         { tr("Allow encryption"), TR_CLEAR_PREFERRED },
         { tr("Prefer encryption"), TR_ENCRYPTION_PREFERRED },
         { tr("Require encryption"), TR_ENCRYPTION_REQUIRED },
-    } };
+    });
 
     initComboFromItems(Items, w, key);
 }

--- a/qt/main.cc
+++ b/qt/main.cc
@@ -37,7 +37,7 @@ auto constexpr FileArgsSeparator = "--"sv;
 auto constexpr QtArgsSeparator = "---"sv;
 
 using Arg = tr_option::Arg;
-auto constexpr Opts = std::array<tr_option, 8>{ {
+auto constexpr Opts = std::to_array<tr_option>({
     {
         .val = 'g',
         .longName = "config-dir",
@@ -102,7 +102,7 @@ auto constexpr Opts = std::array<tr_option, 8>{ {
         .arg = Arg::None,
         .argName = nullptr,
     },
-} };
+});
 static_assert(Opts[std::size(Opts) - 2].val != 0);
 } // namespace
 

--- a/tests/libtransmission/announce-list-test.cc
+++ b/tests/libtransmission/announce-list-test.cc
@@ -130,12 +130,12 @@ TEST_F(AnnounceListTest, canNotAddInvalidUrl)
 
 TEST_F(AnnounceListTest, canSet)
 {
-    auto constexpr Urls = std::array<char const*, 3>{
+    auto constexpr Urls = std::to_array<char const*>({
         "https://www.example.com/a/announce",
         "https://www.example.com/b/announce",
         "https://www.example.com/c/announce",
-    };
-    auto constexpr Tiers = std::array<tr_tracker_tier_t, 3>{ 1, 2, 3 };
+    });
+    auto constexpr Tiers = std::to_array<tr_tracker_tier_t>({ 1, 2, 3 });
 
     auto announce_list = tr_announce_list{};
     EXPECT_EQ(3U, announce_list.set(std::data(Urls), std::data(Tiers), 3));
@@ -150,11 +150,15 @@ TEST_F(AnnounceListTest, canSet)
 
 TEST_F(AnnounceListTest, canSetUnsortedWithBackupsInTiers)
 {
-    auto constexpr Urls = std::array<char const*, 6>{
-        "https://www.backup-a.com/announce",  "https://www.backup-b.com/announce",  "https://www.backup-c.com/announce",
-        "https://www.primary-a.com/announce", "https://www.primary-b.com/announce", "https://www.primary-c.com/announce",
-    };
-    auto constexpr Tiers = std::array<tr_tracker_tier_t, 6>{ 0, 1, 2, 0, 1, 2 };
+    auto constexpr Urls = std::to_array<char const*>({
+        "https://www.backup-a.com/announce",
+        "https://www.backup-b.com/announce",
+        "https://www.backup-c.com/announce",
+        "https://www.primary-a.com/announce",
+        "https://www.primary-b.com/announce",
+        "https://www.primary-c.com/announce",
+    });
+    auto constexpr Tiers = std::to_array<tr_tracker_tier_t>({ 0, 1, 2, 0, 1, 2 });
 
     auto announce_list = tr_announce_list{};
     EXPECT_EQ(6U, announce_list.set(std::data(Urls), std::data(Tiers), 6));
@@ -183,12 +187,12 @@ TEST_F(AnnounceListTest, canSetUnsortedWithBackupsInTiers)
 
 TEST_F(AnnounceListTest, canSetExceptDuplicate)
 {
-    auto constexpr Urls = std::array<char const*, 3>{
+    auto constexpr Urls = std::to_array<char const*>({
         "https://www.example.com/a/announce",
         "https://www.example.com/b/announce",
         "https://www.example.com/b/announce",
-    };
-    auto constexpr Tiers = std::array<tr_tracker_tier_t, 3>{ 3, 2, 1 };
+    });
+    auto constexpr Tiers = std::to_array<tr_tracker_tier_t>({ 3, 2, 1 });
 
     auto announce_list = tr_announce_list{};
     EXPECT_EQ(2U, announce_list.set(std::data(Urls), std::data(Tiers), 3));
@@ -201,12 +205,12 @@ TEST_F(AnnounceListTest, canSetExceptDuplicate)
 
 TEST_F(AnnounceListTest, canSetExceptInvalid)
 {
-    auto constexpr Urls = std::array<char const*, 3>{
+    auto constexpr Urls = std::to_array<char const*>({
         "https://www.example.com/a/announce",
         "telnet://www.example.com/b/announce",
         "https://www.example.com/c/announce",
-    };
-    auto constexpr Tiers = std::array<tr_tracker_tier_t, 3>{ 1, 2, 3 };
+    });
+    auto constexpr Tiers = std::to_array<tr_tracker_tier_t>({ 1, 2, 3 });
 
     auto announce_list = tr_announce_list{};
     EXPECT_EQ(2U, announce_list.set(std::data(Urls), std::data(Tiers), 3));
@@ -339,11 +343,11 @@ TEST_F(AnnounceListTest, announceToScrape)
         std::string_view expected_scrape;
     };
 
-    auto constexpr Tests = std::array<ScrapeTest, 3>{ {
+    auto constexpr Tests = std::to_array<ScrapeTest>({
         { .announce = "https://www.example.com/announce"sv, .expected_scrape = "https://www.example.com/scrape"sv },
         { .announce = "https://www.example.com/foo"sv, .expected_scrape = ""sv },
         { .announce = "udp://www.example.com:999/"sv, .expected_scrape = "udp://www.example.com:999/"sv },
-    } };
+    });
 
     for (auto const& test : Tests)
     {
@@ -354,12 +358,12 @@ TEST_F(AnnounceListTest, announceToScrape)
 
 TEST_F(AnnounceListTest, save)
 {
-    auto constexpr Urls = std::array<char const*, 3>{
+    auto constexpr Urls = std::to_array<char const*>({
         "https://www.example.com/a/announce",
         "https://www.example.com/b/announce",
         "https://www.example.com/c/announce",
-    };
-    auto constexpr Tiers = std::array<tr_tracker_tier_t, 3>{ 0, 1, 2 };
+    });
+    auto constexpr Tiers = std::to_array<tr_tracker_tier_t>({ 0, 1, 2 });
 
     // first, set up a scratch torrent
     auto constexpr* const OriginalFile = LIBTRANSMISSION_TEST_ASSETS_DIR "/Android-x86 8.1 r6 iso.torrent";

--- a/tests/libtransmission/announcer-udp-test.cc
+++ b/tests/libtransmission/announcer-udp-test.cc
@@ -691,11 +691,11 @@ TEST_F(AnnouncerUdpTest, canAnnounceIPv4)
     static auto constexpr Interval = time_t{ 3600 };
     static auto constexpr Leechers = uint32_t{ 10 };
     static auto constexpr Seeders = uint32_t{ 20 };
-    auto const addresses = std::array<tr_socket_address, 3>{ {
+    auto const addresses = std::to_array<tr_socket_address>({
         { tr_address::from_string("10.10.10.5"sv).value_or(tr_address{}), tr_port::from_host(128) },
         { tr_address::from_string("192.168.1.2"sv).value_or(tr_address{}), tr_port::from_host(2021) },
         { tr_address::from_string("192.168.1.3"sv).value_or(tr_address{}), tr_port::from_host(2022) },
-    } };
+    });
 
     auto const request = tr_announce_request{
         .event = TR_ANNOUNCE_EVENT_STARTED,
@@ -777,11 +777,11 @@ TEST_F(AnnouncerUdpTest, canAnnounceIPv6)
     static auto constexpr Interval = time_t{ 3600 };
     static auto constexpr Leechers = uint32_t{ 10 };
     static auto constexpr Seeders = uint32_t{ 20 };
-    auto const addresses = std::array<tr_socket_address, 3>{ {
+    auto const addresses = std::to_array<tr_socket_address>({
         { tr_address::from_string("fd12:3456:789a:1::1"sv).value_or(tr_address{}), tr_port::from_host(128) },
         { tr_address::from_string("fd12:3456:789a:1::2"sv).value_or(tr_address{}), tr_port::from_host(2021) },
         { tr_address::from_string("fd12:3456:789a:1::3"sv).value_or(tr_address{}), tr_port::from_host(2022) },
-    } };
+    });
 
     auto const request = tr_announce_request{
         .event = TR_ANNOUNCE_EVENT_STARTED,
@@ -864,16 +864,16 @@ TEST_F(AnnouncerUdpTest, canAnnounceDualStack)
     static auto constexpr Leechers = uint32_t{ 10 };
     static auto constexpr Seeders = uint32_t{ 20 };
     auto const addresses = std::array{
-        std::array<tr_socket_address, 3>{ {
+        std::to_array<tr_socket_address>({
             { tr_address::from_string("10.10.10.5"sv).value_or(tr_address{}), tr_port::from_host(128) },
             { tr_address::from_string("192.168.1.2"sv).value_or(tr_address{}), tr_port::from_host(2021) },
             { tr_address::from_string("192.168.1.3"sv).value_or(tr_address{}), tr_port::from_host(2022) },
-        } },
-        std::array<tr_socket_address, 3>{ {
+        }),
+        std::to_array<tr_socket_address>({
             { tr_address::from_string("fd12:3456:789a:1::1"sv).value_or(tr_address{}), tr_port::from_host(128) },
             { tr_address::from_string("fd12:3456:789a:1::2"sv).value_or(tr_address{}), tr_port::from_host(2021) },
             { tr_address::from_string("fd12:3456:789a:1::3"sv).value_or(tr_address{}), tr_port::from_host(2022) },
-        } },
+        }),
     };
 
     auto request = tr_announce_request{};
@@ -986,11 +986,11 @@ TEST_F(AnnouncerUdpTest, announceDualStackOnlyIPv4Successful)
     static auto constexpr Interval = time_t{ 3600 };
     static auto constexpr Leechers = uint32_t{ 10 };
     static auto constexpr Seeders = uint32_t{ 20 };
-    auto const addresses = std::array<tr_socket_address, 3>{ {
+    auto const addresses = std::to_array<tr_socket_address>({
         { tr_address::from_string("10.10.10.5"sv).value_or(tr_address{}), tr_port::from_host(128) },
         { tr_address::from_string("192.168.1.2"sv).value_or(tr_address{}), tr_port::from_host(2021) },
         { tr_address::from_string("192.168.1.3"sv).value_or(tr_address{}), tr_port::from_host(2022) },
-    } };
+    });
 
     auto request = tr_announce_request{};
     request.event = TR_ANNOUNCE_EVENT_STARTED;
@@ -1092,11 +1092,11 @@ TEST_F(AnnouncerUdpTest, announceDualStackOnlyIPv6Successful)
     static auto constexpr Interval = time_t{ 3600 };
     static auto constexpr Leechers = uint32_t{ 10 };
     static auto constexpr Seeders = uint32_t{ 20 };
-    auto const addresses = std::array<tr_socket_address, 3>{ {
+    auto const addresses = std::to_array<tr_socket_address>({
         { tr_address::from_string("fd12:3456:789a:1::1"sv).value_or(tr_address{}), tr_port::from_host(128) },
         { tr_address::from_string("fd12:3456:789a:1::2"sv).value_or(tr_address{}), tr_port::from_host(2021) },
         { tr_address::from_string("fd12:3456:789a:1::3"sv).value_or(tr_address{}), tr_port::from_host(2022) },
-    } };
+    });
 
     auto request = tr_announce_request{};
     request.event = TR_ANNOUNCE_EVENT_STARTED;

--- a/tests/libtransmission/api-compat-test.cc
+++ b/tests/libtransmission/api-compat-test.cc
@@ -1224,7 +1224,7 @@ TEST_F(ApiCompatTest, canConvertRpc)
     using TestCase = std::tuple<std::string_view, std::string_view, Style, std::string_view>;
 
     // clang-format off
-    static auto constexpr TestCases = std::array<TestCase, 74U>{ {
+    static auto constexpr TestCases = std::to_array<TestCase>({
         { "free_space tr5 -> tr5", BadFreeSpaceRequest, Style::Tr5, BadFreeSpaceRequest },
         { "free_space tr5 -> tr4", BadFreeSpaceRequest, Style::Tr4, BadFreeSpaceRequestLegacy },
         { "free_space tr4 -> tr5", BadFreeSpaceRequestLegacy, Style::Tr5, BadFreeSpaceRequest },
@@ -1301,7 +1301,7 @@ TEST_F(ApiCompatTest, canConvertRpc)
         { "prefer clear request tr5 -> tr4", LegacyPreferClearRequest, Style::Tr4, LegacyPreferClearRequest },
 
         // TODO(ckerr): torrent-get with 'table'
-    } };
+    });
     // clang-format on
 
     for (auto const& [name, src, tgt_style, expected] : TestCases)
@@ -1319,7 +1319,7 @@ TEST_F(ApiCompatTest, canConvertJsonDataFiles)
     using Style = tr::api_compat::Style;
     using TestCase = std::tuple<std::string_view, std::string_view, Style, std::string_view>;
 
-    static auto constexpr TestCases = std::array<TestCase, 20U>{ {
+    static auto constexpr TestCases = std::to_array<TestCase>({
         { "settings tr5 -> tr5", CurrentSettingsJson, Style::Tr5, CurrentSettingsJson },
         { "settings tr5 -> tr4", CurrentSettingsJson, Style::Tr4, LegacySettingsJson },
         { "settings tr4 -> tr5", LegacySettingsJson, Style::Tr5, CurrentSettingsJson },
@@ -1341,7 +1341,7 @@ TEST_F(ApiCompatTest, canConvertJsonDataFiles)
         { "stats tr5 -> tr4", CurrentStatsJson, Style::Tr4, LegacyStatsJson },
         { "stats tr4 -> tr5", LegacyStatsJson, Style::Tr5, CurrentStatsJson },
         { "stats tr4 -> tr4", LegacyStatsJson, Style::Tr4, LegacyStatsJson },
-    } };
+    });
 
     for (auto const& [name, src, tgt_style, expected] : TestCases)
     {
@@ -1360,7 +1360,7 @@ TEST_F(ApiCompatTest, migratesLegacyRatioSettingKeys)
     using Style = tr::api_compat::Style;
     using TestCase = std::tuple<std::string_view, std::string_view, Style, std::string_view>;
 
-    static auto constexpr TestCases = std::array<TestCase, 6U>{ {
+    static auto constexpr TestCases = std::to_array<TestCase>({
         { "settings ratio kebab tr4 -> tr5", LegacyRatioSettingsKebabJson, Style::Tr5, CurrentSeedRatioSettingsJson },
         { "settings ratio underscore tr4 -> tr5", LegacyRatioSettingsUnderscoreJson, Style::Tr5, CurrentSeedRatioSettingsJson },
         { "settings ratio tr5 -> tr5", CurrentSeedRatioSettingsJson, Style::Tr5, CurrentSeedRatioSettingsJson },
@@ -1370,7 +1370,7 @@ TEST_F(ApiCompatTest, migratesLegacyRatioSettingKeys)
           Style::Tr4,
           LegacyRatioSettingsUnderscoreJson },
         { "settings ratio tr5 -> tr4", CurrentSeedRatioSettingsJson, Style::Tr4, LegacyRatioSettingsKebabJson },
-    } };
+    });
 
     for (auto const& [name, src, tgt_style, expected] : TestCases)
     {
@@ -1389,12 +1389,12 @@ TEST_F(ApiCompatTest, canConvertBencDataFiles)
     using Style = tr::api_compat::Style;
     using TestCase = std::tuple<std::string_view, std::string_view, Style, std::string_view>;
 
-    static auto constexpr TestCases = std::array<TestCase, 4U>{ {
+    static auto constexpr TestCases = std::to_array<TestCase>({
         { "resume tr5 -> tr5", ResumeBenc, Style::Tr5, ResumeBenc },
         { "resume tr5 -> tr4", ResumeBenc, Style::Tr4, LegacyResumeBenc },
         { "resume tr4 -> tr5", LegacyResumeBenc, Style::Tr5, ResumeBenc },
         { "resume tr4 -> tr4", LegacyResumeBenc, Style::Tr4, LegacyResumeBenc },
-    } };
+    });
 
     for (auto const& [name, src, tgt_style, expected] : TestCases)
     {

--- a/tests/libtransmission/bitfield-test.cc
+++ b/tests/libtransmission/bitfield-test.cc
@@ -63,11 +63,11 @@ TEST(Bitfield, count)
 
 TEST(Bitfield, ctorFromFlagArray)
 {
-    auto constexpr Tests = std::array<std::array<bool, 10>, 3>{ {
+    auto constexpr Tests = std::to_array<std::array<bool, 10>>({
         { false, true, false, true, false, false, true, false, false, true }, // mixed
         { true, true, true, true, true, true, true, true, true, true }, // have all
         { false, false, false, false, false, false, false, false, false, false }, // have none
-    } };
+    });
 
     for (auto const& flags : Tests)
     {

--- a/tests/libtransmission/clients-test.cc
+++ b/tests/libtransmission/clients-test.cc
@@ -24,7 +24,7 @@ TEST(Client, clientForId)
         std::string_view expected_client;
     };
 
-    auto constexpr Tests = std::array<LocalTest, 47>{ {
+    auto constexpr Tests = std::to_array<LocalTest>({
         { .peer_id = "-ADB560-"sv, .expected_client = "Advanced Download Manager 11.5.6"sv },
         { .peer_id = "-AZ8421-"sv, .expected_client = "Azureus / Vuze 8.4.2.1"sv },
         { .peer_id = "-BC0241-"sv, .expected_client = "BitComet 2.41"sv }, // two major, two minor
@@ -77,7 +77,7 @@ TEST(Client, clientForId)
           .expected_client = "BitLord 0.56"sv },
         { .peer_id = "\x65\x78\x62\x63\x00\x38\x7A\x44\x63\x10\x2D\x6E\x9A\xD6\x72\x3B\x33\x9F\x35\xA9"sv,
           .expected_client = "BitComet 0.56"sv },
-    } };
+    });
 
     for (auto const& test : Tests)
     {
@@ -93,10 +93,13 @@ TEST(Client, clientForId)
 
 TEST(Client, clientForIdFuzzRegressions)
 {
-    auto constexpr Tests = std::array<std::string_view, 5>{
-        "LVJTp3u+Aptl01HjzTHXVC5b9g4="sv, "LWJrHb2OpoNsJdODHA7iyXjnHxc="sv, "LU1PjpTjmvUth+f15YTOOggXl3k="sv,
-        "LUxU1gO7xhfBD4bmyZkB+neZIx0="sv, "LVJTp3u+Aptl01HjzTHXVC5b9g4="sv,
-    };
+    auto constexpr Tests = std::to_array<std::string_view>({
+        "LVJTp3u+Aptl01HjzTHXVC5b9g4="sv,
+        "LWJrHb2OpoNsJdODHA7iyXjnHxc="sv,
+        "LU1PjpTjmvUth+f15YTOOggXl3k="sv,
+        "LUxU1gO7xhfBD4bmyZkB+neZIx0="sv,
+        "LVJTp3u+Aptl01HjzTHXVC5b9g4="sv,
+    });
 
     for (auto const& test : Tests)
     {

--- a/tests/libtransmission/crypto-test.cc
+++ b/tests/libtransmission/crypto-test.cc
@@ -123,7 +123,7 @@ TEST(Crypto, sha1)
     auto const hash4 = tr_sha1::digest("te"sv, "st"sv);
     EXPECT_EQ("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"sv, tr_sha1_to_string(hash4));
 
-    auto const hash5 = tr_sha1::digest("t"sv, "e"sv, std::string{ "s" }, std::array<char, 1>{ { 't' } });
+    auto const hash5 = tr_sha1::digest("t"sv, "e"sv, std::string{ "s" }, std::to_array<char>({ 't' }));
     EXPECT_EQ("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"sv, tr_sha1_to_string(hash5));
 }
 
@@ -135,11 +135,11 @@ TEST(Crypto, ssha1)
         std::string_view ssha1;
     };
 
-    static auto constexpr Tests = std::array<LocalTest, 2>{ {
+    static auto constexpr Tests = std::to_array<LocalTest>({
         { .plain_text = "test"sv, .ssha1 = "{15ad0621b259a84d24dcd4e75b09004e98a3627bAMbyRHJy"sv },
         { .plain_text = "QNY)(*#$B)!_X$B !_B#($^!)*&$%CV!#)&$C!@$(P*)"sv,
           .ssha1 = "{10e2d7acbb104d970514a147cd16d51dfa40fb3c0OSwJtOL"sv },
-    } };
+    });
 
     static auto constexpr HashCount = size_t{ 4U } * 1024U;
 

--- a/tests/libtransmission/file-piece-map-test.cc
+++ b/tests/libtransmission/file-piece-map-test.cc
@@ -95,7 +95,7 @@ TEST_F(FilePieceMapTest, pieceSpan)
     // Note to reviewers: it's easy to see a nonexistent fencepost error here.
     // Remember everything is zero-indexed, so the 9 valid pieces are [0..10).
     // Piece #10 is the 'end' iterator position.
-    auto constexpr ExpectedPieceSpans = std::array<tr_file_piece_map::piece_span_t, 17>{ {
+    auto constexpr ExpectedPieceSpans = std::to_array<tr_file_piece_map::piece_span_t>({
         { .begin = 0U, .end = 5U },
         { .begin = 5U, .end = 6U },
         { .begin = 5U, .end = 6U },
@@ -113,7 +113,7 @@ TEST_F(FilePieceMapTest, pieceSpan)
         { .begin = 9U, .end = 10U },
         { .begin = 9U, .end = 10U },
         { .begin = 9U, .end = 10U },
-    } };
+    });
     EXPECT_EQ(std::size(FileSizes), std::size(ExpectedPieceSpans));
 
     auto const fpm = tr_file_piece_map{ block_info_, std::data(FileSizes), std::size(FileSizes) };

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -768,7 +768,7 @@ TEST_F(FileTest, pathBasename)
 TEST_F(FileTest, pathDirname)
 {
 #ifdef _WIN32
-    static auto constexpr DirnameTests = std::array<std::pair<std::string_view, std::string_view>, 48>{ {
+    static auto constexpr DirnameTests = std::to_array<std::pair<std::string_view, std::string_view>>({
         { R"(C:\a/b\c)"sv, R"(C:\a/b)"sv },
         { R"(C:\a/b\c\)"sv, R"(C:\a/b)"sv },
         { R"(C:\a/b)"sv, R"(C:\a)"sv },
@@ -819,9 +819,9 @@ TEST_F(FileTest, pathDirname)
         { "/"sv, "/"sv },
         { "////"sv, "/"sv },
         { "foo"sv, "."sv },
-    } };
+    });
 #else
-    static auto constexpr DirnameTests = std::array<std::pair<std::string_view, std::string_view>, 15>{ {
+    static auto constexpr DirnameTests = std::to_array<std::pair<std::string_view, std::string_view>>({
         // taken from Node.js unit tests
         // https://github.com/nodejs/node/blob/e46c680bf2b211bbd52cf959ca17ee98c7f657f5/test/parallel/test-path-dirname.js
         { "/a/b/"sv, "/a"sv },
@@ -840,7 +840,7 @@ TEST_F(FileTest, pathDirname)
         { "/"sv, "/"sv },
         { "."sv, "."sv },
         { ".."sv, "."sv },
-    } };
+    });
 #endif
 
     for (auto const& [input, expected] : DirnameTests)
@@ -1008,13 +1008,13 @@ TEST_F(FileTest, pathNativeSeparators)
 {
     EXPECT_EQ(nullptr, tr_sys_path_native_separators(nullptr));
 
-    static auto constexpr Tests = std::array<std::pair<std::string_view, std::string_view>, 5>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, std::string_view>>({
         { "", "" },
         { "a", TR_IF_WIN32("a", "a") },
         { "/", TR_IF_WIN32("\\", "/") },
         { "/a/b/c", TR_IF_WIN32("\\a\\b\\c", "/a/b/c") },
         { "C:\\a/b\\c", TR_IF_WIN32("C:\\a\\b\\c", "C:\\a/b\\c") },
-    } };
+    });
 
     for (auto const& [input, expected] : Tests)
     {

--- a/tests/libtransmission/getopt-test.cc
+++ b/tests/libtransmission/getopt-test.cc
@@ -12,7 +12,7 @@
 namespace
 {
 using Arg = tr_option::Arg;
-auto constexpr Options = std::array<tr_option, 9>{ {
+auto constexpr Options = std::to_array<tr_option>({
     { .val = 'p',
       .longName = "private",
       .description = "Allow this torrent to only be used with the specified tracker(s)",
@@ -57,7 +57,7 @@ auto constexpr Options = std::array<tr_option, 9>{ {
       .arg = Arg::Optional,
       .argName = "<piece>" },
     { .val = 0, .longName = nullptr, .description = nullptr, .shortName = nullptr, .arg = Arg::None, .argName = nullptr },
-} };
+});
 static_assert(Options[std::size(Options) - 2].val != 0);
 } // namespace
 
@@ -90,7 +90,7 @@ protected:
 
 TEST_F(GetoptTest, noOptions)
 {
-    static auto constexpr Args = std::array<char const*, 1>{ "/some/path/tr-getopt-test" };
+    static auto constexpr Args = std::to_array<char const*>({ "/some/path/tr-getopt-test" });
     static auto constexpr ExpectedN = 0;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{};
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{};
@@ -99,7 +99,7 @@ TEST_F(GetoptTest, noOptions)
 
 TEST_F(GetoptTest, shortNoarg)
 {
-    static auto constexpr Args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "-p" };
+    static auto constexpr Args = std::to_array<char const*>({ "/some/path/tr-getopt-test", "-p" });
     static auto constexpr ExpectedN = 1;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{ 'p' };
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ nullptr };
@@ -108,7 +108,7 @@ TEST_F(GetoptTest, shortNoarg)
 
 TEST_F(GetoptTest, longNoarg)
 {
-    static auto constexpr Args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "--private" };
+    static auto constexpr Args = std::to_array<char const*>({ "/some/path/tr-getopt-test", "--private" });
     static auto constexpr ExpectedN = 1;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{ 'p' };
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ nullptr };
@@ -117,7 +117,7 @@ TEST_F(GetoptTest, longNoarg)
 
 TEST_F(GetoptTest, shortWithRequiredArg)
 {
-    static auto constexpr Args = std::array<char const*, 3>{ "/some/path/tr-getopt-test", "-o", "/tmp/outfile" };
+    static auto constexpr Args = std::to_array<char const*>({ "/some/path/tr-getopt-test", "-o", "/tmp/outfile" });
     auto constexpr ExpectedN = 1;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{ 'o' };
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ "/tmp/outfile" };
@@ -126,7 +126,7 @@ TEST_F(GetoptTest, shortWithRequiredArg)
 
 TEST_F(GetoptTest, longWithRequiredArg)
 {
-    static auto constexpr Args = std::array<char const*, 3>{ "/some/path/tr-getopt-test", "--outfile", "/tmp/outfile" };
+    static auto constexpr Args = std::to_array<char const*>({ "/some/path/tr-getopt-test", "--outfile", "/tmp/outfile" });
     static auto constexpr ExpectedN = 1;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{ 'o' };
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ "/tmp/outfile" };
@@ -135,7 +135,7 @@ TEST_F(GetoptTest, longWithRequiredArg)
 
 TEST_F(GetoptTest, shortWithRequiredArgAfterEq)
 {
-    static auto constexpr Args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "-o=/tmp/outfile" };
+    static auto constexpr Args = std::to_array<char const*>({ "/some/path/tr-getopt-test", "-o=/tmp/outfile" });
     static auto constexpr ExpectedN = 1;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{ 'o' };
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ "/tmp/outfile" };
@@ -144,7 +144,7 @@ TEST_F(GetoptTest, shortWithRequiredArgAfterEq)
 
 TEST_F(GetoptTest, longWithRequiredArgAfterEq)
 {
-    static auto constexpr Args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "--outfile=/tmp/outfile" };
+    static auto constexpr Args = std::to_array<char const*>({ "/some/path/tr-getopt-test", "--outfile=/tmp/outfile" });
     static auto constexpr ExpectedN = 1;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{ 'o' };
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ "/tmp/outfile" };
@@ -153,7 +153,7 @@ TEST_F(GetoptTest, longWithRequiredArgAfterEq)
 
 TEST_F(GetoptTest, unknownOption)
 {
-    static auto constexpr Args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "-z" };
+    static auto constexpr Args = std::to_array<char const*>({ "/some/path/tr-getopt-test", "-z" });
     static auto constexpr ExpectedN = 1;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{ TR_OPT_UNK };
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ "-z" };
@@ -162,7 +162,7 @@ TEST_F(GetoptTest, unknownOption)
 
 TEST_F(GetoptTest, missingArgEnd)
 {
-    static auto constexpr Args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "-o" };
+    static auto constexpr Args = std::to_array<char const*>({ "/some/path/tr-getopt-test", "-o" });
     static auto constexpr ExpectedN = 1;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{ TR_OPT_ERR };
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ nullptr };
@@ -171,7 +171,7 @@ TEST_F(GetoptTest, missingArgEnd)
 
 TEST_F(GetoptTest, missingArgMiddle)
 {
-    static auto constexpr Args = std::array<char const*, 3>{ "/some/path/tr-getopt-test", "-o", "-p" };
+    static auto constexpr Args = std::to_array<char const*>({ "/some/path/tr-getopt-test", "-o", "-p" });
     static auto constexpr ExpectedN = 2;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{ TR_OPT_ERR, 'p' };
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ nullptr, nullptr };
@@ -180,9 +180,8 @@ TEST_F(GetoptTest, missingArgMiddle)
 
 TEST_F(GetoptTest, lotsOfOptions)
 {
-    static auto constexpr Args = std::array<char const*, 6>{
-        "/some/path/tr-getopt-test", "--piecesize=4", "-c", "hello world", "-p", "--tracker=foo"
-    };
+    static auto constexpr Args = std::to_array<char const*>(
+        { "/some/path/tr-getopt-test", "--piecesize=4", "-c", "hello world", "-p", "--tracker=foo" });
     static auto constexpr ExpectedN = 4;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{ 's', 'c', 'p', 't' };
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ "4", "hello world", nullptr, "foo" };
@@ -192,7 +191,7 @@ TEST_F(GetoptTest, lotsOfOptions)
 TEST_F(GetoptTest, matchLongerKey)
 {
     // confirm that this resolves to 'q' and not 'p'
-    static auto constexpr Args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "-pk" };
+    static auto constexpr Args = std::to_array<char const*>({ "/some/path/tr-getopt-test", "-pk" });
     static auto constexpr ExpectedN = 1;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{ 'q' };
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ nullptr };
@@ -201,7 +200,7 @@ TEST_F(GetoptTest, matchLongerKey)
 
 TEST_F(GetoptTest, shortWithOptionalArg)
 {
-    static auto constexpr Args = std::array<char const*, 3>{ "/some/path/tr-getopt-test", "-seq", "12" };
+    static auto constexpr Args = std::to_array<char const*>({ "/some/path/tr-getopt-test", "-seq", "12" });
     static auto constexpr ExpectedN = 1;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{ 994 };
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ "12" };
@@ -210,7 +209,7 @@ TEST_F(GetoptTest, shortWithOptionalArg)
 
 TEST_F(GetoptTest, longWithOptionalArg)
 {
-    static auto constexpr Args = std::array<char const*, 3>{ "/some/path/tr-getopt-test", "--sequential-download", "12" };
+    static auto constexpr Args = std::to_array<char const*>({ "/some/path/tr-getopt-test", "--sequential-download", "12" });
     static auto constexpr ExpectedN = 1;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{ 994 };
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ "12" };
@@ -219,7 +218,7 @@ TEST_F(GetoptTest, longWithOptionalArg)
 
 TEST_F(GetoptTest, shortWithOptionalArgAfterEq)
 {
-    static auto constexpr Args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "-seq=12" };
+    static auto constexpr Args = std::to_array<char const*>({ "/some/path/tr-getopt-test", "-seq=12" });
     static auto constexpr ExpectedN = 1;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{ 994 };
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ "12" };
@@ -228,7 +227,7 @@ TEST_F(GetoptTest, shortWithOptionalArgAfterEq)
 
 TEST_F(GetoptTest, longWithOptionalArgAfterEq)
 {
-    static auto constexpr Args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "--sequential-download=12" };
+    static auto constexpr Args = std::to_array<char const*>({ "/some/path/tr-getopt-test", "--sequential-download=12" });
     static auto constexpr ExpectedN = 1;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{ 994 };
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ "12" };
@@ -237,7 +236,7 @@ TEST_F(GetoptTest, longWithOptionalArgAfterEq)
 
 TEST_F(GetoptTest, shortWithoutOptionalArgEnd)
 {
-    static auto constexpr Args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "-seq" };
+    static auto constexpr Args = std::to_array<char const*>({ "/some/path/tr-getopt-test", "-seq" });
     static auto constexpr ExpectedN = 1;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{ 994 };
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ nullptr };
@@ -246,7 +245,7 @@ TEST_F(GetoptTest, shortWithoutOptionalArgEnd)
 
 TEST_F(GetoptTest, longWithoutOptionalArgEnd)
 {
-    static auto constexpr Args = std::array<char const*, 2>{ "/some/path/tr-getopt-test", "--sequential-download" };
+    static auto constexpr Args = std::to_array<char const*>({ "/some/path/tr-getopt-test", "--sequential-download" });
     static auto constexpr ExpectedN = 1;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{ 994 };
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ nullptr };
@@ -255,7 +254,7 @@ TEST_F(GetoptTest, longWithoutOptionalArgEnd)
 
 TEST_F(GetoptTest, shortWithoutOptionalArgMiddle)
 {
-    static auto constexpr Args = std::array<char const*, 3>{ "/some/path/tr-getopt-test", "-seq", "-p" };
+    static auto constexpr Args = std::to_array<char const*>({ "/some/path/tr-getopt-test", "-seq", "-p" });
     static auto constexpr ExpectedN = 2;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{ 994, 'p' };
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ nullptr, nullptr };
@@ -264,7 +263,7 @@ TEST_F(GetoptTest, shortWithoutOptionalArgMiddle)
 
 TEST_F(GetoptTest, longWithoutOptionalArgMiddle)
 {
-    static auto constexpr Args = std::array<char const*, 3>{ "/some/path/tr-getopt-test", "--sequential-download", "-p" };
+    static auto constexpr Args = std::to_array<char const*>({ "/some/path/tr-getopt-test", "--sequential-download", "-p" });
     static auto constexpr ExpectedN = 2;
     static auto constexpr ExpectedC = std::array<int, ExpectedN>{ 994, 'p' };
     static auto constexpr ExpectedOptArg = std::array<char const*, ExpectedN>{ nullptr, nullptr };

--- a/tests/libtransmission/handshake-test.cc
+++ b/tests/libtransmission/handshake-test.cc
@@ -144,7 +144,7 @@ public:
         sendToClient(sock, tr_base64_decode(b64));
     }
 
-    static auto constexpr ReservedBytesNoExtensions = std::array<uint8_t, 8>{ 0, 0, 0, 0, 0, 0, 0, 0 };
+    static auto constexpr ReservedBytesNoExtensions = std::to_array<uint8_t>({ 0, 0, 0, 0, 0, 0, 0, 0 });
     static auto constexpr PlaintextProtocolName = "\023BitTorrent protocol"sv;
 
     tr_socket_address const DefaultPeerSockAddr{ *tr_address::from_string("127.0.0.1"sv), tr_port::from_host(8080) };
@@ -165,7 +165,7 @@ public:
 
     auto createIncomingIo(tr_session* session)
     {
-        auto sockpair = std::array<evutil_socket_t, 2>{ -1, -1 };
+        auto sockpair = std::to_array<evutil_socket_t>({ -1, -1 });
         EXPECT_EQ(0, evutil_socketpair(LOCAL_SOCKETPAIR_AF, SOCK_STREAM, 0, std::data(sockpair))) << tr_strerror(errno);
         EXPECT_EQ(0, evutil_make_socket_nonblocking(sockpair[0]));
         EXPECT_EQ(0, evutil_make_socket_nonblocking(sockpair[1]));
@@ -180,7 +180,7 @@ public:
 
     auto createOutgoingIo(tr_session* session, tr_sha1_digest_t const& info_hash)
     {
-        auto sockpair = std::array<evutil_socket_t, 2>{ -1, -1 };
+        auto sockpair = std::to_array<evutil_socket_t>({ -1, -1 });
         EXPECT_EQ(0, evutil_socketpair(LOCAL_SOCKETPAIR_AF, SOCK_STREAM, 0, std::data(sockpair))) << tr_strerror(errno);
         EXPECT_EQ(0, evutil_make_socket_nonblocking(sockpair[0]));
         EXPECT_EQ(0, evutil_make_socket_nonblocking(sockpair[1]));

--- a/tests/libtransmission/ip-cache-test.cc
+++ b/tests/libtransmission/ip-cache-test.cc
@@ -95,18 +95,18 @@ protected:
 TEST_F(IPCacheTest, bindAddr)
 {
     static constexpr auto AddrTests = std::array{
-        std::array<std::pair<std::string_view, std::string_view>, 4>{ {
+        std::to_array<std::pair<std::string_view, std::string_view>>({
             { "8.8.8.8"sv, "8.8.8.8"sv },
             { "192.168.133.133"sv, "192.168.133.133"sv },
             { "2001:1890:1112:1::20"sv, "0.0.0.0"sv },
             { "asdasd"sv, "0.0.0.0"sv },
-        } } /* IPv4 */,
-        std::array<std::pair<std::string_view, std::string_view>, 4>{ {
+        }) /* IPv4 */,
+        std::to_array<std::pair<std::string_view, std::string_view>>({
             { "fd12:3456:789a:1::1"sv, "fd12:3456:789a:1::1"sv },
             { "192.168.133.133"sv, "::"sv },
             { "2001:1890:1112:1::20"sv, "2001:1890:1112:1::20"sv },
             { "asdasd"sv, "::"sv },
-        } } /* IPv6 */
+        }) /* IPv6 */
     };
     static_assert(TR_AF_INET == 0);
     static_assert(TR_AF_INET6 == 1);

--- a/tests/libtransmission/magnet-metainfo-test.cc
+++ b/tests/libtransmission/magnet-metainfo-test.cc
@@ -94,9 +94,9 @@ TEST_F(MagnetMetainfoTest, magnetParse)
 
 TEST_F(MagnetMetainfoTest, parseMagnetFuzzRegressions)
 {
-    static auto constexpr Tests = std::array<std::string_view, 1>{
+    static auto constexpr Tests = std::to_array<std::string_view>({
         "UICOl7RLjChs/QZZwNH4sSQwuH890UMHuoxoWBmMkr0=",
-    };
+    });
 
     for (auto const& test : Tests)
     {

--- a/tests/libtransmission/net-test.cc
+++ b/tests/libtransmission/net-test.cc
@@ -184,7 +184,7 @@ TEST_F(NetTest, compact6)
 
 TEST_F(NetTest, isGlobalUnicastAddress)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 17>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },
         { "1.0.0.0"sv, true },
         { "10.0.0.0"sv, false },
@@ -202,7 +202,7 @@ TEST_F(NetTest, isGlobalUnicastAddress)
         { "224.0.0.0"sv, false },
         { "0:0:0:0:0:0:0:1"sv, false },
         { "2001:0:0eab:dead::a0:abcd:4e"sv, true },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -214,7 +214,7 @@ TEST_F(NetTest, isGlobalUnicastAddress)
 
 TEST_F(NetTest, isIPv4CurrentNetwork)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 19>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, true },
         { "0.25.37.132"sv, true },
         { "0.255.255.255"sv, true },
@@ -234,7 +234,7 @@ TEST_F(NetTest, isIPv4CurrentNetwork)
         { "224.0.0.0"sv, false },
         { "0:0:0:0:0:0:0:1"sv, false },
         { "2001:0:0eab:dead::a0:abcd:4e"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -246,7 +246,7 @@ TEST_F(NetTest, isIPv4CurrentNetwork)
 
 TEST_F(NetTest, isIPv4And10Private)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 18>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },
         { "9.255.255.255"sv, false },
         { "10.0.0.0"sv, true },
@@ -265,7 +265,7 @@ TEST_F(NetTest, isIPv4And10Private)
         { "224.0.0.0"sv, false },
         { "0:0:0:0:0:0:0:1"sv, false },
         { "2001:0:0eab:dead::a0:abcd:4e"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -277,7 +277,7 @@ TEST_F(NetTest, isIPv4And10Private)
 
 TEST_F(NetTest, isIPv4CarrierGradeNAT)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 19>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },
         { "1.0.0.0"sv, false },
         { "10.0.0.0"sv, false },
@@ -297,7 +297,7 @@ TEST_F(NetTest, isIPv4CarrierGradeNAT)
         { "224.0.0.0"sv, false },
         { "0:0:0:0:0:0:0:1"sv, false },
         { "2001:0:0eab:dead::a0:abcd:4e"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -309,7 +309,7 @@ TEST_F(NetTest, isIPv4CarrierGradeNAT)
 
 TEST_F(NetTest, isIPv4Loopback)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 19>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },
         { "1.0.0.0"sv, false },
         { "10.0.0.0"sv, false },
@@ -329,7 +329,7 @@ TEST_F(NetTest, isIPv4Loopback)
         { "224.0.0.0"sv, false },
         { "0:0:0:0:0:0:0:1"sv, false },
         { "2001:0:0eab:dead::a0:abcd:4e"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -341,7 +341,7 @@ TEST_F(NetTest, isIPv4Loopback)
 
 TEST_F(NetTest, isIPv4LinkLocal)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 18>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },
         { "1.0.0.0"sv, false },
         { "10.0.0.0"sv, false },
@@ -360,7 +360,7 @@ TEST_F(NetTest, isIPv4LinkLocal)
         { "224.0.0.0"sv, false },
         { "0:0:0:0:0:0:0:1"sv, false },
         { "2001:0:0eab:dead::a0:abcd:4e"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -372,7 +372,7 @@ TEST_F(NetTest, isIPv4LinkLocal)
 
 TEST_F(NetTest, isIPv4And172Private)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 20>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },         { "10.0.0.0"sv, false },
         { "10.255.0.0"sv, false },      { "10.255.0.255"sv, false },
         { "100.64.0.0"sv, false },      { "100.128.0.0"sv, false },
@@ -383,7 +383,7 @@ TEST_F(NetTest, isIPv4And172Private)
         { "172.31.255.255"sv, true },   { "172.32.0.0"sv, false },
         { "223.0.0.0"sv, false },       { "224.0.0.0"sv, false },
         { "0:0:0:0:0:0:0:1"sv, false }, { "2001:0:0eab:dead::a0:abcd:4e"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -395,7 +395,7 @@ TEST_F(NetTest, isIPv4And172Private)
 
 TEST_F(NetTest, isIPv4IetfProtocolAssignment)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 20>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },         { "10.0.0.0"sv, false },
         { "10.255.0.255"sv, false },    { "100.64.0.0"sv, false },
         { "127.0.0.0"sv, false },       { "169.253.255.255"sv, false },
@@ -406,7 +406,7 @@ TEST_F(NetTest, isIPv4IetfProtocolAssignment)
         { "192.0.0.255"sv, true },      { "192.0.1.0"sv, false },
         { "223.0.0.0"sv, false },       { "224.0.0.0"sv, false },
         { "0:0:0:0:0:0:0:1"sv, false }, { "2001:0:0eab:dead::a0:abcd:4e"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -418,7 +418,7 @@ TEST_F(NetTest, isIPv4IetfProtocolAssignment)
 
 TEST_F(NetTest, isIPv4TestNet1)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 20>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },         { "10.0.0.0"sv, false },
         { "10.255.0.255"sv, false },    { "100.64.0.0"sv, false },
         { "127.0.0.0"sv, false },       { "169.253.255.255"sv, false },
@@ -429,7 +429,7 @@ TEST_F(NetTest, isIPv4TestNet1)
         { "192.0.2.225"sv, true },      { "192.0.3.0"sv, false },
         { "223.0.0.0"sv, false },       { "224.0.0.0"sv, false },
         { "0:0:0:0:0:0:0:1"sv, false }, { "2001:0:0eab:dead::a0:abcd:4e"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -441,7 +441,7 @@ TEST_F(NetTest, isIPv4TestNet1)
 
 TEST_F(NetTest, isIPv4And6to4Relay)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 20>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },         { "10.0.0.0"sv, false },
         { "10.255.0.255"sv, false },    { "100.64.0.0"sv, false },
         { "127.0.0.0"sv, false },       { "169.253.255.255"sv, false },
@@ -452,7 +452,7 @@ TEST_F(NetTest, isIPv4And6to4Relay)
         { "192.88.99.225"sv, true },    { "192.88.100.0"sv, false },
         { "223.0.0.0"sv, false },       { "224.0.0.0"sv, false },
         { "0:0:0:0:0:0:0:1"sv, false }, { "2001:0:0eab:dead::a0:abcd:4e"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -464,7 +464,7 @@ TEST_F(NetTest, isIPv4And6to4Relay)
 
 TEST_F(NetTest, isIPv4And192Private)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 20>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },         { "10.0.0.0"sv, false },
         { "10.255.0.255"sv, false },    { "100.64.0.0"sv, false },
         { "127.0.0.0"sv, false },       { "169.253.255.255"sv, false },
@@ -475,7 +475,7 @@ TEST_F(NetTest, isIPv4And192Private)
         { "192.168.255.225"sv, true },  { "192.169.0.0"sv, false },
         { "223.0.0.0"sv, false },       { "224.0.0.0"sv, false },
         { "0:0:0:0:0:0:0:1"sv, false }, { "2001:0:0eab:dead::a0:abcd:4e"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -487,7 +487,7 @@ TEST_F(NetTest, isIPv4And192Private)
 
 TEST_F(NetTest, isIPv4Benchmark)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 20>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },         { "10.0.0.0"sv, false },
         { "10.255.0.255"sv, false },    { "100.64.0.0"sv, false },
         { "127.0.0.0"sv, false },       { "169.253.255.255"sv, false },
@@ -498,7 +498,7 @@ TEST_F(NetTest, isIPv4Benchmark)
         { "198.19.255.225"sv, true },   { "198.20.0.0"sv, false },
         { "223.0.0.0"sv, false },       { "224.0.0.0"sv, false },
         { "0:0:0:0:0:0:0:1"sv, false }, { "2001:0:0eab:dead::a0:abcd:4e"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -510,7 +510,7 @@ TEST_F(NetTest, isIPv4Benchmark)
 
 TEST_F(NetTest, isIPv4TestNet2)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 20>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },         { "10.0.0.0"sv, false },
         { "10.255.0.255"sv, false },    { "100.64.0.0"sv, false },
         { "127.0.0.0"sv, false },       { "169.253.255.255"sv, false },
@@ -521,7 +521,7 @@ TEST_F(NetTest, isIPv4TestNet2)
         { "198.51.100.255"sv, true },   { "198.51.101.0"sv, false },
         { "223.0.0.0"sv, false },       { "224.0.0.0"sv, false },
         { "0:0:0:0:0:0:0:1"sv, false }, { "2001:0:0eab:dead::a0:abcd:4e"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -533,7 +533,7 @@ TEST_F(NetTest, isIPv4TestNet2)
 
 TEST_F(NetTest, isIPv4TestNet3)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 20>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },         { "10.0.0.0"sv, false },
         { "10.255.0.255"sv, false },    { "100.64.0.0"sv, false },
         { "127.0.0.0"sv, false },       { "169.253.255.255"sv, false },
@@ -544,7 +544,7 @@ TEST_F(NetTest, isIPv4TestNet3)
         { "203.0.113.255"sv, true },    { "203.0.114.0"sv, false },
         { "223.0.0.0"sv, false },       { "224.0.0.0"sv, false },
         { "0:0:0:0:0:0:0:1"sv, false }, { "2001:0:0eab:dead::a0:abcd:4e"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -556,7 +556,7 @@ TEST_F(NetTest, isIPv4TestNet3)
 
 TEST_F(NetTest, isIPv4Multicast)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 20>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },         { "10.0.0.0"sv, false },
         { "10.255.0.255"sv, false },    { "100.64.0.0"sv, false },
         { "127.0.0.0"sv, false },       { "169.253.255.255"sv, false },
@@ -567,7 +567,7 @@ TEST_F(NetTest, isIPv4Multicast)
         { "224.0.0.0"sv, true },        { "230.124.45.18"sv, true },
         { "239.255.255.255"sv, true },  { "240.0.0.0"sv, false },
         { "0:0:0:0:0:0:0:1"sv, false }, { "2001:0:0eab:dead::a0:abcd:4e"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -579,7 +579,7 @@ TEST_F(NetTest, isIPv4Multicast)
 
 TEST_F(NetTest, isIPv4McastTestNet)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 20>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },         { "10.0.0.0"sv, false },
         { "10.255.0.255"sv, false },    { "100.64.0.0"sv, false },
         { "127.0.0.0"sv, false },       { "169.253.255.255"sv, false },
@@ -590,7 +590,7 @@ TEST_F(NetTest, isIPv4McastTestNet)
         { "233.252.0.0"sv, true },      { "233.252.0.18"sv, true },
         { "233.252.0.255"sv, true },    { "233.252.1.0"sv, false },
         { "0:0:0:0:0:0:0:1"sv, false }, { "2001:0:0eab:dead::a0:abcd:4e"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -602,7 +602,7 @@ TEST_F(NetTest, isIPv4McastTestNet)
 
 TEST_F(NetTest, isIPv4ReservedClassE)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 20>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },         { "10.0.0.0"sv, false },
         { "10.255.0.255"sv, false },    { "100.64.0.0"sv, false },
         { "127.0.0.0"sv, false },       { "169.253.255.255"sv, false },
@@ -613,7 +613,7 @@ TEST_F(NetTest, isIPv4ReservedClassE)
         { "240.0.0.0"sv, true },        { "247.252.0.18"sv, true },
         { "255.255.255.254"sv, true },  { "255.255.255.255"sv, false },
         { "0:0:0:0:0:0:0:1"sv, false }, { "2001:0:0eab:dead::a0:abcd:4e"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -625,7 +625,7 @@ TEST_F(NetTest, isIPv4ReservedClassE)
 
 TEST_F(NetTest, isIPv4LimitedBroadcast)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 20>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },         { "10.0.0.0"sv, false },
         { "10.255.0.255"sv, false },    { "100.64.0.0"sv, false },
         { "127.0.0.0"sv, false },       { "169.253.255.255"sv, false },
@@ -636,7 +636,7 @@ TEST_F(NetTest, isIPv4LimitedBroadcast)
         { "240.0.0.0"sv, false },       { "247.252.0.18"sv, false },
         { "255.255.255.254"sv, false }, { "255.255.255.255"sv, true },
         { "0:0:0:0:0:0:0:1"sv, false }, { "2001:0:0eab:dead::a0:abcd:4e"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -648,7 +648,7 @@ TEST_F(NetTest, isIPv4LimitedBroadcast)
 
 TEST_F(NetTest, isIPv6Unspecified)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 26>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },
         { "169.254.0.0"sv, false },
         { "::"sv, true },
@@ -675,7 +675,7 @@ TEST_F(NetTest, isIPv6Unspecified)
         { "feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"sv, false },
         { "ff00::"sv, false },
         { "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -687,7 +687,7 @@ TEST_F(NetTest, isIPv6Unspecified)
 
 TEST_F(NetTest, isIPv6Loopback)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 26>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },
         { "169.254.0.0"sv, false },
         { "::"sv, false },
@@ -714,7 +714,7 @@ TEST_F(NetTest, isIPv6Loopback)
         { "feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"sv, false },
         { "ff00::"sv, false },
         { "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -726,7 +726,7 @@ TEST_F(NetTest, isIPv6Loopback)
 
 TEST_F(NetTest, isIPv6IPv4Mapped)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 26>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },
         { "169.254.0.0"sv, false },
         { "::"sv, false },
@@ -753,7 +753,7 @@ TEST_F(NetTest, isIPv6IPv4Mapped)
         { "feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"sv, false },
         { "ff00::"sv, false },
         { "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -765,7 +765,7 @@ TEST_F(NetTest, isIPv6IPv4Mapped)
 
 TEST_F(NetTest, isIPv6Teredo)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 26>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },
         { "169.254.0.0"sv, false },
         { "::"sv, false },
@@ -792,7 +792,7 @@ TEST_F(NetTest, isIPv6Teredo)
         { "feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"sv, false },
         { "ff00::"sv, false },
         { "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -804,7 +804,7 @@ TEST_F(NetTest, isIPv6Teredo)
 
 TEST_F(NetTest, isIPv6And6to4)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 26>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },
         { "169.254.0.0"sv, false },
         { "::"sv, false },
@@ -831,7 +831,7 @@ TEST_F(NetTest, isIPv6And6to4)
         { "feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"sv, false },
         { "ff00::"sv, false },
         { "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -843,7 +843,7 @@ TEST_F(NetTest, isIPv6And6to4)
 
 TEST_F(NetTest, isIPv6LinkLocal)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 26>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },
         { "169.254.0.0"sv, false },
         { "::"sv, false },
@@ -870,7 +870,7 @@ TEST_F(NetTest, isIPv6LinkLocal)
         { "feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"sv, false },
         { "ff00::"sv, false },
         { "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"sv, false },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -882,7 +882,7 @@ TEST_F(NetTest, isIPv6LinkLocal)
 
 TEST_F(NetTest, isIPv6Multicast)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 26>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "0.0.0.0"sv, false },
         { "169.254.0.0"sv, false },
         { "::"sv, false },
@@ -909,7 +909,7 @@ TEST_F(NetTest, isIPv6Multicast)
         { "feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"sv, false },
         { "ff00::"sv, true },
         { "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"sv, true },
-    } };
+    });
 
     for (auto const& [presentation, expected] : Tests)
     {
@@ -949,7 +949,7 @@ TEST_F(NetTest, ipCompare)
 
 TEST_F(NetTest, IPv4MappedAddress)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, std::string_view>, 14>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, std::string_view>>({
         { "::ffff:1.0.0.0"sv, "1.0.0.0"sv },
         { "::ffff:10.0.0.0"sv, "10.0.0.0"sv },
         { "::ffff:10.255.0.0"sv, "10.255.0.0"sv },
@@ -964,7 +964,7 @@ TEST_F(NetTest, IPv4MappedAddress)
         { "::ffff:169.255.0.0"sv, "169.255.0.0"sv },
         { "::ffff:223.0.0.0"sv, "223.0.0.0"sv },
         { "::ffff:224.0.0.0"sv, "224.0.0.0"sv },
-    } };
+    });
 
     for (auto const& [mapped_sv, native_sv] : Tests)
     {

--- a/tests/libtransmission/peer-mgr-wishlist-test.cc
+++ b/tests/libtransmission/peer-mgr-wishlist-test.cc
@@ -2363,7 +2363,7 @@ TEST_F(PeerMgrWishlistTest, unalignedTorrentDeselected2ConsecutivePieces)
         auto wishlist = Wishlist{ mediator };
 
         // we don't want pieces 1, 2 anymore
-        auto constexpr Deselected = std::array<tr_file_index_t, 2>{ 1, 2 };
+        auto constexpr Deselected = std::to_array<tr_file_index_t>({ 1, 2 });
         for (auto const idx : Deselected)
         {
             mediator.client_wants_piece_.erase(idx);
@@ -2481,7 +2481,7 @@ TEST_F(PeerMgrWishlistTest, unalignedTorrentSelected2ConsecutivePieces)
         auto wishlist = Wishlist{ mediator };
 
         // we don't want pieces 1, 2 anymore
-        auto constexpr Selected = std::array<tr_file_index_t, 2>{ 1, 2 };
+        auto constexpr Selected = std::to_array<tr_file_index_t>({ 1, 2 });
         for (auto const idx : Selected)
         {
             mediator.client_wants_piece_.insert(idx);

--- a/tests/libtransmission/remove-test.cc
+++ b/tests/libtransmission/remove-test.cc
@@ -154,8 +154,8 @@ protected:
 
     static auto ubuntuFiles()
     {
-        static auto constexpr Files = std::array<SubpathAndSize, 1>{ { { "ubuntu-20.04.4-desktop-amd64.iso"sv,
-                                                                         3379068928ULL } } };
+        static auto constexpr Files = std::to_array<SubpathAndSize>(
+            { { "ubuntu-20.04.4-desktop-amd64.iso"sv, 3379068928ULL } });
 
         auto files = tr_torrent_files{};
 

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -231,18 +231,18 @@ TEST_F(RenameTest, singleFilenameTorrent)
 TEST_F(RenameTest, multifileTorrent)
 {
     auto constexpr TotalSize = size_t{ 67 };
-    auto constexpr ExpectedFiles = std::array<std::string_view, 4>{
+    auto constexpr ExpectedFiles = std::to_array<std::string_view>({
         "Felidae/Felinae/Acinonyx/Cheetah/Chester"sv,
         "Felidae/Felinae/Felis/catus/Kyphi"sv,
         "Felidae/Felinae/Felis/catus/Saffron"sv,
         "Felidae/Pantherinae/Panthera/Tiger/Tony"sv,
-    };
-    auto constexpr ExpectedContents = std::array<std::string_view, 4>{
+    });
+    auto constexpr ExpectedContents = std::to_array<std::string_view>({
         "It ain't easy bein' cheesy.\n"sv,
         "Inquisitive\n"sv,
         "Tough\n"sv,
         "They’re Grrrrreat!\n"sv,
-    };
+    });
 
     auto* ctor = tr_ctorNew(session_);
     auto* tor = createTorrentFromBase64Metainfo(
@@ -444,7 +444,7 @@ TEST_F(RenameTest, partialFile)
 {
     auto constexpr PieceCount = uint32_t{ 33 };
     auto constexpr PieceSize = uint32_t{ 32768 };
-    auto constexpr Length = std::array<uint32_t, 3>{ 1048576, 4096, 512 };
+    auto constexpr Length = std::to_array<uint32_t>({ 1048576, 4096, 512 });
     auto constexpr TotalSize = uint64_t{ Length[0] } + Length[1] + Length[2];
 
     /***

--- a/tests/libtransmission/session-test.cc
+++ b/tests/libtransmission/session-test.cc
@@ -178,7 +178,7 @@ TEST_F(SessionTest, peerId)
         auto const suffix = peer_id.substr(peer_id_prefix.size());
         for (char const ch : suffix)
         {
-            auto const tmp = std::array<char, 2>{ ch, '\0' };
+            auto const tmp = std::to_array<char>({ ch, '\0' });
             val += strtoul(tmp.data(), nullptr, 36);
         }
 

--- a/tests/libtransmission/subprocess-test.cc
+++ b/tests/libtransmission/subprocess-test.cc
@@ -88,7 +88,7 @@ TEST_P(SubprocessTest, SpawnAsyncMissingExec)
 {
     auto const missing_exe_path = std::string{ TR_IF_WIN32("C:\\", "/") "tr-missing-test-exe" TR_IF_WIN32(".exe", "") };
 
-    auto args = std::array<char const*, 2>{ missing_exe_path.data(), nullptr };
+    auto args = std::to_array<char const*>({ missing_exe_path.data(), nullptr });
 
     auto error = tr_error{};
     auto const ret = tr_spawn_async(std::data(args), {}, {}, &error);
@@ -108,14 +108,14 @@ TEST_P(SubprocessTest, SpawnAsyncArgs)
     auto const test_arg3 = std::string{};
     auto const test_arg4 = std::string{ "\"arg3'^! $PATH %PATH% \\" };
 
-    auto const args = std::array<char const*, 8>{ self_path_.c_str(),
-                                                  result_path.data(),
-                                                  arg_dump_args_.data(),
-                                                  test_arg1.data(),
-                                                  test_arg2.data(),
-                                                  test_arg3.data(),
-                                                  allow_batch_metachars ? test_arg4.data() : nullptr,
-                                                  nullptr };
+    auto const args = std::to_array<char const*>({ self_path_.c_str(),
+                                                   result_path.data(),
+                                                   arg_dump_args_.data(),
+                                                   test_arg1.data(),
+                                                   test_arg2.data(),
+                                                   test_arg3.data(),
+                                                   allow_batch_metachars ? test_arg4.data() : nullptr,
+                                                   nullptr });
 
     auto error = tr_error{};
     bool const ret = tr_spawn_async(std::data(args), {}, {}, &error);
@@ -163,7 +163,7 @@ TEST_P(SubprocessTest, SpawnAsyncEnv)
     auto const test_env_value4 = std::string{ "bar" };
     auto const test_env_value5 = std::string{ "jar" };
 
-    auto args = std::array<char const*, 10>{
+    auto args = std::to_array<char const*>({
         self_path_.c_str(), //
         result_path.data(), //
         arg_dump_env_.data(), //
@@ -174,7 +174,7 @@ TEST_P(SubprocessTest, SpawnAsyncEnv)
         test_env_key5.data(), //
         test_env_key6.data(), //
         nullptr, //
-    };
+    });
 
     auto const env = std::map<std::string_view, std::string_view>{
         { test_env_key1, test_env_value1 },
@@ -223,7 +223,7 @@ TEST_P(SubprocessTest, SpawnAsyncCwdExplicit)
     auto const test_dir = sandbox_.path();
     auto const result_path = buildSandboxPath("result.txt");
 
-    auto const args = std::array<char const*, 4>{ self_path_.c_str(), result_path.c_str(), arg_dump_cwd_.c_str(), nullptr };
+    auto const args = std::to_array<char const*>({ self_path_.c_str(), result_path.c_str(), arg_dump_cwd_.c_str(), nullptr });
 
     auto error = tr_error{};
     bool const ret = tr_spawn_async(std::data(args), {}, test_dir, &error);
@@ -251,7 +251,7 @@ TEST_P(SubprocessTest, SpawnAsyncCwdInherit)
     auto const result_path = buildSandboxPath("result.txt");
     auto const expected_cwd = nativeCwd();
 
-    auto const args = std::array<char const*, 4>{ self_path_.c_str(), result_path.data(), arg_dump_cwd_.data(), nullptr };
+    auto const args = std::to_array<char const*>({ self_path_.c_str(), result_path.data(), arg_dump_cwd_.data(), nullptr });
 
     auto error = tr_error{};
     auto const ret = tr_spawn_async(std::data(args), {}, {}, &error);
@@ -276,7 +276,7 @@ TEST_P(SubprocessTest, SpawnAsyncCwdMissing)
 {
     auto const result_path = buildSandboxPath("result.txt");
 
-    auto const args = std::array<char const*, 4>{ self_path_.c_str(), result_path.data(), arg_dump_cwd_.data(), nullptr };
+    auto const args = std::to_array<char const*>({ self_path_.c_str(), result_path.data(), arg_dump_cwd_.data(), nullptr });
 
     auto error = tr_error{};
     auto const ret = tr_spawn_async(std::data(args), {}, TR_IF_WIN32("C:\\", "/") "tr-missing-test-work-dir", &error);

--- a/tests/libtransmission/torrent-metainfo-test.cc
+++ b/tests/libtransmission/torrent-metainfo-test.cc
@@ -63,7 +63,7 @@ TEST_F(TorrentMetainfoTest, bucket)
         bool expected_parse_result;
     };
 
-    static auto constexpr Tests = std::array<LocalTest, 12U>{ {
+    static auto constexpr Tests = std::to_array<LocalTest>({
         { .benc = BEFORE_PATH "5:a.txt" AFTER_PATH, .expected_parse_result = true },
         // allow empty components, but not =all= empty components, see bug #5517
         { .benc = BEFORE_PATH "0:5:a.txt" AFTER_PATH, .expected_parse_result = true },
@@ -83,7 +83,7 @@ TEST_F(TorrentMetainfoTest, bucket)
         { .benc = "d10:short", .expected_parse_result = false },
         // fail on empty string
         { .benc = "", .expected_parse_result = false },
-    } };
+    });
 
     tr_logSetLevel(TR_LOG_OFF);
 
@@ -96,9 +96,9 @@ TEST_F(TorrentMetainfoTest, bucket)
 
 TEST_F(TorrentMetainfoTest, parseBencFuzzRegressions)
 {
-    static auto constexpr Tests = std::array<std::string_view, 1>{
+    static auto constexpr Tests = std::to_array<std::string_view>({
         "ZC/veNSVW0Ss+KGfMqH4DQqtYXzgmVi5oBi0XlxviLytlwwjf7MLanOcnS73eSB/iye83hVyvSWg27tPl5oqWdNEZ0euMbo7E8FH/xgTvUEOnBVgvPno50CyI7c5F2QTw16avUB7dvGzx5xIjzJ2qkD2BsNtOoiZI3skC6XwSifsDfJUN8NxHFiwvWxmZRLq2eQlE2wGxAW5aLj6U1MHDzPZ83+2o81pRyMr11bHmWFcNorTGLeOpHBd9veduHpNOKNwOatoXeb57jZCy1Zmu9y/wCuUx6DP3I5FGQ/t3AYh7w028Z/zgIlvWat6QjqSPp7j1nEbl6SNZNl1doGmusl9hvRsbaCq9b1XHpTDtQSJ8Owj07fph0p0ZVu5kJpQBfOGsHLh6ALVrTepptIvcnNW9+nauE+NJa2z+9Yla7780sCdBsGYZZA6HUr0J9GXES7+uRPPBwAl2YB1qWhCsOCClixTiAlwrsBl1bJ/a4FV04aU5jXDEYrpJMzdSAEoypDWMsn3Fc5umLqJ1jtqPqykKY0HjPrCkVAMmvmacauBzIj5Eg/uw0xtZp+wXdLQv8qyuXgsJs7dExZbgTgfPY4niTBpftM6YFQrCx/IxiMshYp7tMolykoed/8gZMm6yyWizzml4BlvnvY3+J2eVKRvS7QToRKxN5eFP9l/pflrK+8cHbwVnjQ1pE3hTQACmNIQHRTY2QoOGwG+HTwo48akfbJnjJ3F0iN6miy7lvv5u0p1rpbM2On5FJ3G98OYnzGIxf8BomHvVp/3eX6QJZUMZKsUTpgbRqg0AJH9FjiERQ9v6B25Va+Q0yV8z5DmiA5AgyIwkIzlSBAl0PYsNaw+rH06a93yBhAfK6EPSArYLjMI6o/1kF4UxNyfE+F79xbdCAKRAX3iJ7DH1GncFoIQ1fZd/uZaF9tXjViQ7P/sHuKdZvfLpvJq88JV5Pcdsfdlle86QAF4weB+k/k8f/xgvxRNbbcAfjLvEHhDBzfEvHkgFrW19WvLHyAqjjUovpecIu3KeCqwyOr1dHViUVelxqc5BklyGQ+Asd6GnWPSzO5Hamj4rYrapgogEup5PKm1j2CgL2HH2tySWwjgtOWbooGhsdBnCeQOsapCxwc6ALtudG4Q9RBu6A6pLUfFE3rm1RuvNGoJNHiEQ4BAFiqLpYJd4lR7V2fI6EIKug0dB3SpHpUeNCQbG67IM+kVe0I+vP3cECGOGXo="sv,
-    };
+    });
 
     for (auto const& test : Tests)
     {
@@ -213,7 +213,7 @@ TEST_F(TorrentMetainfoTest, GetRightStyleWebseedString)
 
 TEST_F(TorrentMetainfoTest, piecesKeyTest)
 {
-    static auto constexpr BadTorrents = std::array<std::pair<std::string_view, std::string_view>, 7U>{ {
+    static auto constexpr BadTorrents = std::to_array<std::pair<std::string_view, std::string_view>>({
         { "missing-pieces-key.torrent"sv, "missing v1 metadata"sv },
         { "bad-pieces-key.torrent"sv, "missing v1 metadata"sv },
         { "empty-pieces-key.torrent"sv, "missing v1 metadata"sv },
@@ -222,7 +222,7 @@ TEST_F(TorrentMetainfoTest, piecesKeyTest)
         { "dup-pieces-key.torrent"sv, "invalid duplicate 'pieces'"sv },
         { "invalid-pieces-length.torrent"sv,
           "invalid 'pieces' size: 119"sv }, // Test for https://github.com/transmission/transmission/issues/3591
-    } };
+    });
 
     {
         auto tm = tr_torrent_metainfo{};
@@ -278,10 +278,10 @@ TEST_F(TorrentMetainfoTest, preservesInfoDictOrder)
     //
     // These v1 hashes are calculated by hand with this command:
     // dd if=${TORRENT_FILE} skip=225 count=343 bs=1 status=none | sha1sum -b
-    static auto constexpr Tests = std::array<std::pair<std::string_view, std::string_view>, 2U>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, std::string_view>>({
         { "unordered-info-dict.torrent"sv, "e44a814ac5ed962f9181638d1136a6aface3f734"sv },
         { "perfect-pieces.torrent"sv, "efa7eb3dec5661698f353fde079418543a63e872"sv },
-    } };
+    });
 
     for (auto const& [name, v1hash] : Tests)
     {

--- a/tests/libtransmission/torrents-test.cc
+++ b/tests/libtransmission/torrents-test.cc
@@ -228,7 +228,7 @@ TEST_F(TorrentsTest, rangedLoop)
     auto constexpr Filenames = std::to_array<std::string_view>({ "Android-x86 8.1 r6 iso.torrent"sv,
                                                                  "debian-11.2.0-amd64-DVD-1.iso.torrent"sv,
                                                                  "ubuntu-18.04.6-desktop-amd64.iso.torrent"sv,
-                                                                 "ubuntu-20.04.4-desktop-amd64.iso.torrent"sv });
+                                                                 "ubuntu-20.04.4-desktop-amd64.iso.torrent"sv, });
 
     auto owned = std::vector<std::unique_ptr<tr_torrent>>{};
     auto torrents = tr_torrents{};
@@ -259,7 +259,7 @@ TEST_F(TorrentsTest, removedSince)
     auto constexpr Filenames = std::to_array<std::string_view>({ "Android-x86 8.1 r6 iso.torrent"sv,
                                                                  "debian-11.2.0-amd64-DVD-1.iso.torrent"sv,
                                                                  "ubuntu-18.04.6-desktop-amd64.iso.torrent"sv,
-                                                                 "ubuntu-20.04.4-desktop-amd64.iso.torrent"sv });
+                                                                 "ubuntu-20.04.4-desktop-amd64.iso.torrent"sv, });
 
     auto owned = std::vector<std::unique_ptr<tr_torrent>>{};
     auto torrents = tr_torrents{};

--- a/tests/libtransmission/torrents-test.cc
+++ b/tests/libtransmission/torrents-test.cc
@@ -225,10 +225,10 @@ TEST_F(TorrentsTest, simpleTests)
 
 TEST_F(TorrentsTest, rangedLoop)
 {
-    auto constexpr Filenames = std::array<std::string_view, 4>{ "Android-x86 8.1 r6 iso.torrent"sv,
-                                                                "debian-11.2.0-amd64-DVD-1.iso.torrent"sv,
-                                                                "ubuntu-18.04.6-desktop-amd64.iso.torrent"sv,
-                                                                "ubuntu-20.04.4-desktop-amd64.iso.torrent"sv };
+    auto constexpr Filenames = std::to_array<std::string_view>({ "Android-x86 8.1 r6 iso.torrent"sv,
+                                                                 "debian-11.2.0-amd64-DVD-1.iso.torrent"sv,
+                                                                 "ubuntu-18.04.6-desktop-amd64.iso.torrent"sv,
+                                                                 "ubuntu-20.04.4-desktop-amd64.iso.torrent"sv });
 
     auto owned = std::vector<std::unique_ptr<tr_torrent>>{};
     auto torrents = tr_torrents{};
@@ -256,10 +256,10 @@ TEST_F(TorrentsTest, rangedLoop)
 
 TEST_F(TorrentsTest, removedSince)
 {
-    auto constexpr Filenames = std::array<std::string_view, 4>{ "Android-x86 8.1 r6 iso.torrent"sv,
-                                                                "debian-11.2.0-amd64-DVD-1.iso.torrent"sv,
-                                                                "ubuntu-18.04.6-desktop-amd64.iso.torrent"sv,
-                                                                "ubuntu-20.04.4-desktop-amd64.iso.torrent"sv };
+    auto constexpr Filenames = std::to_array<std::string_view>({ "Android-x86 8.1 r6 iso.torrent"sv,
+                                                                 "debian-11.2.0-amd64-DVD-1.iso.torrent"sv,
+                                                                 "ubuntu-18.04.6-desktop-amd64.iso.torrent"sv,
+                                                                 "ubuntu-20.04.4-desktop-amd64.iso.torrent"sv });
 
     auto owned = std::vector<std::unique_ptr<tr_torrent>>{};
     auto torrents = tr_torrents{};
@@ -280,7 +280,7 @@ TEST_F(TorrentsTest, removedSince)
     }
 
     // setup: remove them at the given timestamp
-    auto constexpr TimeRemoved = std::array<time_t, 4>{ 100, 200, 200, 300 };
+    auto constexpr TimeRemoved = std::to_array<time_t>({ 100, 200, 200, 300 });
     for (size_t i = 0; i < 4; ++i)
     {
         auto* const tor = torrents_v[i];

--- a/tests/libtransmission/torrents-test.cc
+++ b/tests/libtransmission/torrents-test.cc
@@ -225,10 +225,12 @@ TEST_F(TorrentsTest, simpleTests)
 
 TEST_F(TorrentsTest, rangedLoop)
 {
-    auto constexpr Filenames = std::to_array<std::string_view>({ "Android-x86 8.1 r6 iso.torrent"sv,
-                                                                 "debian-11.2.0-amd64-DVD-1.iso.torrent"sv,
-                                                                 "ubuntu-18.04.6-desktop-amd64.iso.torrent"sv,
-                                                                 "ubuntu-20.04.4-desktop-amd64.iso.torrent"sv, });
+    auto constexpr Filenames = std::to_array<std::string_view>({
+        "Android-x86 8.1 r6 iso.torrent"sv,
+        "debian-11.2.0-amd64-DVD-1.iso.torrent"sv,
+        "ubuntu-18.04.6-desktop-amd64.iso.torrent"sv,
+        "ubuntu-20.04.4-desktop-amd64.iso.torrent"sv,
+    });
 
     auto owned = std::vector<std::unique_ptr<tr_torrent>>{};
     auto torrents = tr_torrents{};
@@ -256,10 +258,12 @@ TEST_F(TorrentsTest, rangedLoop)
 
 TEST_F(TorrentsTest, removedSince)
 {
-    auto constexpr Filenames = std::to_array<std::string_view>({ "Android-x86 8.1 r6 iso.torrent"sv,
-                                                                 "debian-11.2.0-amd64-DVD-1.iso.torrent"sv,
-                                                                 "ubuntu-18.04.6-desktop-amd64.iso.torrent"sv,
-                                                                 "ubuntu-20.04.4-desktop-amd64.iso.torrent"sv, });
+    auto constexpr Filenames = std::to_array<std::string_view>({
+        "Android-x86 8.1 r6 iso.torrent"sv,
+        "debian-11.2.0-amd64-DVD-1.iso.torrent"sv,
+        "ubuntu-18.04.6-desktop-amd64.iso.torrent"sv,
+        "ubuntu-20.04.4-desktop-amd64.iso.torrent"sv,
+    });
 
     auto owned = std::vector<std::unique_ptr<tr_torrent>>{};
     auto torrents = tr_torrents{};

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -101,7 +101,7 @@ TEST_F(UtilsTest, ratioToString)
                                                                                        { 4000.4, "4000" },
                                                                                        { 600000.0, "600000" },
                                                                                        { 900000000.0, "900000000" },
-                                                                                       { TR_RATIO_INF, "inf" } });
+                                                                                       { TR_RATIO_INF, "inf" }, });
     char const nullchar = '\0';
 
     ASSERT_EQ(tr_strratio(TR_RATIO_NA, "None", "Ratio is NaN"), "None");

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -86,22 +86,24 @@ TEST_F(UtilsTest, mimeTypes)
 TEST_F(UtilsTest, ratioToString)
 {
     // Testpairs contain ratio as a double and a string
-    static auto constexpr Tests = std::to_array<std::pair<double, std::string_view>>({ { 0.0, "0.00" },
-                                                                                       { 0.01, "0.01" },
-                                                                                       { 0.1, "0.10" },
-                                                                                       { 1.0, "1.00" },
-                                                                                       { 1.015, "1.01" },
-                                                                                       { 4.99, "4.99" },
-                                                                                       { 4.996, "4.99" },
-                                                                                       { 5.0, "5.0" },
-                                                                                       { 5.09999, "5.0" },
-                                                                                       { 5.1, "5.1" },
-                                                                                       { 99.99, "99.9" },
-                                                                                       { 100.0, "100" },
-                                                                                       { 4000.4, "4000" },
-                                                                                       { 600000.0, "600000" },
-                                                                                       { 900000000.0, "900000000" },
-                                                                                       { TR_RATIO_INF, "inf" }, });
+    static auto constexpr Tests = std::to_array<std::pair<double, std::string_view>>({
+        { 0.0, "0.00" },
+        { 0.01, "0.01" },
+        { 0.1, "0.10" },
+        { 1.0, "1.00" },
+        { 1.015, "1.01" },
+        { 4.99, "4.99" },
+        { 4.996, "4.99" },
+        { 5.0, "5.0" },
+        { 5.09999, "5.0" },
+        { 5.1, "5.1" },
+        { 99.99, "99.9" },
+        { 100.0, "100" },
+        { 4000.4, "4000" },
+        { 600000.0, "600000" },
+        { 900000000.0, "900000000" },
+        { TR_RATIO_INF, "inf" },
+    });
     char const nullchar = '\0';
 
     ASSERT_EQ(tr_strratio(TR_RATIO_NA, "None", "Ratio is NaN"), "None");

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -86,22 +86,22 @@ TEST_F(UtilsTest, mimeTypes)
 TEST_F(UtilsTest, ratioToString)
 {
     // Testpairs contain ratio as a double and a string
-    static auto constexpr Tests = std::array<std::pair<double, std::string_view>, 16>{ { { 0.0, "0.00" },
-                                                                                         { 0.01, "0.01" },
-                                                                                         { 0.1, "0.10" },
-                                                                                         { 1.0, "1.00" },
-                                                                                         { 1.015, "1.01" },
-                                                                                         { 4.99, "4.99" },
-                                                                                         { 4.996, "4.99" },
-                                                                                         { 5.0, "5.0" },
-                                                                                         { 5.09999, "5.0" },
-                                                                                         { 5.1, "5.1" },
-                                                                                         { 99.99, "99.9" },
-                                                                                         { 100.0, "100" },
-                                                                                         { 4000.4, "4000" },
-                                                                                         { 600000.0, "600000" },
-                                                                                         { 900000000.0, "900000000" },
-                                                                                         { TR_RATIO_INF, "inf" } } };
+    static auto constexpr Tests = std::to_array<std::pair<double, std::string_view>>({ { 0.0, "0.00" },
+                                                                                       { 0.01, "0.01" },
+                                                                                       { 0.1, "0.10" },
+                                                                                       { 1.0, "1.00" },
+                                                                                       { 1.015, "1.01" },
+                                                                                       { 4.99, "4.99" },
+                                                                                       { 4.996, "4.99" },
+                                                                                       { 5.0, "5.0" },
+                                                                                       { 5.09999, "5.0" },
+                                                                                       { 5.1, "5.1" },
+                                                                                       { 99.99, "99.9" },
+                                                                                       { 100.0, "100" },
+                                                                                       { 4000.4, "4000" },
+                                                                                       { 600000.0, "600000" },
+                                                                                       { 900000000.0, "900000000" },
+                                                                                       { TR_RATIO_INF, "inf" } });
     char const nullchar = '\0';
 
     ASSERT_EQ(tr_strratio(TR_RATIO_NA, "None", "Ratio is NaN"), "None");

--- a/tests/libtransmission/variant-test.cc
+++ b/tests/libtransmission/variant-test.cc
@@ -356,7 +356,7 @@ TEST_F(VariantTest, parse)
 
 TEST_F(VariantTest, bencParseAndReencode)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, bool>, 9>{ {
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, bool>>({
         { "llleee"sv, true },
         { "d3:cow3:moo4:spam4:eggse"sv, true },
         { "d4:spaml1:a1:bee"sv, true },
@@ -366,7 +366,7 @@ TEST_F(VariantTest, bencParseAndReencode)
         { "d1:ai0e1:be"sv, false }, // odd number of children
         { ""sv, false },
         { " "sv, false },
-    } };
+    });
 
     auto serde = tr_variant_serde::benc();
     serde.inplace();
@@ -427,14 +427,13 @@ TEST_F(VariantTest, bencMalformedIncompleteString)
 
 TEST_F(VariantTest, bencToJson)
 {
-    static auto constexpr Tests = std::array<std::pair<std::string_view, std::string_view>, 5>{
+    static auto constexpr Tests = std::to_array<std::pair<std::string_view, std::string_view>>(
         { { "i6e"sv, "6"sv },
           { "d5:helloi1e5:worldi2ee"sv, R"({"hello":1,"world":2})"sv },
           { "d5:helloi1e5:worldi2e3:fooli1ei2ei3eee"sv, R"({"foo":[1,2,3],"hello":1,"world":2})"sv },
           { "d5:helloi1e5:worldi2e3:fooli1ei2ei3ed1:ai0eeee"sv, R"({"foo":[1,2,3,{"a":0}],"hello":1,"world":2})"sv },
           { "d4:argsd6:statusle7:status2lee6:result7:successe"sv,
-            R"({"args":{"status":[],"status2":[]},"result":"success"})"sv } }
-    };
+            R"({"args":{"status":[],"status2":[]},"result":"success"})"sv } });
 
     auto benc_serde = tr_variant_serde::benc();
     auto json_serde = tr_variant_serde::json();
@@ -664,7 +663,7 @@ TEST_F(VariantTest, variantAssingmentOperator)
 
 TEST_F(VariantTest, mergeOverwritesDifferingTypes)
 {
-    auto const variants = std::array<std::pair<tr_variant, std::string_view>, 7U>{ {
+    auto const variants = std::to_array<std::pair<tr_variant, std::string_view>>({
         { tr_variant{ true }, "true" },
         { tr_variant{ int64_t{ 123 } }, "123" },
         { tr_variant{ 4.5 }, "4.5" },
@@ -672,7 +671,7 @@ TEST_F(VariantTest, mergeOverwritesDifferingTypes)
         { tr_variant{ nullptr }, "null"sv },
         { tr_variant::make_map(0U), "{}"sv },
         { tr_variant::make_vector(), "[]"sv },
-    } };
+    });
 
     auto serde = tr_variant_serde::json();
     serde.compact();

--- a/tests/libtransmission/web-utils-test.cc
+++ b/tests/libtransmission/web-utils-test.cc
@@ -245,7 +245,7 @@ TEST_F(WebUtilsTest, urlIsValid)
 
 TEST_F(WebUtilsTest, urlPercentDecode)
 {
-    auto constexpr Tests = std::array<std::pair<std::string_view, std::string_view>, 13>{ {
+    auto constexpr Tests = std::to_array<std::pair<std::string_view, std::string_view>>({
         { "%-2"sv, "%-2"sv },
         { "%6 1"sv, "%6 1"sv },
         { "%6"sv, "%6"sv },
@@ -260,7 +260,7 @@ TEST_F(WebUtilsTest, urlPercentDecode)
         { "%FG"sv, "%FG"sv },
         { "http%3A%2F%2Fwww.example.com%2F~user%2F%3Ftest%3D1%26test1%3D2"sv,
           "http://www.example.com/~user/?test=1&test1=2"sv },
-    } };
+    });
 
     for (auto const& [encoded, decoded] : Tests)
     {
@@ -270,7 +270,7 @@ TEST_F(WebUtilsTest, urlPercentDecode)
 
 TEST_F(WebUtilsTest, urlPercentEncode)
 {
-    static auto constexpr Tests = std::array<std::tuple<std::string_view, std::string_view, bool>, 10U>{ {
+    static auto constexpr Tests = std::to_array<std::tuple<std::string_view, std::string_view, bool>>({
         { "192.168.202.101"sv, "192.168.202.101"sv, true },
         { "8.8.8.8"sv, "8.8.8.8"sv, true },
         { "[2001:0:0eab:dead::a0:abcd:4e]"sv, "%5B2001%3A0%3A0eab%3Adead%3A%3Aa0%3Aabcd%3A4e%5D"sv, true },
@@ -281,7 +281,7 @@ TEST_F(WebUtilsTest, urlPercentEncode)
         { "https://example.com/Let%C3%B6lt%C3%A9sek"sv, "https://example.com/Let%C3%B6lt%C3%A9sek"sv, false },
         { "udp://你好.com/announce"sv, "udp://%E4%BD%A0%E5%A5%BD.com/announce"sv, false },
         { "udp://%E4%BD%A0%E5%A5%BD.com/announce"sv, "udp://%E4%BD%A0%E5%A5%BD.com/announce"sv, false },
-    } };
+    });
 
     for (auto const& [decoded, encoded, escape_reserved] : Tests)
     {

--- a/utils/create.cc
+++ b/utils/create.cc
@@ -43,7 +43,7 @@ char constexpr Usage[] = "Usage: transmission-create [options] <file|directory>"
 uint32_t constexpr KiB = 1024;
 
 using Arg = tr_option::Arg;
-auto constexpr Options = std::array<tr_option, 10>{ {
+auto constexpr Options = std::to_array<tr_option>({
     { 'p', "private", "Allow this torrent to only be used with the specified tracker(s)", "p", Arg::None, nullptr },
     { 'r', "source", "Set the source for private trackers", "r", Arg::Required, "<source>" },
     { 'o', "outfile", "Save the generated .torrent to this filename", "o", Arg::Required, "<file>" },
@@ -54,7 +54,7 @@ auto constexpr Options = std::array<tr_option, 10>{ {
     { 'x', "anonymize", R"(Omit "Creation date" and "Created by" info)", nullptr, Arg::None, nullptr },
     { 'V', "version", "Show version number and exit", "V", Arg::None, nullptr },
     { 0, nullptr, nullptr, nullptr, Arg::None, nullptr },
-} };
+});
 static_assert(Options[std::size(Options) - 2].val != 0);
 } // namespace
 

--- a/utils/edit.cc
+++ b/utils/edit.cc
@@ -37,14 +37,14 @@ struct app_options
 };
 
 using Arg = tr_option::Arg;
-auto constexpr Options = std::array<tr_option, 6>{ {
+auto constexpr Options = std::to_array<tr_option>({
     { 'a', "add", "Add a tracker's announce URL", "a", Arg::Required, "<url>" },
     { 'd', "delete", "Delete a tracker's announce URL", "d", Arg::Required, "<url>" },
     { 'r', "replace", "Search and replace a substring in the announce URLs", "r", Arg::Required, "<old> <new>" },
     { 's', "source", "Set the source", "s", Arg::Required, "<source>" },
     { 'V', "version", "Show version number and exit", "V", Arg::None, nullptr },
     { 0, nullptr, nullptr, nullptr, Arg::None, nullptr },
-} };
+});
 static_assert(Options[std::size(Options) - 2].val != 0);
 } // namespace
 

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -218,7 +218,7 @@ enum
 
 using Arg = tr_option::Arg;
 static_assert(TrDefaultPeerPort == 51413, "update 'port' desc");
-auto constexpr Options = std::array<tr_option, 106>{ {
+auto constexpr Options = std::to_array<tr_option>({
     { 'a', "add", "Add torrent files by filename or URL", "a", Arg::None, nullptr },
     { 970, "alt-speed", "Use the alternate Limits", "as", Arg::None, nullptr },
     { 971, "no-alt-speed", "Don't use the alternate Limits", "AS", Arg::None, nullptr },
@@ -386,7 +386,7 @@ auto constexpr Options = std::array<tr_option, 106>{ {
     { 'Y', "no-lpd", "Disable local peer discovery (LPD)", "Y", Arg::None, nullptr },
     { 941, "peer-info", "List the current torrent(s)' peers", "pi", Arg::None, nullptr },
     { 0, nullptr, nullptr, nullptr, Arg::None, nullptr },
-} };
+});
 static_assert(Options[std::size(Options) - 2].val != 0);
 } // namespace
 
@@ -750,15 +750,15 @@ void set_preferred_transports(tr_variant::Map& args, std::string_view comma_deli
     return files;
 }
 
-auto constexpr FilesKeys = std::array<tr_quark, 4>{
+auto constexpr FilesKeys = std::to_array<tr_quark>({
     TR_KEY_files,
     TR_KEY_name,
     TR_KEY_priorities,
     TR_KEY_wanted,
-};
+});
 static_assert(FilesKeys[std::size(FilesKeys) - 1] != tr_quark{});
 
-auto constexpr DetailsKeys = std::array<tr_quark, 57>{
+auto constexpr DetailsKeys = std::to_array<tr_quark>({
     TR_KEY_activity_date,
     TR_KEY_added_date,
     TR_KEY_bandwidth_priority,
@@ -816,10 +816,10 @@ auto constexpr DetailsKeys = std::array<tr_quark, 57>{
     TR_KEY_upload_ratio,
     TR_KEY_webseeds,
     TR_KEY_webseeds_sending_to_us,
-};
+});
 static_assert(DetailsKeys[std::size(DetailsKeys) - 1] != tr_quark{});
 
-auto constexpr ListKeys = std::array<tr_quark, 15U>{
+auto constexpr ListKeys = std::to_array<tr_quark>({
     TR_KEY_added_date,
     TR_KEY_error,
     TR_KEY_error_string,
@@ -835,7 +835,7 @@ auto constexpr ListKeys = std::array<tr_quark, 15U>{
     TR_KEY_size_when_done,
     TR_KEY_status,
     TR_KEY_upload_ratio,
-};
+});
 static_assert(ListKeys[std::size(ListKeys) - 1] != tr_quark{});
 
 [[nodiscard]] size_t write_func(void* ptr, size_t size, size_t nmemb, void* vbuf)
@@ -968,12 +968,12 @@ void warn_if_unsupported_rpc_version(std::string_view const semver)
     }
 }
 
-auto constexpr BandwidthPriorityNames = std::array<std::string_view, 4>{
+auto constexpr BandwidthPriorityNames = std::to_array<std::string_view>({
     "Low"sv,
     "Normal"sv,
     "High"sv,
     "Invalid"sv,
-};
+});
 static_assert(!BandwidthPriorityNames[std::size(BandwidthPriorityNames) - 1].empty());
 
 template<size_t N>

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -48,7 +48,7 @@ char constexpr MyName[] = "transmission-show";
 char constexpr Usage[] = "Usage: transmission-show [options] <torrent-file>";
 
 using Arg = tr_option::Arg;
-auto constexpr Options = std::array<tr_option, 14>{ {
+auto constexpr Options = std::to_array<tr_option>({
     { 'd', "header", "Show only header section", "d", Arg::None, nullptr },
     { 'i', "info", "Show only info section", "i", Arg::None, nullptr },
     { 't', "trackers", "Show only trackers section", "t", Arg::None, nullptr },
@@ -63,7 +63,7 @@ auto constexpr Options = std::array<tr_option, 14>{ {
     { 'u', "unsorted", "Do not sort files by name", "u", Arg::None, nullptr },
     { 'V', "version", "Show version number and exit", "V", Arg::None, nullptr },
     { 0, nullptr, nullptr, nullptr, Arg::None, nullptr },
-} };
+});
 static_assert(Options[std::size(Options) - 2].val != 0);
 } // namespace
 


### PR DESCRIPTION
Hardcoding array sizes is error-prone: it's easy to forget to change the number when you add or remove an item, eg in the `api-compat` arrays.

Use `std::to_array()` instead so the size is always correct.

Notes: Moved from C++17 to C++20