### PR TITLE
fix: don't expose RPC session id via CORS

### DIFF
--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -560,17 +560,9 @@ void handle_request(struct evhttp_request* req, void* arg)
         return;
     }
 
-    evhttp_add_header(output_headers, "Access-Control-Allow-Origin", "*");
-
     auto const* const input_headers = evhttp_request_get_input_headers(req);
     if (auto const cmd = evhttp_request_get_command(req); cmd == EVHTTP_REQ_OPTIONS)
     {
-        if (char const* headers = evhttp_find_header(input_headers, "Access-Control-Request-Headers"); headers != nullptr)
-        {
-            evhttp_add_header(output_headers, "Access-Control-Allow-Headers", headers);
-        }
-
-        evhttp_add_header(output_headers, "Access-Control-Allow-Methods", "GET, POST, OPTIONS");
         send_simple_response(req, HTTP_OK);
         return;
     }
@@ -1044,6 +1036,14 @@ void tr_rpc_server::load(Settings&& settings)
         if (this->is_password_enabled())
         {
             tr_logAddInfo(_("Password required"));
+        }
+        else if (!this->is_whitelist_enabled())
+        {
+            tr_logAddWarn(
+                "The RPC server has no password and its IP whitelist is disabled. "
+                "Anyone who can reach it has full control. "
+                "Consider enabling 'rpc_whitelist_enabled' or "
+                "setting 'rpc_authentication_required' and 'rpc_password'.");
         }
     }
     else


### PR DESCRIPTION
Cherry-pick of upstream `4.1.x` PR 8938. Approved upstream by @tearfur .

---

The RPC server sent `Access-Control-Allow-Origin: *`, reflected the preflight CORS headers, and advertised X-Transmission-Session-Id via Access-Control-Expose-Headers on the 409 handshake. Any page a user visited could read the session-id nonce that guards against CSRF.

Emit no CORS headers at all. The bundled Web UI and non-browser clients are same-origin or unrestricted, so only cross-origin browser reads are blocked.

Also, add a warning when starting a daemon if the remote whitelist and remote authentication are both disabled.

Reported by Jan Kahmen (turingpoint).