### PR TITLE
ci: more fixes & changes

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1371,7 +1371,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_INSTALL_PREFIX=pfx \
             -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold \
-             -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
+            -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_GTK=${{ (needs.what-to-make.outputs.make-gtk == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_MAC=OFF \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,7 +15,7 @@ env:
   GTEST_OUTPUT: xml:./
 jobs:
   what-to-make:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       make-core: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.core-changed == '1' || steps.check-diffs.outputs.ci-actions-changed == '1' }}
       make-android: ${{ steps.check-main-push.outputs.is-main-push == '1' || steps.check-diffs.outputs.android-changed == '1' || steps.check-diffs.outputs.ci-actions-changed == '1' }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -417,6 +417,7 @@ jobs:
             -DENABLE_TESTS=${{ matrix.enable-tests && 'ON' || 'OFF' }} \
             -DRUN_CLANG_TIDY=OFF \
             -DUSE_SYSTEM_DEFAULT=ON \
+            -DUSE_SYSTEM_FMT=${{ matrix.toolkit == 'gtk4' && 'OFF' || 'ON' }} `# TODO: remove this line when fmt>10 or clang>20` \
             -DUSE_SYSTEM_DHT=OFF `# Not packaged in Ubuntu` \
             -DUSE_SYSTEM_SIGSLOT=OFF `# Not packaged in Ubuntu` \
             -DUSE_SYSTEM_SMALL=OFF `# Not packaged in Ubuntu` \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -750,6 +750,8 @@ jobs:
             runner: windows-2022
           - arch: x64
             runner: windows-2022
+          - arch: x64
+            runner: windows-2025-vs2026
           - arch: arm64
             runner: windows-11-arm
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -102,11 +102,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
-      - name: Get NPM
-        if: ${{ needs.what-to-make.outputs.make-web == 'true' }}
-        uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
       - name: Check for style diffs
         id: check-for-diffs
         working-directory: .

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1417,6 +1417,11 @@ jobs:
         run: |
           echo '${{ toJSON(needs) }}'
           echo '${{ toJSON(runner) }}'
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Get Source
         uses: actions/download-artifact@v7
         with:
@@ -1589,6 +1594,11 @@ jobs:
         run: |
           echo '${{ toJSON(needs) }}'
           echo '${{ toJSON(runner) }}'
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Get Source
         uses: actions/download-artifact@v7
         with:
@@ -1670,6 +1680,11 @@ jobs:
         run: |
           echo '${{ toJSON(needs) }}'
           echo '${{ toJSON(runner) }}'
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Get Source
         uses: actions/download-artifact@v7
         with:
@@ -1764,6 +1779,11 @@ jobs:
         run: |
           echo '${{ toJSON(needs) }}'
           echo '${{ toJSON(runner) }}'
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Get Source
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -102,11 +102,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
-      - name: Get Dependencies
-        run: |
-          set -ex
-          sudo apt update
-          sudo apt install -y clang-format-22
       - name: Get NPM
         if: ${{ needs.what-to-make.outputs.make-web == 'true' }}
         uses: actions/setup-node@v6


### PR DESCRIPTION
#41 is better, but `clang-tidy-linux (gtk3)` is still  failing when merged into `main` with another fmt10+clang20 bug.

- ci(fix): squash another variant of the fmt10 + clang20 FTBFS
- ci(perf): use `ubuntu-slim` for the `what-to-make` job
- ci(perf): ensure kvm is enabled when running bsd in qemu
- ci(perf): skip installing unnecessary / preinstalled deps in the `code-style` job
- ci(feat): add windows-2025-vs2026 windows build