### PR TITLE
ci: use clang-tidy-diff.py

### DIFF
--- a/.github/actions/clang-tidy-diff/action.yml
+++ b/.github/actions/clang-tidy-diff/action.yml
@@ -1,0 +1,76 @@
+name: Run clang-tidy on changed lines
+description: >
+  Runs clang-tidy using LLVM's clang-tidy-diff.py so that only the lines
+  changed since the merge base are analyzed (or, when full-run is true, every
+  compilable file in the selected directories). Per-directory .clang-tidy files
+  are auto-discovered by clang-tidy itself, so no config path is passed.
+inputs:
+  build-path:
+    description: Directory containing compile_commands.json
+    default: obj
+  regex:
+    description: >
+      Anchored regex (clang-tidy-diff -regex) selecting which changed file
+      paths to check, e.g. '(qt|tests/qt)/.*'. Scopes a cell to its own source
+      directories so toolkit-independent files are not checked more than once.
+    required: true
+  clang-tidy-binary:
+    description: clang-tidy executable to use (e.g. clang-tidy-20 on Linux)
+    default: clang-tidy
+  full-run:
+    description: >
+      When 'true', check every compilable file in the selected directories by
+      diffing against the empty tree instead of only the changed lines.
+    default: 'false'
+  base-ref:
+    description: Git ref to diff against in changed-lines mode
+    default: origin/main
+runs:
+  using: composite
+  steps:
+    - name: clang-tidy (changed lines)
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # Fetch the clang-tidy-diff.py that ships with LLVM 20.1.8, matching
+        # the clang-tidy-20 we install. Pinned to an exact release tag for
+        # reproducibility.
+        script_url='https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-20.1.8/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py'
+        curl -fsSL "$script_url" -o clang-tidy-diff.py
+
+        py="$(command -v python3 || command -v python)"
+
+        if [ '${{ inputs.full-run }}' = 'true' ]; then
+          # The empty tree makes every line of every file look "added", so all
+          # compilable files in the selected directories get re-checked. Used
+          # when a .clang-tidy changed (or on push to main).
+          base="$(git hash-object -t tree /dev/null)"
+        else
+          base="$(git merge-base '${{ inputs.base-ref }}' HEAD)"
+        fi
+
+        # -regex scopes a cell to its own directories; -only-check-in-db skips
+        # any matched path that has no compile command (headers, files excluded
+        # by this toolkit), so we never invoke clang-tidy without a command.
+        set +e
+        git diff -U0 "$base" HEAD \
+          | "$py" clang-tidy-diff.py \
+              -p1 \
+              -path '${{ inputs.build-path }}' \
+              -clang-tidy-binary '${{ inputs.clang-tidy-binary }}' \
+              -regex '${{ inputs.regex }}' \
+              -only-check-in-db \
+              -allow-no-checks \
+              -j 0 \
+              2>&1 | tee clang-tidy.log
+        tidy_status=${PIPESTATUS[1]}
+        set -e
+
+        # clang-tidy-diff exits non-zero only when an invocation fails (e.g. a
+        # compile error); diagnostics themselves do not change the exit code, so
+        # we also fail when any 'warning:'/'error:' line was emitted.
+        if [ "$tidy_status" -ne 0 ] || grep -E -q '(warning|error):' clang-tidy.log; then
+          echo '::error::clang-tidy reported problems on changed lines'
+          exit 1
+        fi

--- a/.github/actions/clang-tidy-diff/action.yml
+++ b/.github/actions/clang-tidy-diff/action.yml
@@ -25,6 +25,12 @@ inputs:
   base-ref:
     description: Git ref to diff against in changed-lines mode
     default: origin/main
+  extra-arg:
+    description: >
+      Optional extra argument appended to every clang invocation (clang-tidy
+      -extra-arg), e.g. -Wno-unused-command-line-argument to silence the
+      driver diagnostics MSVC-style compile commands trigger under clang-cl.
+    default: ''
 runs:
   using: composite
   steps:
@@ -53,6 +59,12 @@ runs:
         # -regex scopes a cell to its own directories; -only-check-in-db skips
         # any matched path that has no compile command (headers, files excluded
         # by this toolkit), so we never invoke clang-tidy without a command.
+        extra=()
+        if [ -n '${{ inputs.extra-arg }}' ]; then
+          # Single token (-extra-arg=VALUE) so argparse never mistakes a
+          # leading-dash VALUE for another option.
+          extra+=('-extra-arg=${{ inputs.extra-arg }}')
+        fi
         set +e
         git diff -U0 "$base" HEAD \
           | "$py" clang-tidy-diff.py \
@@ -62,6 +74,7 @@ runs:
               -regex '${{ inputs.regex }}' \
               -only-check-in-db \
               -allow-no-checks \
+              "${extra[@]}" \
               -j 0 \
               2>&1 | tee clang-tidy.log
         tidy_status=${PIPESTATUS[1]}

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -80,8 +80,10 @@ runs:
             SUDO_CMD="sudo"
           fi
 
-          # Setup LLVM repo if clang-tidy is needed
-          if [[ "${{ inputs.enable-clang-tidy }}" == "true" ]]; then
+          # Setup LLVM repo if clang-tidy is needed.
+          # Ubuntu 26.04 already ships clang-tidy-20 in its own repositories,
+          # so apt.llvm.org is only needed on older releases.
+          if [[ "${{ inputs.enable-clang-tidy }}" == "true" && ! ( "$DISTRO" == "ubuntu" && "$DISTRO_VERSION" == "26.04" ) ]]; then
             wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | $SUDO_CMD apt-key add -
             if [[ "$DISTRO" == "ubuntu" && "$DISTRO_VERSION" == "24.04" ]]; then
               $SUDO_CMD add-apt-repository "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -460,13 +460,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        toolkit: [headless, qt6]
         include:
-          - name: core
+          - toolkit: headless
             deps: CoreDeps
             enable-qt: 'OFF'
             regex: '(libtransmission|libtransmission-app|tests/libtransmission)/.*'
             enabled: ${{ needs.what-to-make.outputs.tidy-core }}
-          - name: qt6
+          - toolkit: qt6
             deps: Deps
             enable-qt: 'ON'
             regex: '(qt|tests/qt)/.*'

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -31,9 +31,9 @@ jobs:
       make-utils: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.utils-changed == '1' || steps.check-diffs.outputs.tests-changed == '1' || steps.check-diffs.outputs.ci-actions-changed == '1' }}
       make-web: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.web-changed == '1' }}
       test-style: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.our-code-changed == '1' || steps.check-diffs.outputs.ci-actions-changed == '1' }}
-      tidy-core: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.core-changed == '1' || steps.check-diffs.outputs.tests-changed == '1' || steps.check-diffs.outputs.ci-actions-changed == '1' || steps.check-diffs.outputs.tidy-config-changed == '1' }}
-      tidy-gtk: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.gtk-changed == '1' || steps.check-diffs.outputs.ci-actions-changed == '1' || steps.check-diffs.outputs.tidy-config-changed == '1' }}
-      tidy-qt: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.qt-changed == '1' || steps.check-diffs.outputs.tests-changed == '1' || steps.check-diffs.outputs.ci-actions-changed == '1' || steps.check-diffs.outputs.tidy-config-changed == '1' }}
+      tidy-core: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.tidy-core-src-changed == '1' || steps.check-diffs.outputs.ci-actions-changed == '1' || steps.check-diffs.outputs.tidy-config-changed == '1' }}
+      tidy-gtk: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.tidy-gtk-src-changed == '1' || steps.check-diffs.outputs.ci-actions-changed == '1' || steps.check-diffs.outputs.tidy-config-changed == '1' }}
+      tidy-qt: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.tidy-qt-src-changed == '1' || steps.check-diffs.outputs.ci-actions-changed == '1' || steps.check-diffs.outputs.tidy-config-changed == '1' }}
       tidy-everything: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.tidy-config-changed == '1' }}
     steps:
       - name: Check Push to Main Branch
@@ -70,6 +70,12 @@ jobs:
           get_changes any-code   CMakeLists.txt cmake Transmission.xcodeproj libtransmission libtransmission-app cli daemon gtk macosx qt utils tests web third-party
           get_changes our-code   CMakeLists.txt cmake Transmission.xcodeproj libtransmission libtransmission-app cli daemon gtk macosx qt utils tests web
           get_changes tidy-config libtransmission/.clang-tidy libtransmission-app/.clang-tidy gtk/.clang-tidy qt/.clang-tidy tests/libtransmission/.clang-tidy tests/qt/.clang-tidy
+          # clang-tidy-diff only inspects changed lines, so each tidy cell keys
+          # off just the directories its -regex matches -- not the wider build
+          # deps (a libtransmission-only change has no gtk/qt lines to check).
+          get_changes tidy-core-src libtransmission libtransmission-app tests/libtransmission
+          get_changes tidy-gtk-src  gtk
+          get_changes tidy-qt-src   qt tests/qt
           get_changes daemon     CMakeLists.txt cmake Transmission.xcodeproj third-party libtransmission daemon
           get_changes dist       dist release
           get_changes docs       docs

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -530,6 +530,10 @@ jobs:
           build-path: obj
           regex: ${{ matrix.regex }}
           clang-tidy-binary: clang-tidy
+          # MSVC-style compile commands carry flags clang-cl ignores (e.g. /GL),
+          # whose per-TU 'unused argument' driver warning escapes the line
+          # filter; silence it so it is not mistaken for a finding.
+          extra-arg: -Wno-unused-command-line-argument
           full-run: ${{ needs.what-to-make.outputs.tidy-everything }}
 
   macos-xcodebuild-universal:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -340,22 +340,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        toolkit: [none, gtk3, gtk4, qt5, qt6]
         include:
-          - name: core
+          - toolkit: none
             runner: ubuntu-24.04
             enable-gtk: false
             enable-qt: false
             enable-tests: true
             regex: '(libtransmission|libtransmission-app|tests/libtransmission)/.*'
             enabled: ${{ needs.what-to-make.outputs.tidy-core }}
-          - name: gtk3
+          - toolkit: gtk3
             runner: ubuntu-24.04
             enable-gtk: gtk3
             enable-qt: false
             enable-tests: false
             regex: 'gtk/.*'
             enabled: ${{ needs.what-to-make.outputs.tidy-gtk }}
-          - name: gtk4
+          - toolkit: gtk4
             # Ubuntu 24.04 ships gtkmm-4.0 4.10, but the project requires
             # >= 4.11.1 (GTKMM4_MINIMUM); 26.04 is the first GA-track image new
             # enough. install-deps installs clang-tidy-20 from the distro there.
@@ -365,14 +366,14 @@ jobs:
             enable-tests: false
             regex: 'gtk/.*'
             enabled: ${{ needs.what-to-make.outputs.tidy-gtk }}
-          - name: qt5
+          - toolkit: qt5
             runner: ubuntu-24.04
             enable-gtk: false
             enable-qt: qt5
             enable-tests: true
             regex: '(qt|tests/qt)/.*'
             enabled: ${{ needs.what-to-make.outputs.tidy-qt }}
-          - name: qt6
+          - toolkit: qt6
             runner: ubuntu-24.04
             enable-gtk: false
             enable-qt: qt6

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -31,6 +31,10 @@ jobs:
       make-utils: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.utils-changed == '1' || steps.check-diffs.outputs.tests-changed == '1' || steps.check-diffs.outputs.ci-actions-changed == '1' }}
       make-web: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.web-changed == '1' }}
       test-style: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.our-code-changed == '1' || steps.check-diffs.outputs.ci-actions-changed == '1' }}
+      tidy-core: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.core-changed == '1' || steps.check-diffs.outputs.tests-changed == '1' || steps.check-diffs.outputs.ci-actions-changed == '1' || steps.check-diffs.outputs.tidy-config-changed == '1' }}
+      tidy-gtk: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.gtk-changed == '1' || steps.check-diffs.outputs.ci-actions-changed == '1' || steps.check-diffs.outputs.tidy-config-changed == '1' }}
+      tidy-qt: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.qt-changed == '1' || steps.check-diffs.outputs.tests-changed == '1' || steps.check-diffs.outputs.ci-actions-changed == '1' || steps.check-diffs.outputs.tidy-config-changed == '1' }}
+      tidy-everything: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.tidy-config-changed == '1' }}
     steps:
       - name: Check Push to Main Branch
         id: check-main-push
@@ -60,18 +64,19 @@ jobs:
             git diff --exit-code "$MERGE_BASE" -- "$@"
             echo "$name-changed=$?" >> "$GITHUB_OUTPUT"
           }
-          get_changes core       CMakeLists.txt cmake third-party libtransmission
+          get_changes core       CMakeLists.txt cmake third-party libtransmission libtransmission-app
           get_changes android    CMakeLists.txt cmake third-party libtransmission android
           get_changes cli        CMakeLists.txt cmake Transmission.xcodeproj third-party libtransmission cli
-          get_changes any-code   CMakeLists.txt cmake Transmission.xcodeproj libtransmission cli daemon gtk macosx qt utils tests web third-party
-          get_changes our-code   CMakeLists.txt cmake Transmission.xcodeproj libtransmission cli daemon gtk macosx qt utils tests web
+          get_changes any-code   CMakeLists.txt cmake Transmission.xcodeproj libtransmission libtransmission-app cli daemon gtk macosx qt utils tests web third-party
+          get_changes our-code   CMakeLists.txt cmake Transmission.xcodeproj libtransmission libtransmission-app cli daemon gtk macosx qt utils tests web
+          get_changes tidy-config libtransmission/.clang-tidy libtransmission-app/.clang-tidy gtk/.clang-tidy qt/.clang-tidy tests/libtransmission/.clang-tidy tests/qt/.clang-tidy
           get_changes daemon     CMakeLists.txt cmake Transmission.xcodeproj third-party libtransmission daemon
           get_changes dist       dist release
           get_changes docs       docs
-          get_changes gtk        CMakeLists.txt cmake third-party libtransmission gtk
+          get_changes gtk        CMakeLists.txt cmake third-party libtransmission libtransmission-app gtk
           get_changes mac        CMakeLists.txt cmake Transmission.xcodeproj third-party libtransmission macosx
-          get_changes qt         CMakeLists.txt cmake third-party libtransmission qt
-          get_changes tests      CMakeLists.txt cmake third-party libtransmission utils tests
+          get_changes qt         CMakeLists.txt cmake third-party libtransmission libtransmission-app qt
+          get_changes tests      CMakeLists.txt cmake third-party libtransmission libtransmission-app utils tests
           get_changes utils      CMakeLists.txt cmake third-party libtransmission utils
           get_changes web        CMakeLists.txt cmake web
           get_changes ci-actions .github/workflows/actions.yml .github/actions release
@@ -321,140 +326,65 @@ jobs:
           extra-asan-options: allocator_may_return_null=0
           timeout: 600
 
-  clang-tidy-libtransmission:
+  clang-tidy-linux:
     runs-on: ubuntu-24.04
     needs: what-to-make
     if: |
-      needs.what-to-make.outputs.make-core == 'true' ||
-      needs.what-to-make.outputs.make-gtk == 'true' ||
-      needs.what-to-make.outputs.make-qt == 'true' ||
-      needs.what-to-make.outputs.make-tests == 'true'
-    steps:
-      - name: Show Configuration
-        run: |
-          echo '${{ toJSON(needs) }}'
-          echo '${{ toJSON(runner) }}'
-          cat /etc/os-release
-      - name: Cache project files
-        id: cache-project-files
-        uses: actions/cache@v5
-        with:
-          key: clang-tidy-${{ github.sha }}
-          path: .
-      - name: Get Source
-        if: steps.cache-project-files.outputs.cache-hit != 'true'
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-      - name: Get Dependencies
-        uses: ./.github/actions/install-deps
-        with:
-          compiler: clang
-          enable-clang-tidy: true
-          use-sudo: true
-      - name: Configure
-        run: |
-          cmake \
-            -S . \
-            -B obj \
-            -G Ninja \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_CXX_COMPILER='clang++' \
-            -DCMAKE_C_COMPILER='clang' \
-            -DCMAKE_INSTALL_PREFIX=pfx \
-            -DRUN_CLANG_TIDY=ON \
-            -DUSE_SYSTEM_DEFAULT=ON \
-            -DUSE_SYSTEM_DHT=OFF `# Not packaged in Ubuntu` \
-            -DUSE_SYSTEM_SIGSLOT=OFF `# Not packaged in Ubuntu` \
-            -DUSE_SYSTEM_SMALL=OFF `# Not packaged in Ubuntu` \
-            -DUSE_SYSTEM_UTP=OFF `# Not packaged in Ubuntu` \
-            -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in Ubuntu`
-      - name: Make (Core)
-        run: |
-          set -euo pipefail
-          cmake --build obj --config Debug --target transmission 2>&1 | tee makelog
-      - name: Make (App)
-        run: |
-          set -euo pipefail
-          cmake --build obj --config Debug --target transmission-app 2>&1 | tee -a makelog
-      - name: Test for warnings
-        run: |
-          if grep 'warning:' makelog; then exit 1; fi
-
-  what-to-clang-tidy:
-    runs-on: ubuntu-latest
-    needs: [ what-to-make, clang-tidy-libtransmission ]
-    if: |
-      needs.what-to-make.outputs.make-gtk == 'true' ||
-      needs.what-to-make.outputs.make-qt == 'true' ||
-      needs.what-to-make.outputs.make-tests == 'true'
-    outputs:
-      matrix: ${{ steps.generate-matrix.outputs.matrix }}
-    steps:
-      - name: Generate clang-tidy matrix
-        id: generate-matrix
-        run: |
-          set -exuo pipefail
-
-          # Generate elements in the include array
-          jobs=()
-          if [ '${{ needs.what-to-make.outputs.make-gtk }}' = 'true' ]; then
-            jobs+=("$(
-              jq -nc '$ARGS.named' \
-                --arg target transmission-gtk \
-                --arg enable-gtk gtk3 \
-                --argjson enable-qt false \
-                --argjson enable-tests false
-            )")
-          fi
-          if [ '${{ needs.what-to-make.outputs.make-qt }}' = 'true' ]; then
-            jobs+=("$(
-              jq -nc '$ARGS.named' \
-                --arg target transmission-qt \
-                --argjson enable-gtk false \
-                --arg enable-qt qt6 \
-                --argjson enable-tests false
-            )"
-            "$(
-              jq -nc '$ARGS.named' \
-                --arg target transmission-qt \
-                --argjson enable-gtk false \
-                --arg enable-qt qt5 \
-                --argjson enable-tests false
-            )")
-          fi
-          if [ '${{ needs.what-to-make.outputs.make-tests }}' = 'true' ]; then
-            jobs+=("$(
-              jq -nc '$ARGS.named' \
-                --arg target libtransmission-test \
-                --argjson enable-gtk false \
-                --argjson enable-qt '${{ needs.what-to-make.outputs.make-qt == 'true' && '"qt6"' || 'false' }}' \
-                --argjson enable-tests true
-            )")
-          fi
-
-          # Combine the include array elements into a JSON string and output
-          echo "matrix=$(printf "%s\n" "${jobs[@]}" | jq -sc '{include: .}')" >> "$GITHUB_OUTPUT"
-
-  clang-tidy:
-    runs-on: ubuntu-24.04
-    needs: what-to-clang-tidy
+      needs.what-to-make.outputs.tidy-core == 'true' ||
+      needs.what-to-make.outputs.tidy-gtk == 'true' ||
+      needs.what-to-make.outputs.tidy-qt == 'true'
+    # One cell per toolkit version. clang-tidy-diff.py checks only the lines
+    # changed since the merge base, so each cell needs to generate code (Qt moc/
+    # uic) but never compiles the whole target. The matrix.enabled flag (wired to
+    # the what-to-make tidy-* outputs) skips cells whose area did not change.
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.what-to-clang-tidy.outputs.matrix) }}
+      matrix:
+        include:
+          - name: core
+            enable-gtk: false
+            enable-qt: false
+            enable-tests: true
+            regex: '(libtransmission|libtransmission-app|tests/libtransmission)/.*'
+            enabled: ${{ needs.what-to-make.outputs.tidy-core }}
+          - name: gtk3
+            enable-gtk: gtk3
+            enable-qt: false
+            enable-tests: false
+            regex: 'gtk/.*'
+            enabled: ${{ needs.what-to-make.outputs.tidy-gtk }}
+          - name: gtk4
+            enable-gtk: gtk4
+            enable-qt: false
+            enable-tests: false
+            regex: 'gtk/.*'
+            enabled: ${{ needs.what-to-make.outputs.tidy-gtk }}
+          - name: qt5
+            enable-gtk: false
+            enable-qt: qt5
+            enable-tests: true
+            regex: '(qt|tests/qt)/.*'
+            enabled: ${{ needs.what-to-make.outputs.tidy-qt }}
+          - name: qt6
+            enable-gtk: false
+            enable-qt: qt6
+            enable-tests: true
+            regex: '(qt|tests/qt)/.*'
+            enabled: ${{ needs.what-to-make.outputs.tidy-qt }}
     steps:
       - name: Show Configuration
         run: |
-          echo '${{ toJSON(needs) }}'
+          echo '${{ toJSON(matrix) }}'
           echo '${{ toJSON(runner) }}'
           cat /etc/os-release
-      - name: Get cached project files
-        uses: actions/cache/restore@v5
+      - name: Get Source
+        if: matrix.enabled == 'true'
+        uses: actions/checkout@v6
         with:
-          key: clang-tidy-${{ github.sha }}
-          path: .
-          fail-on-cache-miss: true
+          fetch-depth: 0
+          submodules: recursive
       - name: Get Dependencies
+        if: matrix.enabled == 'true'
         uses: ./.github/actions/install-deps
         with:
           compiler: clang
@@ -463,6 +393,7 @@ jobs:
           enable-gtk: ${{ matrix.enable-gtk }}
           enable-qt: ${{ matrix.enable-qt }}
       - name: Configure
+        if: matrix.enabled == 'true'
         run: |
           cmake \
             -S . \
@@ -471,75 +402,120 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_CXX_COMPILER='clang++' \
             -DCMAKE_C_COMPILER='clang' \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DCMAKE_INSTALL_PREFIX=pfx \
             -DENABLE_GTK=${{ matrix.enable-gtk && 'ON' || 'OFF' }} \
             -DENABLE_QT=${{ matrix.enable-qt && 'ON' || 'OFF' }} \
             -DENABLE_TESTS=${{ matrix.enable-tests && 'ON' || 'OFF' }} \
-            -DRUN_CLANG_TIDY=ON \
+            -DRUN_CLANG_TIDY=OFF \
             -DUSE_SYSTEM_DEFAULT=ON \
             -DUSE_SYSTEM_DHT=OFF `# Not packaged in Ubuntu` \
+            -DUSE_SYSTEM_SIGSLOT=OFF `# Not packaged in Ubuntu` \
             -DUSE_SYSTEM_SMALL=OFF `# Not packaged in Ubuntu` \
             -DUSE_SYSTEM_UTP=OFF `# Not packaged in Ubuntu` \
             -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in Ubuntu`
-      - name: Make
+      - name: Generate sources
+        if: matrix.enabled == 'true'
         run: |
-          set -euo pipefail
-          cmake --build obj --config Debug --target ${{ matrix.target }} 2>&1 | tee makelog
-      - name: Test for warnings
-        run: |
-          if grep 'warning:' makelog; then exit 1; fi
+          # Materialize generated moc/uic headers so clang-tidy can compile the
+          # changed Qt translation units. Non-Qt cells have no autogen targets,
+          # so this is a no-op for them.
+          mapfile -t targets < <(ninja -C obj -t targets all 2>/dev/null | sed -n 's/^\([^:]*_autogen\):.*/\1/p' | sort -u)
+          if [ "${#targets[@]}" -gt 0 ]; then
+            cmake --build obj --target "${targets[@]}"
+          fi
+      - name: Run clang-tidy
+        if: matrix.enabled == 'true'
+        uses: ./.github/actions/clang-tidy-diff
+        with:
+          build-path: obj
+          regex: ${{ matrix.regex }}
+          clang-tidy-binary: clang-tidy-20
+          full-run: ${{ needs.what-to-make.outputs.tidy-everything }}
 
-  clang-tidy-libtransmission-win32:
+  clang-tidy-windows:
     runs-on: windows-2025
     needs: what-to-make
     if: |
-      needs.what-to-make.outputs.make-core == 'true' ||
-      needs.what-to-make.outputs.make-tests == 'true'
+      needs.what-to-make.outputs.tidy-core == 'true' ||
+      needs.what-to-make.outputs.tidy-qt == 'true'
+    # MSVC + Qt6 coverage. qt5 on Windows is intentionally omitted for now: it
+    # would require building Qt5 from source on the runners (see
+    # prepare-deps-win32 / release/windows). Linux covers qt5.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: core
+            deps: CoreDeps
+            enable-qt: 'OFF'
+            enable-tests: 'ON'
+            regex: '(libtransmission|libtransmission-app|tests/libtransmission)/.*'
+            enabled: ${{ needs.what-to-make.outputs.tidy-core }}
+          - name: qt6
+            deps: Deps
+            enable-qt: 'ON'
+            enable-tests: 'ON'
+            regex: '(qt|tests/qt)/.*'
+            enabled: ${{ needs.what-to-make.outputs.tidy-qt }}
     steps:
       - name: Show Configuration
         run: |
-          echo '${{ toJSON(needs) }}'
+          echo '${{ toJSON(matrix) }}'
           echo '${{ toJSON(runner) }}'
       - name: Get Source
+        if: matrix.enabled == 'true'
         uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           submodules: recursive
-          path: src
       - name: Prepare Build Deps
-        uses: ./src/.github/actions/prepare-deps-win32
+        if: matrix.enabled == 'true'
+        uses: ./.github/actions/prepare-deps-win32
         with:
           arch: x64
-          type: CoreDeps
+          type: ${{ matrix.deps }}
       - name: Setup Visual Studio Environment
-        uses: ./src/.github/actions/setup-vs-env-win32
+        if: matrix.enabled == 'true'
+        uses: ./.github/actions/setup-vs-env-win32
         with:
           arch: x64
       - name: Configure
+        if: matrix.enabled == 'true'
         run: |
           $CmakeArgs = @(
-            '-S src'
+            '-S .'
             '-B obj'
             '-G Ninja'
             '-DCMAKE_BUILD_TYPE=Debug'
+            '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON'
             "-DCMAKE_PREFIX_PATH=`"$Env:DEPS_PREFIX`""
-            "-DENABLE_TESTS=${{ needs.what-to-make.outputs.make-tests == 'true' && 'ON' || 'OFF' }}"
-            '-DRUN_CLANG_TIDY=ON'
+            '-DENABLE_QT=${{ matrix.enable-qt }}'
+            '-DENABLE_TESTS=${{ matrix.enable-tests }}'
+            '-DRUN_CLANG_TIDY=OFF'
             '-DUSE_SYSTEM_DEFAULT=OFF'
           )
           cmd /c "`"$Env:VCVARSALL`" $Env:VC_ARCH >nul && cmake $($CmakeArgs -join ' ')"
-      - name: Make (Core)
+      - name: Generate sources
+        if: matrix.enabled == 'true'
         run: |
-          cmd /c "`"$Env:VCVARSALL`" $Env:VC_ARCH >nul && cmake --build obj --config Debug --target transmission" 2>&1 | tee makelog
-      - name: Make (App)
-        run: |
-          cmd /c "`"$Env:VCVARSALL`" $Env:VC_ARCH >nul && cmake --build obj --config Debug --target transmission-app" 2>&1 | tee -a makelog
-      - name: Make (Tests)
-        if: needs.what-to-make.outputs.make-tests == 'true'
-        run: |
-          cmd /c "`"$Env:VCVARSALL`" $Env:VC_ARCH >nul && cmake --build obj --config Debug --target libtransmission-test" 2>&1 | tee -a makelog
-      - name: Test for warnings
-        run: |
-          if (Select-String -Path makelog -Pattern 'warning:') { exit 1 }
+          # Materialize generated moc/uic headers so clang-tidy can compile the
+          # changed Qt translation units. Non-Qt cells have no autogen targets.
+          $list = cmd /c "`"$Env:VCVARSALL`" $Env:VC_ARCH >nul && ninja -C obj -t targets all"
+          $targets = $list |
+            ForEach-Object { if ($_ -match '^([^:]+_autogen):') { $Matches[1] } } |
+            Sort-Object -Unique
+          if ($targets) {
+            cmd /c "`"$Env:VCVARSALL`" $Env:VC_ARCH >nul && cmake --build obj --target $($targets -join ' ')"
+          }
+      - name: Run clang-tidy
+        if: matrix.enabled == 'true'
+        uses: ./.github/actions/clang-tidy-diff
+        with:
+          build-path: obj
+          regex: ${{ matrix.regex }}
+          clang-tidy-binary: clang-tidy
+          full-run: ${{ needs.what-to-make.outputs.tidy-everything }}
 
   macos-xcodebuild-universal:
     runs-on: macos-26

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -327,7 +327,7 @@ jobs:
           timeout: 600
 
   clang-tidy-linux:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
     needs: what-to-make
     if: |
       needs.what-to-make.outputs.tidy-core == 'true' ||
@@ -342,30 +342,38 @@ jobs:
       matrix:
         include:
           - name: core
+            runner: ubuntu-24.04
             enable-gtk: false
             enable-qt: false
             enable-tests: true
             regex: '(libtransmission|libtransmission-app|tests/libtransmission)/.*'
             enabled: ${{ needs.what-to-make.outputs.tidy-core }}
           - name: gtk3
+            runner: ubuntu-24.04
             enable-gtk: gtk3
             enable-qt: false
             enable-tests: false
             regex: 'gtk/.*'
             enabled: ${{ needs.what-to-make.outputs.tidy-gtk }}
           - name: gtk4
+            # Ubuntu 24.04 ships gtkmm-4.0 4.10, but the project requires
+            # >= 4.11.1 (GTKMM4_MINIMUM); 26.04 is the first GA-track image new
+            # enough. install-deps installs clang-tidy-20 from the distro there.
+            runner: ubuntu-26.04
             enable-gtk: gtk4
             enable-qt: false
             enable-tests: false
             regex: 'gtk/.*'
             enabled: ${{ needs.what-to-make.outputs.tidy-gtk }}
           - name: qt5
+            runner: ubuntu-24.04
             enable-gtk: false
             enable-qt: qt5
             enable-tests: true
             regex: '(qt|tests/qt)/.*'
             enabled: ${{ needs.what-to-make.outputs.tidy-qt }}
           - name: qt6
+            runner: ubuntu-24.04
             enable-gtk: false
             enable-qt: qt6
             enable-tests: true

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -346,46 +346,43 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolkit: [headless, gtk3, gtk4, qt5, qt6]
+        toolkit: [core, gtk3, gtk4, qt5, qt6]
         include:
-          - toolkit: headless
-            runner: ubuntu-24.04
+          - toolkit: core
             enable-gtk: false
             enable-qt: false
             enable-tests: true
-            regex: '(libtransmission|libtransmission-app|tests/libtransmission)/.*'
             enabled: ${{ needs.what-to-make.outputs.tidy-core }}
-          - toolkit: gtk3
+            regex: '(libtransmission|libtransmission-app|tests/libtransmission)/.*'
             runner: ubuntu-24.04
+          - toolkit: gtk3
             enable-gtk: gtk3
             enable-qt: false
             enable-tests: false
-            regex: 'gtk/.*'
             enabled: ${{ needs.what-to-make.outputs.tidy-gtk }}
+            regex: 'gtk/.*'
+            runner: ubuntu-24.04
           - toolkit: gtk4
-            # Ubuntu 24.04 ships gtkmm-4.0 4.10, but the project requires
-            # >= 4.11.1 (GTKMM4_MINIMUM); 26.04 is the first GA-track image new
-            # enough. install-deps installs clang-tidy-20 from the distro there.
-            runner: ubuntu-26.04
             enable-gtk: gtk4
             enable-qt: false
             enable-tests: false
-            regex: 'gtk/.*'
             enabled: ${{ needs.what-to-make.outputs.tidy-gtk }}
+            regex: 'gtk/.*'
+            runner: ubuntu-26.04 # 24.04 doesn't have GTKMM4_MINIMUM
           - toolkit: qt5
-            runner: ubuntu-24.04
             enable-gtk: false
             enable-qt: qt5
             enable-tests: true
-            regex: '(qt|tests/qt)/.*'
             enabled: ${{ needs.what-to-make.outputs.tidy-qt }}
-          - toolkit: qt6
+            regex: '(qt|tests/qt)/.*'
             runner: ubuntu-24.04
+          - toolkit: qt6
             enable-gtk: false
             enable-qt: qt6
             enable-tests: true
-            regex: '(qt|tests/qt)/.*'
             enabled: ${{ needs.what-to-make.outputs.tidy-qt }}
+            regex: '(qt|tests/qt)/.*'
+            runner: ubuntu-24.04
     steps:
       - name: Show Configuration
         run: |
@@ -460,18 +457,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolkit: [headless, qt6]
+        toolkit: [core, qt6]
         include:
-          - toolkit: headless
+          - toolkit: core
             deps: CoreDeps
             enable-qt: 'OFF'
-            regex: '(libtransmission|libtransmission-app|tests/libtransmission)/.*'
             enabled: ${{ needs.what-to-make.outputs.tidy-core }}
+            regex: '(libtransmission|libtransmission-app|tests/libtransmission)/.*'
           - toolkit: qt6
             deps: Deps
             enable-qt: 'ON'
-            regex: '(qt|tests/qt)/.*'
             enabled: ${{ needs.what-to-make.outputs.tidy-qt }}
+            regex: '(qt|tests/qt)/.*'
     steps:
       - name: Show Configuration
         run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -464,13 +464,11 @@ jobs:
           - name: core
             deps: CoreDeps
             enable-qt: 'OFF'
-            enable-tests: 'ON'
             regex: '(libtransmission|libtransmission-app|tests/libtransmission)/.*'
             enabled: ${{ needs.what-to-make.outputs.tidy-core }}
           - name: qt6
             deps: Deps
             enable-qt: 'ON'
-            enable-tests: 'ON'
             regex: '(qt|tests/qt)/.*'
             enabled: ${{ needs.what-to-make.outputs.tidy-qt }}
     steps:
@@ -506,7 +504,7 @@ jobs:
             '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON'
             "-DCMAKE_PREFIX_PATH=`"$Env:DEPS_PREFIX`""
             '-DENABLE_QT=${{ matrix.enable-qt }}'
-            '-DENABLE_TESTS=${{ matrix.enable-tests }}'
+            '-DENABLE_TESTS=ON'
             '-DRUN_CLANG_TIDY=OFF'
             '-DUSE_SYSTEM_DEFAULT=OFF'
           )

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -340,9 +340,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolkit: [none, gtk3, gtk4, qt5, qt6]
+        toolkit: [headless, gtk3, gtk4, qt5, qt6]
         include:
-          - toolkit: none
+          - toolkit: headless
             runner: ubuntu-24.04
             enable-gtk: false
             enable-qt: false

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -367,10 +367,6 @@ private:
     }
 
 public:
-    tr_net_init_mgr(tr_net_init_mgr const&) = delete;
-    tr_net_init_mgr(tr_net_init_mgr&&) = delete;
-    tr_net_init_mgr& operator=(tr_net_init_mgr const&) = delete;
-    tr_net_init_mgr& operator=(tr_net_init_mgr&&) = delete;
     ~tr_net_init_mgr()
     {
         curl_global_cleanup();

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -390,8 +390,6 @@ std::unique_ptr<tr_net_init_mgr> tr_net_init_mgr::instance;
 
 void tr_lib_init()
 {
-    // DO NOT MERGE
-    fmt::print("hello, world!\n");
     static auto once = std::once_flag{};
     std::call_once(once, [] { tr_net_init_impl::tr_net_init_mgr::create(); });
 }

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -390,6 +390,8 @@ std::unique_ptr<tr_net_init_mgr> tr_net_init_mgr::instance;
 
 void tr_lib_init()
 {
+    // DO NOT MERGE
+    fmt::print("hello, world!\n");
     static auto once = std::once_flag{};
     std::call_once(once, [] { tr_net_init_impl::tr_net_init_mgr::create(); });
 }

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -367,6 +367,11 @@ private:
     }
 
 public:
+    tr_net_init_mgr& operator=(tr_net_init_mgr&&) = delete;
+    tr_net_init_mgr& operator=(tr_net_init_mgr const&) = delete;
+    tr_net_init_mgr(tr_net_init_mgr&&) = delete;
+    tr_net_init_mgr(tr_net_init_mgr const&) = delete;
+
     ~tr_net_init_mgr()
     {
         curl_global_cleanup();


### PR DESCRIPTION
- Use [clang-tidy-diffs.py](https://clang.llvm.org/extra/clang-tidy/#id6) in GitHub Actions workflows for faster CI.
- Run CI on both GTK3 and GTK4
- Update `decide-what-jobs-to-run` to accommodate the new library `libtransmission-app`

---

Some of this is not going to get proper testing inside this branch, because we need to both test (a) when clang-tidy config changes (b) when the workflows change and (c) when the source code changes, and they are mutually exclusive. The CI in this PR tests, of course, (b).