### PR TITLE
feat: remember maximized window between sessions in qt client

### DIFF
--- a/libtransmission-app/prefs.h
+++ b/libtransmission-app/prefs.h
@@ -167,6 +167,7 @@ private:
     bool dir_watch_enabled_ = false;
     bool filterbar_ = true;
     bool inhibit_hibernation_ = false;
+    bool main_window_is_maximized_ = false;
     bool options_prompt_ = true;
     bool read_clipboard_ = false;
     bool session_is_remote_ = false;
@@ -281,6 +282,7 @@ public:
         Field<&Prefs::inhibit_hibernation_>{ TR_KEY_inhibit_desktop_hibernation },
         Field<&Prefs::lpd_enabled_>{ TR_KEY_lpd_enabled },
         Field<&Prefs::main_window_height_>{ TR_KEY_main_window_height },
+        Field<&Prefs::main_window_is_maximized_>{ TR_KEY_main_window_is_maximized },
         Field<&Prefs::main_window_layout_order_>{ TR_KEY_main_window_layout_order },
         Field<&Prefs::main_window_width_>{ TR_KEY_main_window_width },
         Field<&Prefs::main_window_x_>{ TR_KEY_main_window_x },

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -348,11 +348,18 @@ void Application::notifyTorrentAdded(Torrent const* tor) const
 void Application::saveGeometry() const
 {
     if (window_ != nullptr) {
-        auto const geometry = window_->geometry();
-        prefs_.set(TR_KEY_main_window_height, std::max(100, geometry.height()));
-        prefs_.set(TR_KEY_main_window_width, std::max(100, geometry.width()));
-        prefs_.set(TR_KEY_main_window_x, geometry.x());
-        prefs_.set(TR_KEY_main_window_y, geometry.y());
+        bool const is_maximized = window_->isMaximized();
+        prefs_.set(TR_KEY_main_window_is_maximized, is_maximized);
+
+        // When maximized, keep the previously-saved "normal" geometry so the
+        // window can be restored to it after un-maximizing.
+        if (!is_maximized) {
+            auto const geometry = window_->geometry();
+            prefs_.set(TR_KEY_main_window_height, std::max(100, geometry.height()));
+            prefs_.set(TR_KEY_main_window_width, std::max(100, geometry.width()));
+            prefs_.set(TR_KEY_main_window_x, geometry.x());
+            prefs_.set(TR_KEY_main_window_y, geometry.y());
+        }
     }
 }
 

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -219,7 +219,7 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
     connect(&filter_model_, &TorrentFilter::rowsRemoved, this, refresh_header_soon);
     connect(ui_.listView, &TorrentView::headerDoubleClicked, filter_bar, &FilterBar::clear);
 
-    static std::array<tr_quark, 17> constexpr InitKeys = {
+    static auto constexpr InitKeys = std::to_array<tr_quark>({
         TR_KEY_alt_speed_enabled, //
         TR_KEY_compact_view, //
         TR_KEY_speed_limit_down, //
@@ -237,7 +237,8 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
         TR_KEY_show_toolbar, //
         TR_KEY_speed_limit_up, //
         TR_KEY_speed_limit_up_enabled, //
-    };
+        TR_KEY_main_window_is_maximized, //
+    });
     for (auto const key : InitKeys) {
         refreshPref(key);
     }
@@ -1128,6 +1129,15 @@ void MainWindow::refreshPref(tr_quark const key)
             prefs_.get<int>(TR_KEY_main_window_y),
             prefs_.get<int>(TR_KEY_main_window_width),
             prefs_.get<int>(TR_KEY_main_window_height));
+        break;
+
+    case TR_KEY_main_window_is_maximized:
+        if (prefs_.get<bool>(key)) {
+            // Set the state rather than calling showMaximized() so a window
+            // that is hidden (e.g. started minimized to tray) stays hidden
+            // until it is explicitly shown.
+            setWindowState(windowState() | Qt::WindowMaximized);
+        }
         break;
 
     case TR_KEY_alt_speed_enabled:

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -222,22 +222,22 @@ MainWindow::MainWindow(Session& session, Prefs& prefs, TorrentModel& model, bool
     static auto constexpr InitKeys = std::to_array<tr_quark>({
         TR_KEY_alt_speed_enabled, //
         TR_KEY_compact_view, //
-        TR_KEY_speed_limit_down, //
-        TR_KEY_speed_limit_down_enabled, //
-        TR_KEY_show_filterbar, //
+        TR_KEY_main_window_is_maximized, //
         TR_KEY_main_window_x, //
+        TR_KEY_read_clipboard, //
         TR_KEY_seed_ratio_limit, //
         TR_KEY_seed_ratio_limited, //
-        TR_KEY_read_clipboard, //
+        TR_KEY_show_filterbar, //
         TR_KEY_show_notification_area_icon, //
+        TR_KEY_show_statusbar, //
+        TR_KEY_show_toolbar, //
         TR_KEY_sort_mode, //
         TR_KEY_sort_reversed, //
-        TR_KEY_show_statusbar, //
-        TR_KEY_statusbar_stats, //
-        TR_KEY_show_toolbar, //
+        TR_KEY_speed_limit_down, //
+        TR_KEY_speed_limit_down_enabled, //
         TR_KEY_speed_limit_up, //
         TR_KEY_speed_limit_up_enabled, //
-        TR_KEY_main_window_is_maximized, //
+        TR_KEY_statusbar_stats, //
     });
     for (auto const key : InitKeys) {
         refreshPref(key);


### PR DESCRIPTION
Remember between sessions whether the main window was maximized..

The GTK client has done this for ages. Now the Qt client does, too.

Notes: Improved `settings.json` compatibility between the GTK and Qt clients.

See also: #34