### PR TITLE
fix: don't throw in `tr_dht_impl` destructor

### DIFF
--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1314,7 +1314,7 @@ public:
     std::unique_ptr<tr_announcer> announcer_ = tr_announcer::create(this, *announcer_udp_);
 
     // depends-on: public_peer_port_, udp_core_, dht_mediator_
-    std::unique_ptr<tr_dht> dht_;
+    tr_dht::unique_ptr dht_{ nullptr, nullptr };
 
 private:
     // depends-on: session_thread_, timer_maker_, settings_, torrents_, web_

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -102,14 +102,11 @@ int dht_gettimeofday(struct timeval* tv, [[maybe_unused]] struct timezone* tz)
 
 namespace
 {
-
 constexpr std::array<std::pair<char const*, uint16_t>, 3> const DefaultBootstraps = { {
     { "dht.transmissiontorrent.com", 6881 },
     { "router.bittorrent.com", 6881 },
     { "dht.libtorrent.org", 25401 },
 } };
-
-}
 
 class tr_dht_impl final : public tr_dht
 {
@@ -155,7 +152,7 @@ public:
     tr_dht_impl& operator=(tr_dht_impl&&) = delete;
     tr_dht_impl& operator=(tr_dht_impl const&) = delete;
 
-    ~tr_dht_impl() override
+    void uninit()
     {
         tr_logAddTrace("Uninitializing DHT");
 
@@ -575,11 +572,19 @@ private:
     std::map<tr_torrent_id_t, AnnounceInfo> announce_times_;
 };
 
-[[nodiscard]] std::unique_ptr<tr_dht> tr_dht::create(
-    Mediator& mediator,
-    tr_port peer_port,
-    tr_socket_t udp4_socket,
-    tr_socket_t udp6_socket)
+void free_dht(tr_dht* const dht)
 {
-    return std::make_unique<tr_dht_impl>(mediator, peer_port, udp4_socket, udp6_socket);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast): this function is only used with `new tr_dht_impl`
+    static_cast<tr_dht_impl*>(dht)->uninit();
+    delete dht;
+}
+} // namespace
+
+[[nodiscard]] tr_dht::unique_ptr tr_dht::create(
+    Mediator& mediator,
+    tr_port const peer_port,
+    tr_socket_t const udp4_socket,
+    tr_socket_t const udp6_socket)
+{
+    return tr_dht::unique_ptr{ new tr_dht_impl{ mediator, peer_port, udp4_socket, udp6_socket }, free_dht };
 }

--- a/libtransmission/tr-dht.h
+++ b/libtransmission/tr-dht.h
@@ -35,6 +35,8 @@ class TimerMaker;
 class tr_dht
 {
 public:
+    using unique_ptr = std::unique_ptr<tr_dht, void (*)(tr_dht*)>;
+
     // Wrapper around DHT library.
     // This calls `jech/dht` in production, but makes it possible for tests to inject a mock.
     struct API {
@@ -104,7 +106,7 @@ public:
         API api_;
     };
 
-    [[nodiscard]] static std::unique_ptr<tr_dht> create(
+    [[nodiscard]] static unique_ptr create(
         Mediator& mediator,
         tr_port peer_port,
         tr_socket_t udp4_socket,


### PR DESCRIPTION
Extract the code in `~tr_dht_impl()` to a deleter since they can throw exceptions.

There should be no change in behaviour as long as no exceptions are thrown.