### PR TITLE
ci: fix clang-tidy ci failures

### DIFF
--- a/.github/actions/clang-tidy-diff/action.yml
+++ b/.github/actions/clang-tidy-diff/action.yml
@@ -74,6 +74,7 @@ runs:
               -regex '${{ inputs.regex }}' \
               -only-check-in-db \
               -allow-no-checks \
+              -quiet \
               "${extra[@]}" \
               -j 0 \
               2>&1 | tee clang-tidy.log

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -343,6 +343,7 @@ jobs:
     # changed since the merge base, so each cell needs to generate code (Qt moc/
     # uic) but never compiles the whole target. The matrix.enabled flag (wired to
     # the what-to-make tidy-* outputs) skips cells whose area did not change.
+    # TODO: try removing '-DFMT_USE_CONSTEVAL=0' either when upgrading clang or fmt
     strategy:
       fail-fast: false
       matrix:
@@ -444,6 +445,7 @@ jobs:
           regex: ${{ matrix.regex }}
           clang-tidy-binary: clang-tidy-20
           full-run: ${{ needs.what-to-make.outputs.tidy-everything }}
+          extra-arg: '-DFMT_USE_CONSTEVAL=0'
 
   clang-tidy-windows:
     runs-on: windows-2025

--- a/tests/qt/prefs-test.cc
+++ b/tests/qt/prefs-test.cc
@@ -25,11 +25,6 @@
 #include "TrQtInit.h"
 #include "qt-test-fixtures.h"
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 3, 0)
-#define QCOMPARE_EQ(actual, expected) QCOMPARE(actual, expected)
-#define QCOMPARE_NE(actual, expected) QVERIFY((actual) != (expected))
-#endif
-
 using namespace std::literals;
 
 Q_DECLARE_METATYPE(tr_quark)
@@ -66,22 +61,22 @@ class PrefsTest
     template<typename T>
     void verify_get_set_by_property(Prefs& prefs, tr_quark const key, T const& val1, T const& val2)
     {
-        QCOMPARE_NE(val1, val2);
+        TRCOMPARE_NE(val1, val2);
 
         prefs.set(key, val1);
-        QCOMPARE_EQ(prefs.get<T>(key), val1);
-        QCOMPARE_NE(prefs.get<T>(key), val2);
+        TRCOMPARE_EQ(prefs.get<T>(key), val1);
+        TRCOMPARE_NE(prefs.get<T>(key), val2);
 
         prefs.set(key, val2);
-        QCOMPARE_NE(prefs.get<T>(key), val1);
-        QCOMPARE_EQ(prefs.get<T>(key), val2);
+        TRCOMPARE_NE(prefs.get<T>(key), val1);
+        TRCOMPARE_EQ(prefs.get<T>(key), val2);
     }
 
     template<typename T>
     void verify_get_by_json(Prefs& prefs, tr_quark const key, T const& val, std::string_view const valstr)
     {
         prefs.set(key, val);
-        QCOMPARE_EQ(prefs.get<T>(key), val);
+        TRCOMPARE_EQ(prefs.get<T>(key), val);
         verify_json_contains(prefs.current_settings(), prefs.keyval(key).first, valstr);
     }
 
@@ -99,7 +94,7 @@ class PrefsTest
         QVERIFY(map);
         if (map) {
             auto const prefs = Prefs{ *map };
-            QCOMPARE_EQ(prefs.get<T>(key), val);
+            TRCOMPARE_EQ(prefs.get<T>(key), val);
         }
     }
 
@@ -108,7 +103,7 @@ class PrefsTest
         auto serde = tr_variant_serde::json();
         serde.compact();
         auto const str = serde.to_string(var);
-        QCOMPARE_EQ(str, std::string{ expected });
+        TRCOMPARE_EQ(str, std::string{ expected });
     }
 
 private slots:
@@ -116,12 +111,12 @@ private slots:
     {
         auto prefs = Prefs{};
 
-        QCOMPARE_EQ(prefs.get<ShowMode>(TR_KEY_filter_mode), DefaultShowMode);
-        QCOMPARE_EQ(prefs.get<SortMode>(TR_KEY_sort_mode), DefaultSortMode);
-        QCOMPARE_EQ(prefs.get<StatsMode>(TR_KEY_statusbar_stats), DefaultStatsMode);
-        QCOMPARE_EQ(prefs.get<std::chrono::sys_seconds>(TR_KEY_blocklist_date), std::chrono::sys_seconds{});
-        QCOMPARE_EQ(prefs.get<bool>(TR_KEY_torrent_complete_sound_enabled), true);
-        QCOMPARE_EQ(prefs.get<bool>(TR_KEY_show_statusbar), true);
+        TRCOMPARE_EQ(prefs.get<ShowMode>(TR_KEY_filter_mode), DefaultShowMode);
+        TRCOMPARE_EQ(prefs.get<SortMode>(TR_KEY_sort_mode), DefaultSortMode);
+        TRCOMPARE_EQ(prefs.get<StatsMode>(TR_KEY_statusbar_stats), DefaultStatsMode);
+        TRCOMPARE_EQ(prefs.get<std::chrono::sys_seconds>(TR_KEY_blocklist_date), std::chrono::sys_seconds{});
+        TRCOMPARE_EQ(prefs.get<bool>(TR_KEY_torrent_complete_sound_enabled), true);
+        TRCOMPARE_EQ(prefs.get<bool>(TR_KEY_show_statusbar), true);
     }
 
     void handles_bool()
@@ -264,7 +259,7 @@ private slots:
             prefs.set(Key, Val);
 
             auto const [key, var] = prefs.keyval(Key);
-            QCOMPARE_EQ(key, TR_KEY_main_window_height);
+            TRCOMPARE_EQ(key, static_cast<tr_quark>(TR_KEY_main_window_height));
             verify_variant_json(var, fmt::format("{}", Val));
         }
 
@@ -274,7 +269,7 @@ private slots:
             prefs.set(Key, val);
 
             auto const [key, var] = prefs.keyval(Key);
-            QCOMPARE_EQ(key, TR_KEY_download_dir);
+            TRCOMPARE_EQ(key, static_cast<tr_quark>(TR_KEY_download_dir));
             verify_variant_json(var, fmt::format(R"("{}")", val.toStdString()));
         }
     }
@@ -319,7 +314,7 @@ private slots:
         auto const new_value = !old_value;
         prefs.set(QuarkKey, new_value);
 
-        QCOMPARE_EQ(prefs.get<bool>(QuarkKey), new_value);
+        TRCOMPARE_EQ(prefs.get<bool>(QuarkKey), new_value);
         QCOMPARE(quark_spy.count(), 1);
         QCOMPARE(quark_spy.first().at(0).value<tr_quark>(), static_cast<tr_quark>(QuarkKey));
 
@@ -337,7 +332,7 @@ private slots:
         auto const current_value = prefs.get<bool>(QuarkKey);
         prefs.set(QuarkKey, tr_variant{ "wrong-type"sv });
 
-        QCOMPARE_EQ(prefs.get<bool>(QuarkKey), current_value);
+        TRCOMPARE_EQ(prefs.get<bool>(QuarkKey), current_value);
         QCOMPARE(quark_spy.count(), 0);
     }
 
@@ -378,18 +373,18 @@ private slots:
         prefs.save(settings_file);
 
         auto saved = tr::settings::load(settings_file.toStdString());
-        QCOMPARE_NE(saved.size(), 0U);
+        TRCOMPARE_NE(saved.size(), 0U);
         QVERIFY(!saved.contains(TR_KEY_filter_text));
 
         auto const custom_value = saved.value_if<int64_t>(custom_key);
         QVERIFY(custom_value.has_value());
-        QCOMPARE_EQ(custom_value, 123);
+        TRCOMPARE_EQ(custom_value, 123);
 
         auto round_tripped = Prefs{ saved };
-        QCOMPARE_EQ(round_tripped.get<QString>(TR_KEY_download_dir), download_dir);
-        QCOMPARE_EQ(round_tripped.get<SortMode>(TR_KEY_sort_mode), SortMode::SortByQueue);
-        QCOMPARE_EQ(round_tripped.get<std::chrono::sys_seconds>(TR_KEY_blocklist_date), blocklist_date);
-        QCOMPARE_EQ(round_tripped.get<QString>(TR_KEY_filter_text), QString{});
+        TRCOMPARE_EQ(round_tripped.get<QString>(TR_KEY_download_dir), download_dir);
+        TRCOMPARE_EQ(round_tripped.get<SortMode>(TR_KEY_sort_mode), SortMode::SortByQueue);
+        TRCOMPARE_EQ(round_tripped.get<std::chrono::sys_seconds>(TR_KEY_blocklist_date), blocklist_date);
+        TRCOMPARE_EQ(round_tripped.get<QString>(TR_KEY_filter_text), QString{});
     }
 
     static void is_core_classifies_core_keys()

--- a/tests/qt/qt-test-fixtures.h
+++ b/tests/qt/qt-test-fixtures.h
@@ -5,9 +5,46 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include <QTemporaryDir>
+#include <QTest>
+
+#include <fmt/format.h>
+
+#include <libtransmission/converters.h>
+#include <libtransmission/variant.h>
 
 #include "TrQtInit.h"
+#include "VariantHelpers.h"
+
+// QCOMPARE_EQ / QCOMPARE_NE only exist in Qt >= 6.3, but Transmission still
+// supports Qt 5.15. These give equivalent comparisons (fuzzy for floats) and,
+// on failure, render both operands as JSON via the serializer. Distinct `T`/`U`
+// allow mixed operand types; an operand without a Converter is a compile error.
+template<typename T, typename U>
+void trcompare(T const& actual, U const& expected, bool const negate)
+{
+    auto ok = bool{};
+    if constexpr (std::is_floating_point_v<T> && std::is_floating_point_v<U>) {
+        ok = qFuzzyCompare(actual, expected);
+    } else {
+        ok = actual == expected;
+    }
+
+    if (negate ? !ok : ok) {
+        return;
+    }
+
+    auto serde = tr_variant_serde::json();
+    serde.compact();
+    auto const actual_str = serde.to_string(tr::serializer::to_variant(actual));
+    auto const expected_str = serde.to_string(tr::serializer::to_variant(expected));
+    QFAIL(fmt::format("got '{:s}', expected '{:s}'", actual_str, expected_str).c_str());
+}
+
+#define TRCOMPARE_EQ(actual, expected) trcompare((actual), (expected), false)
+#define TRCOMPARE_NE(actual, expected) trcompare((actual), (expected), true)
 
 class BasicTest
 {


### PR DESCRIPTION
Fixup to #36 

- fix upstream fmt FTBFS when building with clang-20 and some versions of {fmt}
- fix `clang-diagnostic-float-equal` warning in the qt prefs tests