### PR TITLE
feat: remember the details dialog geometry

### DIFF
--- a/libtransmission-app/prefs.h
+++ b/libtransmission-app/prefs.h
@@ -140,6 +140,8 @@ private:
     StringType session_remote_url_base_path_ = Traits::from_utf8("/transmission/");
     StringType session_remote_username_;
     std::vector<StringType> complete_sound_command_;
+    int details_window_height_ = 500;
+    int details_window_width_ = 700;
     int main_window_height_ = 500;
     int main_window_width_ = 600;
     int main_window_x_ = 50;

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -260,6 +260,8 @@ DetailsDialog::DetailsDialog(Session& session, Prefs& prefs, TorrentModel const&
     ui_.commentTextEdit->setMaximumHeight(QWIDGETSIZE_MAX);
     ui_.tabs->setCurrentIndex(prev_tab_index);
 
+    resize(prefs_.get<int>(TR_KEY_details_window_width), prefs_.get<int>(TR_KEY_details_window_height));
+
     static std::array<tr_quark, 2> constexpr InitKeys = {
         TR_KEY_show_tracker_scrapes,
         TR_KEY_show_backup_trackers,
@@ -290,6 +292,15 @@ DetailsDialog::DetailsDialog(Session& session, Prefs& prefs, TorrentModel const&
 DetailsDialog::~DetailsDialog()
 {
     prev_tab_index = ui_.tabs->currentIndex();
+}
+
+void DetailsDialog::resizeEvent(QResizeEvent* event)
+{
+    BaseDialog::resizeEvent(event);
+
+    auto const rect = geometry();
+    prefs_.set(TR_KEY_details_window_width, rect.width());
+    prefs_.set(TR_KEY_details_window_height, rect.height());
 }
 
 void DetailsDialog::setIds(torrent_ids_t const& ids)

--- a/qt/DetailsDialog.h
+++ b/qt/DetailsDialog.h
@@ -19,6 +19,7 @@
 #include "ui_DetailsDialog.h"
 #include "ui_TrackersDialog.h"
 
+class QResizeEvent;
 class QTreeWidgetItem;
 
 class Prefs;
@@ -48,6 +49,10 @@ public:
     {
         return QSize{ 440, 460 };
     }
+
+protected:
+    // QWidget
+    void resizeEvent(QResizeEvent* event) override;
 
 private:
     void initPeersTab();


### PR DESCRIPTION
When opening the details dialog, remember the geometry from the last time it was opened.

The GTK client has done this for ages. Now the Qt client does, too.

Notes: Improved `settings.json` compatibility between the GTK and Qt clients.