### PR TITLE
refactor: remove `at()` and `operator Char const*` from `tr_strbuf`

### DIFF
--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -58,7 +58,8 @@ using address_range_t = std::pair<tr_address, tr_address>;
 
 void save(std::string_view filename, address_range_t const* ranges, size_t n_ranges)
 {
-    auto out = std::ofstream{ tr_pathbuf{ filename }, std::ios_base::out | std::ios_base::trunc | std::ios_base::binary };
+    auto out = std::ofstream{ tr_pathbuf{ filename }.c_str(),
+                              std::ios_base::out | std::ios_base::trunc | std::ios_base::binary };
     if (!out.is_open()) {
         tr_logAddWarn(
             fmt::format(
@@ -211,7 +212,7 @@ std::optional<std::vector<address_range_t>> parseFile(std::string_view filename)
 {
     using namespace ParseHelpers;
 
-    auto in = std::ifstream{ tr_pathbuf{ filename } };
+    auto in = std::ifstream{ tr_pathbuf{ filename }.c_str() };
     if (!in.is_open()) {
         tr_logAddWarn(
             fmt::format(

--- a/libtransmission/env.cc
+++ b/libtransmission/env.cc
@@ -49,7 +49,7 @@ std::string tr_env_get_string(std::string_view key, std::string_view default_val
 
     auto const szkey = tr_strbuf<char, 256>{ key };
 
-    if (auto const* const value = getenv(szkey); value != nullptr) {
+    if (auto const* const value = getenv(szkey.c_str()); value != nullptr) {
         return value;
     }
 

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -843,7 +843,7 @@ bool tr_sys_dir_create_temp(char* path_template, tr_error* error)
 
 tr_sys_dir_t tr_sys_dir_open(std::string_view path, tr_error* error)
 {
-    if (auto* const ret = opendir(tr_pathbuf{ path }); ret != nullptr) {
+    if (auto* const ret = opendir(tr_pathbuf{ path }.c_str()); ret != nullptr) {
         return (tr_sys_dir_t)ret;
     }
 

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -305,7 +305,7 @@ std::optional<tr_address> tr_address::from_string(std::string_view address_sv)
 
     auto ss = sockaddr_storage{};
     auto sslen = int{ sizeof(ss) };
-    if (evutil_parse_sockaddr_port(address_sz, reinterpret_cast<sockaddr*>(&ss), &sslen) != 0) {
+    if (evutil_parse_sockaddr_port(address_sz.c_str(), reinterpret_cast<sockaddr*>(&ss), &sslen) != 0) {
         return {};
     }
 
@@ -523,8 +523,10 @@ std::optional<tr_socket_address> tr_socket_address::from_string(std::string_view
 {
     auto ss = sockaddr_storage{};
     auto sslen = int{ sizeof(ss) };
-    if (evutil_parse_sockaddr_port(tr_strbuf<char, TrAddrStrlen>{ sockaddr_sv }, reinterpret_cast<sockaddr*>(&ss), &sslen) !=
-        0) {
+    if (evutil_parse_sockaddr_port(
+            tr_strbuf<char, TrAddrStrlen>{ sockaddr_sv }.c_str(),
+            reinterpret_cast<sockaddr*>(&ss),
+            &sslen) != 0) {
         return {};
     }
 

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -439,7 +439,7 @@ bool isHostnameAllowed(tr_rpc_server const* server, evhttp_request* const req)
 
     auto const& src = server->host_whitelist_;
     auto const hostname_sz = tr_urlbuf{ hostname };
-    return std::ranges::any_of(src, [&hostname_sz](auto const& str) { return tr_wildmat(hostname_sz, str.c_str()); });
+    return std::ranges::any_of(src, [&hostname_sz](auto const& str) { return tr_wildmat(hostname_sz.c_str(), str.c_str()); });
 }
 
 bool test_session_id(tr_rpc_server const* server, evhttp_request* const req)

--- a/libtransmission/subprocess-posix.cc
+++ b/libtransmission/subprocess-posix.cc
@@ -65,7 +65,7 @@ void set_system_error(tr_error* error, int code, std::string_view what)
         }
     }
 
-    if (!std::empty(work_dir) && chdir(tr_pathbuf{ work_dir }) == -1) {
+    if (!std::empty(work_dir) && chdir(tr_pathbuf{ work_dir }.c_str()) == -1) {
         return false;
     }
 

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -90,16 +90,6 @@ public:
         return buffer_.end();
     }
 
-    [[nodiscard]] constexpr Char& at(size_t pos) noexcept
-    {
-        return buffer_[pos];
-    }
-
-    [[nodiscard]] constexpr Char at(size_t pos) const noexcept
-    {
-        return buffer_[pos];
-    }
-
     [[nodiscard]] constexpr Char& operator[](size_t pos) noexcept
     {
         return buffer_[pos];

--- a/libtransmission/tr-strbuf.h
+++ b/libtransmission/tr-strbuf.h
@@ -254,12 +254,6 @@ public:
         return sv();
     }
 
-    // NOLINTNEXTLINE(google-explicit-constructor)
-    [[nodiscard]] constexpr operator auto() const noexcept
-    {
-        return c_str();
-    }
-
 private:
     /**
      * Ensure that the buffer's string is zero-terminated, e.g. for

--- a/libtransmission/watchdir-inotify.cc
+++ b/libtransmission/watchdir-inotify.cc
@@ -88,7 +88,7 @@ private:
             return;
         }
 
-        inwd_ = inotify_add_watch(infd_, tr_pathbuf{ dirname() }, InotifyWatchMask | IN_ONLYDIR);
+        inwd_ = inotify_add_watch(infd_, tr_pathbuf{ dirname() }.c_str(), InotifyWatchMask | IN_ONLYDIR);
         if (inwd_ == -1) {
             auto const error_code = errno;
             tr_logAddError(

--- a/libtransmission/watchdir-kqueue.cc
+++ b/libtransmission/watchdir-kqueue.cc
@@ -77,7 +77,7 @@ private:
 
         // open fd for watching
         auto const szdirname = tr_pathbuf{ dirname() };
-        dirfd_ = open(szdirname, O_RDONLY | O_EVTONLY);
+        dirfd_ = open(szdirname.c_str(), O_RDONLY | O_EVTONLY);
         if (dirfd_ == -1) {
             auto const error_code = errno;
             tr_logAddError(

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -568,7 +568,7 @@ TEST_F(DhtTest, usesBootstrapFile)
     // which tr-dht will try to ping as nodes
     static auto constexpr BootstrapNodeName = "91.121.74.28"sv;
     static auto constexpr BootstrapNodePort = tr_port::from_host(8080);
-    if (auto ofs = std::ofstream{ tr_pathbuf{ sandboxDir(), "/dht.bootstrap" } }; ofs) {
+    if (auto ofs = std::ofstream{ tr_pathbuf{ sandboxDir(), "/dht.bootstrap" }.c_str() }; ofs) {
         ofs << BootstrapNodeName << ' ' << BootstrapNodePort.host() << '\n';
         ofs.close();
     }

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -237,7 +237,7 @@ TEST_F(FileTest, getInfo)
     EXPECT_LE(info->last_modified_at, time(nullptr) + 1);
     tr_sys_path_remove(path1);
 
-    if (createSymlink(path1, path2, false)) {
+    if (createSymlink(path1.c_str(), path2.c_str(), false)) {
         // Can't get info of non-existent file/directory
         info = tr_sys_path_get_info(path1, 0, &err);
         EXPECT_FALSE(info.has_value());
@@ -270,7 +270,7 @@ TEST_F(FileTest, getInfo)
         // Good directory info
         t = time(nullptr);
         tr_sys_dir_create(path2, 0, 0777);
-        EXPECT_TRUE(createSymlink(path1, path2, true)); /* Win32: directory and file symlinks differ :( */
+        EXPECT_TRUE(createSymlink(path1.c_str(), path2.c_str(), true)); /* Win32: directory and file symlinks differ :( */
         info = tr_sys_path_get_info(path1, 0, &err);
         EXPECT_TRUE(info.has_value());
         assert(info.has_value());
@@ -344,7 +344,7 @@ TEST_F(FileTest, pathExists)
 
     tr_sys_path_remove(path1);
 
-    if (createSymlink(path1, path2, false)) {
+    if (createSymlink(path1.c_str(), path2.c_str(), false)) {
         // Non-existent file does not exist (via symlink)
         EXPECT_FALSE(tr_sys_path_exists(path1, &error));
         EXPECT_FALSE(error) << error;
@@ -359,7 +359,7 @@ TEST_F(FileTest, pathExists)
 
         /* Create directory and see that it exists (via symlink) */
         tr_sys_dir_create(path2, 0, 0777);
-        EXPECT_TRUE(createSymlink(path1, path2, true)); /* Win32: directory and file symlinks differ :( */
+        EXPECT_TRUE(createSymlink(path1.c_str(), path2.c_str(), true)); /* Win32: directory and file symlinks differ :( */
         EXPECT_TRUE(tr_sys_path_exists(path1, &error));
         EXPECT_FALSE(error) << error;
 
@@ -468,7 +468,7 @@ TEST_F(FileTest, pathIsSame)
     tr_sys_path_remove(path1);
     tr_sys_path_remove(path2);
 
-    if (createSymlink(path1, ".", true)) {
+    if (createSymlink(path1.c_str(), ".", true)) {
         /* Directory and symlink pointing to it are the same */
         EXPECT_TRUE(tr_sys_path_is_same(path1, test_dir.data(), &error));
         EXPECT_FALSE(error) << error;
@@ -482,7 +482,7 @@ TEST_F(FileTest, pathIsSame)
         EXPECT_FALSE(error) << error;
 
         /* Symlinks pointing to different directories are not the same */
-        createSymlink(path2, "..", true);
+        createSymlink(path2.c_str(), "..", true);
         EXPECT_FALSE(tr_sys_path_is_same(path1, path2, &error));
         EXPECT_FALSE(error) << error;
         EXPECT_FALSE(tr_sys_path_is_same(path2, path1, &error));
@@ -491,7 +491,7 @@ TEST_F(FileTest, pathIsSame)
         tr_sys_path_remove(path2);
 
         /* Symlinks pointing to same directory are the same */
-        createSymlink(path2, ".", true);
+        createSymlink(path2.c_str(), ".", true);
         EXPECT_TRUE(tr_sys_path_is_same(path1, path2, &error));
         EXPECT_FALSE(error) << error;
 
@@ -505,7 +505,7 @@ TEST_F(FileTest, pathIsSame)
         EXPECT_FALSE(error) << error;
 
         /* Symlinks pointing to same directory are the same */
-        createSymlink(path3, "..", true);
+        createSymlink(path3.c_str(), "..", true);
         EXPECT_TRUE(tr_sys_path_is_same(path1, path3, &error));
         EXPECT_FALSE(error) << error;
 
@@ -521,7 +521,7 @@ TEST_F(FileTest, pathIsSame)
         tr_sys_path_remove(path3);
 
         /* File and symlink pointing to same file are the same */
-        createSymlink(path3, path1, false);
+        createSymlink(path3.c_str(), path1.c_str(), false);
         EXPECT_TRUE(tr_sys_path_is_same(path1, path3, &error));
         EXPECT_FALSE(error) << error;
         EXPECT_TRUE(tr_sys_path_is_same(path3, path1, &error));
@@ -529,9 +529,9 @@ TEST_F(FileTest, pathIsSame)
 
         /* Symlinks pointing to non-existent files are not the same */
         tr_sys_path_remove(path1);
-        createSymlink(path1, "missing", false);
+        createSymlink(path1.c_str(), "missing", false);
         tr_sys_path_remove(path3);
-        createSymlink(path3, "missing", false);
+        createSymlink(path3.c_str(), "missing", false);
         EXPECT_FALSE(tr_sys_path_is_same(path1, path3, &error));
         EXPECT_FALSE(error) << error;
         EXPECT_FALSE(tr_sys_path_is_same(path3, path1, &error));
@@ -563,13 +563,13 @@ TEST_F(FileTest, pathIsSame)
 
     createFileWithContents(path1, "test");
 
-    if (createHardlink(path2, path1)) {
+    if (createHardlink(path2.c_str(), path1.c_str())) {
         /* File and hardlink to it are the same */
         EXPECT_TRUE(tr_sys_path_is_same(path1, path2, &error));
         EXPECT_FALSE(error) << error;
 
         /* Two hardlinks to the same file are the same */
-        createHardlink(path3, path2);
+        createHardlink(path3.c_str(), path2.c_str());
         EXPECT_TRUE(tr_sys_path_is_same(path2, path3, &error));
         EXPECT_FALSE(error) << error;
         EXPECT_TRUE(tr_sys_path_is_same(path1, path3, &error));
@@ -584,7 +584,7 @@ TEST_F(FileTest, pathIsSame)
 
         /* File and hardlink to another file are not the same */
         createFileWithContents(path3, "test");
-        createHardlink(path2, path3);
+        createHardlink(path2.c_str(), path3.c_str());
         EXPECT_FALSE(tr_sys_path_is_same(path1, path2, &error));
         EXPECT_FALSE(error) << error;
         EXPECT_FALSE(tr_sys_path_is_same(path2, path1, &error));
@@ -596,7 +596,7 @@ TEST_F(FileTest, pathIsSame)
         fmt::print(stderr, "WARNING: [{:s}] unable to run symlink tests\n", __FUNCTION__);
     }
 
-    if (createSymlink(path2, path1, false) && createHardlink(path3, path1)) {
+    if (createSymlink(path2.c_str(), path1.c_str(), false) && createHardlink(path3.c_str(), path1.c_str())) {
         EXPECT_TRUE(tr_sys_path_is_same(path2, path3, &error));
         EXPECT_FALSE(error) << error;
     } else {
@@ -620,7 +620,7 @@ TEST_F(FileTest, pathResolve)
 
     createFileWithContents(path1, "test");
 
-    if (createSymlink(path2, path1, false)) {
+    if (createSymlink(path2.c_str(), path1.c_str(), false)) {
         auto resolved = tr_sys_path_resolve(path2, &error);
         EXPECT_FALSE(error) << error;
         EXPECT_TRUE(pathContainsNoSymlinks(resolved.c_str()));
@@ -629,7 +629,7 @@ TEST_F(FileTest, pathResolve)
         tr_sys_path_remove(path1);
 
         tr_sys_dir_create(path1, 0, 0755);
-        EXPECT_TRUE(createSymlink(path2, path1, true)); /* Win32: directory and file symlinks differ :( */
+        EXPECT_TRUE(createSymlink(path2.c_str(), path1.c_str(), true)); /* Win32: directory and file symlinks differ :( */
         resolved = tr_sys_path_resolve(path2, &error);
         EXPECT_FALSE(error) << error;
         EXPECT_TRUE(pathContainsNoSymlinks(resolved.c_str()));
@@ -880,7 +880,7 @@ TEST_F(FileTest, pathRename)
 
     path3.assign(test_dir, "/c"sv);
 
-    if (createSymlink(path2, path1, false)) {
+    if (createSymlink(path2.c_str(), path1.c_str(), false)) {
         /* Preconditions */
         EXPECT_TRUE(tr_sys_path_exists(path2));
         EXPECT_FALSE(tr_sys_path_exists(path3));
@@ -898,7 +898,7 @@ TEST_F(FileTest, pathRename)
         fmt::print(stderr, "WARNING: [{:s}] unable to run symlink tests\n", __FUNCTION__);
     }
 
-    if (createHardlink(path2, path1)) {
+    if (createHardlink(path2.c_str(), path1.c_str())) {
         /* Preconditions */
         EXPECT_TRUE(tr_sys_path_exists(path2));
         EXPECT_FALSE(tr_sys_path_exists(path3));
@@ -999,11 +999,11 @@ TEST_F(FileTest, fileCopy)
     createFileWithContents(path1, Contents);
 
     // source file exists but is inaccessible
-    (void)chmod(path1, 0);
+    (void)chmod(path1.c_str(), 0);
     EXPECT_FALSE(tr_sys_path_copy(path1, test_dir, &error));
     EXPECT_TRUE(error);
     error = {};
-    (void)chmod(path1, 0600);
+    (void)chmod(path1.c_str(), 0600);
 
     // source file exists but target is invalid
     EXPECT_FALSE(tr_sys_path_copy(path1, test_dir, &error));
@@ -1053,7 +1053,7 @@ TEST_F(FileTest, fileOpen)
     EXPECT_FALSE(error) << error;
     tr_sys_file_close(fd);
     EXPECT_TRUE(tr_sys_path_exists(path1));
-    EXPECT_TRUE(validatePermissions(path1, 0640));
+    EXPECT_TRUE(validatePermissions(path1.c_str(), 0640));
 
     // can open existing file
     EXPECT_TRUE(tr_sys_path_exists(path1));
@@ -1218,7 +1218,7 @@ TEST_F(FileTest, dirCreate)
     EXPECT_TRUE(tr_sys_dir_create(path1, 0, 0700, &error));
     EXPECT_FALSE(error) << error;
     EXPECT_TRUE(tr_sys_path_exists(path1));
-    EXPECT_TRUE(validatePermissions(path1, 0700));
+    EXPECT_TRUE(validatePermissions(path1.c_str(), 0700));
 
     tr_sys_path_remove(path1);
     createFileWithContents(path1, "test");
@@ -1244,8 +1244,8 @@ TEST_F(FileTest, dirCreate)
     EXPECT_FALSE(error) << error;
     EXPECT_TRUE(tr_sys_path_exists(path1));
     EXPECT_TRUE(tr_sys_path_exists(path2));
-    EXPECT_TRUE(validatePermissions(path1, 0751));
-    EXPECT_TRUE(validatePermissions(path2, 0751));
+    EXPECT_TRUE(validatePermissions(path1.c_str(), 0751));
+    EXPECT_TRUE(validatePermissions(path2.c_str(), 0751));
 
     // Can create existing directory (no-op)
     EXPECT_TRUE(tr_sys_dir_create(path1, 0, 0700, &error));

--- a/tests/libtransmission/platform-test.cc
+++ b/tests/libtransmission/platform-test.cc
@@ -83,7 +83,7 @@ TEST_F(PlatformTest, defaultConfigDirXdgConfigHome)
     unsetenv("TRANSMISSION_HOME");
     unsetenv("XDG_CONFIG_HOME");
     auto const home = tr_pathbuf{ sandboxDir(), "/home/user" };
-    setenv("HOME", home, 1);
+    setenv("HOME", home.c_str(), 1);
 
     auto const expected = fmt::format("{:s}/.config/appname", home.sv());
     auto const actual = tr_getDefaultConfigDir("appname");

--- a/tests/libtransmission/strbuf-test.cc
+++ b/tests/libtransmission/strbuf-test.cc
@@ -102,14 +102,14 @@ TEST_F(StrbufTest, indexOperator)
     // mutable
     {
         auto buf = tr_pathbuf{ Value1 };
-        buf.at(0) = 'W';
+        buf[0] = 'W';
         EXPECT_EQ(Value2, buf.sv());
     }
 
     // const
     {
         auto const buf = tr_pathbuf{ Value1 };
-        EXPECT_EQ(Value1.front(), buf.at(0));
+        EXPECT_EQ(Value1.front(), buf[0]);
     }
 }
 


### PR DESCRIPTION
The underlying `fmt::basic_memory_buffer::operator[]` is not bounds-safe, we should reflect this semantics in our API.