### PR TITLE
build: bump Qt versions on Windows to 5.15.19 and 6.10.3

### DIFF
--- a/release/windows/build-qt5.ps1
+++ b/release/windows/build-qt5.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 
-$global:Qt5Version = '5.15.17'
+$global:Qt5Version = '5.15.19'
 
 $global:Qt5Deps = @(
     'DBus'

--- a/release/windows/build-qt6.ps1
+++ b/release/windows/build-qt6.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 
-$global:Qt6Version = '6.10.1'
+$global:Qt6Version = '6.10.3'
 
 $global:Qt6Deps = @(
     'DBus'
@@ -108,6 +108,11 @@ function global:Build-Qt6([string] $PrefixDir, [string] $Arch, [string] $DepsPre
         '-L'; (Join-Path $DepsPrefixDir lib).Replace('\', '/')
         '--'
         "-DCMAKE_PREFIX_PATH=${DepsPrefixDir}"
+        # We don't use Qt's SBOM, we only need the libraries/runtime.
+        # In Qt 6.10.3, enabling SBOM bakes CMAKE_PREFIX_PATH (eg D:\x86-prefix)
+        # verbatim into a generated .cmake which trips up CMake's '\x' escape.
+        # Re-enable iff we someday need SBOM *and* upstream Qt is fixed.
+        '-DQT_GENERATE_SBOM=OFF'
     )
 
     # No need in GUI and some other tools


### PR DESCRIPTION
- build: bump Qt6 to `6.10.3` from `6.10.1`

- build: bump Qt5 to `5.15.19` from `5.15.17`

Notes: Upgrade Windows 10+ builds to Qt 6.10.3

Notes: Upgrade Windows 7 builds to Qt 5.15.19