### PR TITLE
fix: -Wunused NSTimer* warnings

### DIFF
--- a/macosx/AddWindowController.mm
+++ b/macosx/AddWindowController.mm
@@ -153,7 +153,7 @@ typedef NS_ENUM(NSUInteger, PopupPriority) {
     }
 
     __weak __auto_type weakSelf = self;
-    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer* _Nonnull timer) {
+    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer* _Nonnull) {
         [weakSelf updateFiles];
     }];
 

--- a/macosx/BlocklistScheduler.mm
+++ b/macosx/BlocklistScheduler.mm
@@ -52,7 +52,7 @@ static NSTimeInterval const kFullWait = 60 * 60 * 24 * 7;
     NSDate* useDate = lastUpdateDate ? [lastUpdateDate laterDate:closeDate] : closeDate;
 
     __weak __auto_type weakSelf = self;
-    self.fTimer = [[NSTimer alloc] initWithFireDate:useDate interval:0 repeats:NO block:^(NSTimer* _Nonnull timer) {
+    self.fTimer = [[NSTimer alloc] initWithFireDate:useDate interval:0 repeats:NO block:^(NSTimer* _Nonnull) {
         [weakSelf runUpdater];
     }];
 

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -754,7 +754,7 @@ static void removeKeRangerRansomware()
 
     //timer to update the interface every second
     __weak __auto_type weakSelf = self;
-    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateUISeconds repeats:YES block:^(NSTimer* _Nonnull timer) {
+    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateUISeconds repeats:YES block:^(NSTimer* _Nonnull) {
         [weakSelf updateUI];
     }];
 
@@ -3164,7 +3164,7 @@ static void removeKeRangerRansomware()
 
     //check again in 10 seconds in case torrent file wasn't complete
     __weak __auto_type weakSelf = self;
-    self.fAutoImportTimer = [NSTimer scheduledTimerWithTimeInterval:10.0 repeats:NO block:^(NSTimer* _Nonnull timer) {
+    self.fAutoImportTimer = [NSTimer scheduledTimerWithTimeInterval:10.0 repeats:NO block:^(NSTimer* _Nonnull) {
         [weakSelf checkAutoImportDirectory];
     }];
 

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -579,7 +579,7 @@ static NSMutableSet* creatorWindowControllerSet;
     self.fFuture = self.fBuilder->make_checksums();
 
     __weak __auto_type weakSelf = self;
-    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:0.1 repeats:YES block:^(NSTimer* _Nonnull timer) {
+    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:0.1 repeats:YES block:^(NSTimer* _Nonnull) {
         [weakSelf checkProgress];
     }];
 }

--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -155,7 +155,7 @@ static NSUInteger const kMaxQueueLength = 10000U;
 {
     if (!self.fTimer) {
         __weak __auto_type weakSelf = self;
-        self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer* _Nonnull timer) {
+        self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer* _Nonnull) {
             [weakSelf updateLog];
         }];
         [self updateLog];
@@ -182,7 +182,7 @@ static NSUInteger const kMaxQueueLength = 10000U;
 {
     [self.fTimer invalidate];
     __weak __auto_type weakSelf = self;
-    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer* _Nonnull timer) {
+    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer* _Nonnull) {
         [weakSelf updateLog];
     }];
     [self updateLog];

--- a/macosx/PortChecker.mm
+++ b/macosx/PortChecker.mm
@@ -30,7 +30,7 @@ static NSTimeInterval const kCheckFireInterval = 3.0;
         _fStatus = PortStatusChecking;
 
         __weak __auto_type weakSelf = self;
-        _fTimer = [NSTimer scheduledTimerWithTimeInterval:kCheckFireInterval repeats:NO block:^(NSTimer* _Nonnull timer) {
+        _fTimer = [NSTimer scheduledTimerWithTimeInterval:kCheckFireInterval repeats:NO block:^(NSTimer* _Nonnull) {
             [weakSelf startProbe:portNumber];
         }];
 

--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -242,7 +242,7 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
     [self updatePortStatus];
 
     __weak __auto_type weakSelf = self;
-    self.fPortStatusTimer = [NSTimer scheduledTimerWithTimeInterval:5.0 repeats:YES block:^(NSTimer* _Nonnull timer) {
+    self.fPortStatusTimer = [NSTimer scheduledTimerWithTimeInterval:5.0 repeats:YES block:^(NSTimer* _Nonnull) {
         [weakSelf updatePortStatus];
     }];
 

--- a/macosx/StatsWindowController.mm
+++ b/macosx/StatsWindowController.mm
@@ -55,7 +55,7 @@ static tr_session* fLib = NULL;
     [self updateStats];
 
     __weak __auto_type weakSelf = self;
-    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer* _Nonnull timer) {
+    self.fTimer = [NSTimer scheduledTimerWithTimeInterval:kUpdateSeconds repeats:YES block:^(NSTimer* _Nonnull) {
         [weakSelf updateStats];
     }];
     [NSRunLoop.currentRunLoop addTimer:self.fTimer forMode:NSModalPanelRunLoopMode];


### PR DESCRIPTION
Fix `-Wunused` warnings for `NSTimer*` arguments in the blocks passed to `[NSTimer scheduledTimerWithTimeInterval]`