### PR TITLE
perf: separate file name cell into only file and only folder cells.

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 		ED67FB422B70FCE400D8A037 /* converters.cc in Sources */ = {isa = PBXBuildFile; fileRef = ED67FB402B70FCE400D8A037 /* converters.cc */; };
 		ED67FB432B70FCE400D8A037 /* serializer.h in Headers */ = {isa = PBXBuildFile; fileRef = ED67FB412B70FCE400D8A037 /* serializer.h */; };
 		ED67FB452B70FCE400D8A037 /* converters.h in Headers */ = {isa = PBXBuildFile; fileRef = ED67FB442B70FCE400D8A037 /* converters.h */; };
-		ED6F16B52EB8F1EB007CD864 /* FileNameCellView.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED6F16B22EB8F1EB007CD864 /* FileNameCellView.mm */; };
+		ED6F16B52EB8F1EB007CD864 /* BaseFileNameCellView.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED6F16B22EB8F1EB007CD864 /* BaseFileNameCellView.mm */; };
 		ED6F16B62EB8F1EB007CD864 /* FilePriorityCellView.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED6F16B42EB8F1EB007CD864 /* FilePriorityCellView.mm */; };
 		ED6F16B72EB8F1EB007CD864 /* FileCheckCellView.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED6F16B02EB8F1EB007CD864 /* FileCheckCellView.mm */; };
 		ED86936F2ADAE34D00342B1A /* DefaultAppHelper.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED86936E2ADAE34D00342B1A /* DefaultAppHelper.mm */; };
@@ -1455,8 +1455,8 @@
 		ED67FB442B70FCE400D8A037 /* converters.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = converters.h; sourceTree = "<group>"; };
 		ED6F16AF2EB8F1EB007CD864 /* FileCheckCellView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileCheckCellView.h; sourceTree = "<group>"; };
 		ED6F16B02EB8F1EB007CD864 /* FileCheckCellView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FileCheckCellView.mm; sourceTree = "<group>"; };
-		ED6F16B12EB8F1EB007CD864 /* FileNameCellView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileNameCellView.h; sourceTree = "<group>"; };
-		ED6F16B22EB8F1EB007CD864 /* FileNameCellView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FileNameCellView.mm; sourceTree = "<group>"; };
+		ED6F16B12EB8F1EB007CD864 /* BaseFileNameCellView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BaseFileNameCellView.h; sourceTree = "<group>"; };
+		ED6F16B22EB8F1EB007CD864 /* BaseFileNameCellView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BaseFileNameCellView.mm; sourceTree = "<group>"; };
 		ED6F16B32EB8F1EB007CD864 /* FilePriorityCellView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FilePriorityCellView.h; sourceTree = "<group>"; };
 		ED6F16B42EB8F1EB007CD864 /* FilePriorityCellView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FilePriorityCellView.mm; sourceTree = "<group>"; };
 		ED86936D2ADAE34D00342B1A /* DefaultAppHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DefaultAppHelper.h; sourceTree = "<group>"; };
@@ -2161,8 +2161,8 @@
 				A2AF1C370A3D0F6200F1575D /* FileOutlineView.mm */,
 				ED6F16AF2EB8F1EB007CD864 /* FileCheckCellView.h */,
 				ED6F16B02EB8F1EB007CD864 /* FileCheckCellView.mm */,
-				ED6F16B12EB8F1EB007CD864 /* FileNameCellView.h */,
-				ED6F16B22EB8F1EB007CD864 /* FileNameCellView.mm */,
+				ED6F16B12EB8F1EB007CD864 /* BaseFileNameCellView.h */,
+				ED6F16B22EB8F1EB007CD864 /* BaseFileNameCellView.mm */,
 				ED6F16B32EB8F1EB007CD864 /* FilePriorityCellView.h */,
 				ED6F16B42EB8F1EB007CD864 /* FilePriorityCellView.mm */,
 			);
@@ -3517,7 +3517,7 @@
 				A2385DD40BFE06C800B24EF6 /* DragOverlayWindow.mm in Sources */,
 				A2FB057F0BFEB6800095564D /* DragOverlayView.mm in Sources */,
 				E138A9780C04D88F00C5426C /* ProgressGradients.mm in Sources */,
-				ED6F16B52EB8F1EB007CD864 /* FileNameCellView.mm in Sources */,
+				ED6F16B52EB8F1EB007CD864 /* BaseFileNameCellView.mm in Sources */,
 				ED6F16B62EB8F1EB007CD864 /* FilePriorityCellView.mm in Sources */,
 				ED6F16B72EB8F1EB007CD864 /* FileCheckCellView.mm in Sources */,
 				A2DF37070C220D03006523C1 /* CreatorWindowController.mm in Sources */,

--- a/macosx/BaseFileNameCellView.h
+++ b/macosx/BaseFileNameCellView.h
@@ -6,8 +6,14 @@
 
 @class FileListNode;
 
-@interface FileNameCellView : NSTableCellView
+@interface BaseFileNameCellView : NSTableCellView
 
 @property(nonatomic, weak) FileListNode* node;
 
+@end
+
+@interface FileNameCellView : BaseFileNameCellView
+@end
+
+@interface FolderNameCellView : BaseFileNameCellView
 @end

--- a/macosx/BaseFileNameCellView.mm
+++ b/macosx/BaseFileNameCellView.mm
@@ -4,7 +4,7 @@
 
 #include <libtransmission/transmission.h>
 
-#import "FileNameCellView.h"
+#import "BaseFileNameCellView.h"
 #import "FileListNode.h"
 #import "Torrent.h"
 #import "NSStringAdditions.h"
@@ -17,14 +17,14 @@ static CGFloat const kPaddingAboveTitleFile = 2.0;
 static CGFloat const kPaddingBelowStatusFile = 2.0;
 static CGFloat const kPaddingBetweenNameAndFolderStatus = 4.0;
 
-@interface FileNameCellView ()
+@interface BaseFileNameCellView ()
 @property(nonatomic, weak) NSImageView* iconView;
 @property(nonatomic, weak) NSTextField* nameField;
 @property(nonatomic, weak) NSTextField* statusField;
 @property(nonatomic, strong) NSArray<NSLayoutConstraint*>* dynamicConstraints;
 @end
 
-@implementation FileNameCellView
+@implementation BaseFileNameCellView
 
 - (instancetype)initWithFrame:(NSRect)frameRect
 {
@@ -70,22 +70,6 @@ static CGFloat const kPaddingBetweenNameAndFolderStatus = 4.0;
 
 - (void)setupConstraints
 {
-    NSImageView* iconView = self.iconView;
-    NSTextField* nameField = self.nameField;
-
-    // Fixed constraints that don't change
-    [NSLayoutConstraint activateConstraints:@[
-        // Icon view constraints
-        [iconView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:kPaddingHorizontal],
-        [iconView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-        [iconView.widthAnchor constraintEqualToConstant:kImageIconSize],
-        [iconView.heightAnchor constraintEqualToConstant:kImageIconSize],
-
-        // Name field leading constraint
-        [nameField.leadingAnchor constraintEqualToAnchor:iconView.trailingAnchor constant:kPaddingBetweenImageAndTitle],
-    ]];
-
-    self.dynamicConstraints = @[];
 }
 
 - (void)setNode:(FileListNode*)node
@@ -105,14 +89,6 @@ static CGFloat const kPaddingBetweenNameAndFolderStatus = 4.0;
     // Update icon
     self.iconView.image = node.icon;
 
-    // Update icon size constraints based on folder/file
-    CGFloat const imageSize = node.isFolder ? kImageFolderSize : kImageIconSize;
-    for (NSLayoutConstraint* constraint in self.iconView.constraints) {
-        if (constraint.firstAttribute == NSLayoutAttributeWidth || constraint.firstAttribute == NSLayoutAttributeHeight) {
-            constraint.constant = imageSize;
-        }
-    }
-
     // Update name
     self.nameField.stringValue = node.name;
 
@@ -125,39 +101,6 @@ static CGFloat const kPaddingBetweenNameAndFolderStatus = 4.0;
                                                   percentString,
                                                   [NSString stringForFileSize:node.size]];
     self.statusField.stringValue = status;
-
-    // Update layout constraints based on folder vs file
-    [NSLayoutConstraint deactivateConstraints:self.dynamicConstraints];
-
-    NSTextField* nameField = self.nameField;
-    NSTextField* statusField = self.statusField;
-
-    if (node.isFolder) {
-        // For folders, status appears next to name, both centered
-        self.statusField.hidden = NO;
-        self.dynamicConstraints = @[
-            [nameField.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-            [nameField.trailingAnchor constraintLessThanOrEqualToAnchor:statusField.leadingAnchor
-                                                               constant:-kPaddingBetweenNameAndFolderStatus],
-
-            [statusField.leadingAnchor constraintEqualToAnchor:nameField.trailingAnchor constant:kPaddingBetweenNameAndFolderStatus],
-            [statusField.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-            [statusField.trailingAnchor constraintLessThanOrEqualToAnchor:self.trailingAnchor],
-        ];
-    } else {
-        // For files, status appears below name
-        self.statusField.hidden = NO;
-        self.dynamicConstraints = @[
-            [nameField.topAnchor constraintEqualToAnchor:self.topAnchor constant:kPaddingAboveTitleFile],
-            [nameField.trailingAnchor constraintLessThanOrEqualToAnchor:self.trailingAnchor],
-
-            [statusField.leadingAnchor constraintEqualToAnchor:nameField.leadingAnchor],
-            [statusField.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
-            [statusField.bottomAnchor constraintEqualToAnchor:self.bottomAnchor constant:-kPaddingBelowStatusFile],
-        ];
-    }
-
-    [NSLayoutConstraint activateConstraints:self.dynamicConstraints];
 
     // Update colors based on background style and check state
     [self updateColors];
@@ -207,6 +150,68 @@ static CGFloat const kPaddingBetweenNameAndFolderStatus = 4.0;
         self.nameField.textColor = NSColor.controlTextColor;
         self.statusField.textColor = NSColor.secondaryLabelColor;
     }
+}
+
+@end
+
+@implementation FileNameCellView
+
+- (void)setupConstraints
+{
+    NSImageView* iconView = self.iconView;
+    NSTextField* nameField = self.nameField;
+    NSTextField* statusField = self.statusField;
+
+    // Fixed constraints that don't change
+    [NSLayoutConstraint activateConstraints:@[
+        // Icon view constraints
+        [iconView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:kPaddingHorizontal],
+        [iconView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [iconView.widthAnchor constraintEqualToConstant:kImageIconSize],
+        [iconView.heightAnchor constraintEqualToConstant:kImageIconSize],
+
+        // Name field leading constraint
+        [nameField.leadingAnchor constraintEqualToAnchor:iconView.trailingAnchor constant:kPaddingBetweenImageAndTitle],
+
+        // For files, status appears below name
+        [nameField.topAnchor constraintEqualToAnchor:self.topAnchor constant:kPaddingAboveTitleFile],
+        [nameField.trailingAnchor constraintLessThanOrEqualToAnchor:self.trailingAnchor],
+
+        [statusField.leadingAnchor constraintEqualToAnchor:nameField.leadingAnchor],
+        [statusField.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
+        [statusField.bottomAnchor constraintEqualToAnchor:self.bottomAnchor constant:-kPaddingBelowStatusFile],
+    ]];
+}
+
+@end
+
+@implementation FolderNameCellView
+
+- (void)setupConstraints
+{
+    NSImageView* iconView = self.iconView;
+    NSTextField* nameField = self.nameField;
+    NSTextField* statusField = self.statusField;
+
+    // Fixed constraints that don't change
+    [NSLayoutConstraint activateConstraints:@[
+        // Icon view constraints
+        [iconView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:kPaddingHorizontal],
+        [iconView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [iconView.widthAnchor constraintEqualToConstant:kImageFolderSize],
+        [iconView.heightAnchor constraintEqualToConstant:kImageFolderSize],
+
+        // Name field leading constraint
+        [nameField.leadingAnchor constraintEqualToAnchor:iconView.trailingAnchor constant:kPaddingBetweenImageAndTitle],
+
+        // For folders, status appears next to name, both centered
+        [nameField.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [nameField.trailingAnchor constraintLessThanOrEqualToAnchor:statusField.leadingAnchor constant:-kPaddingBetweenNameAndFolderStatus],
+
+        [statusField.leadingAnchor constraintEqualToAnchor:nameField.trailingAnchor constant:kPaddingBetweenNameAndFolderStatus],
+        [statusField.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [statusField.trailingAnchor constraintLessThanOrEqualToAnchor:self.trailingAnchor],
+    ]];
 }
 
 @end

--- a/macosx/CMakeLists.txt
+++ b/macosx/CMakeLists.txt
@@ -48,6 +48,8 @@ target_sources(${TR_NAME}-mac
         Badger.mm
         BadgeView.h
         BadgeView.mm
+        BaseFileNameCellView.h
+        BaseFileNameCellView.mm
         BlocklistDownloader.h
         BlocklistDownloader.mm
         BlocklistDownloaderViewController.h
@@ -79,8 +81,6 @@ target_sources(${TR_NAME}-mac
         FileListNode.mm
         FileCheckCellView.h
         FileCheckCellView.mm
-        FileNameCellView.h
-        FileNameCellView.mm
         FileOutlineController.h
         FileOutlineController.mm
         FileOutlineView.h

--- a/macosx/FileOutlineController.mm
+++ b/macosx/FileOutlineController.mm
@@ -6,7 +6,7 @@
 #import "Torrent.h"
 #import "FileListNode.h"
 #import "FileOutlineView.h"
-#import "FileNameCellView.h"
+#import "BaseFileNameCellView.h"
 #import "FilePriorityCellView.h"
 #import "FileCheckCellView.h"
 #import "FileRenameSheetController.h"
@@ -208,10 +208,20 @@ typedef NS_ENUM(NSUInteger, FilePriorityMenuTag) { //
     FileListNode* node = (FileListNode*)item;
 
     if ([identifier isEqualToString:@"Name"]) {
-        FileNameCellView* cellView = [outlineView makeViewWithIdentifier:@"NameCell" owner:self];
-        if (!cellView) {
-            cellView = [[FileNameCellView alloc] initWithFrame:NSZeroRect];
-            cellView.identifier = @"NameCell";
+        BaseFileNameCellView* cellView = nil;
+
+        if (node.isFolder) {
+            cellView = [outlineView makeViewWithIdentifier:@"OnlyFolderCell" owner:self];
+            if (!cellView) {
+                cellView = [[FolderNameCellView alloc] initWithFrame:NSZeroRect];
+                cellView.identifier = @"OnlyFolderCell";
+            }
+        } else {
+            cellView = [outlineView makeViewWithIdentifier:@"OnlyFileCell" owner:self];
+            if (!cellView) {
+                cellView = [[FileNameCellView alloc] initWithFrame:NSZeroRect];
+                cellView.identifier = @"OnlyFileCell";
+            }
         }
         cellView.node = node;
 

--- a/macosx/FileOutlineView.mm
+++ b/macosx/FileOutlineView.mm
@@ -4,9 +4,8 @@
 
 #import "InfoWindowController.h"
 #import "FileListNode.h"
-#import "FileNameCellView.h"
+#import "BaseFileNameCellView.h"
 #import "FileOutlineView.h"
-#import "FilePriorityCellView.h"
 #import "Torrent.h"
 
 @interface FileOutlineView ()
@@ -47,11 +46,11 @@
 - (NSRect)iconRectForRow:(NSInteger)row
 {
     NSView* view = [self viewAtColumn:[self columnWithIdentifier:@"Name"] row:row makeIfNecessary:NO];
-    if (![view isKindOfClass:[FileNameCellView class]]) {
+    if (![view isKindOfClass:[BaseFileNameCellView class]]) {
         return NSZeroRect;
     }
 
-    FileNameCellView* cellView = (FileNameCellView*)view;
+    __auto_type cellView = (BaseFileNameCellView*)view;
     NSImageView* iconView = [cellView valueForKey:@"iconView"];
     if (!iconView) {
         return NSZeroRect;


### PR DESCRIPTION
cherry-pick of upstream 8497.

Notes: Improved UI code to use less CPU.

---

Separate file name cell into only file and only folder name cells to eliminate dynamic constraints and layout in `setNode`.

I checked with this snippet.

```objective-c++
#import <mach/mach_time.h>

// Inside -(void)updateDisplay {
static uint64_t totalNanoseconds = 0;
static uint64_t callCount = 0;

uint64_t start = mach_absolute_time();

// --- body of updateDisplay... ---

uint64_t end = mach_absolute_time();

mach_timebase_info_data_t info;
mach_timebase_info(&info);
uint64_t elapsedNano = (end - start) * info.numer / info.denom;

totalNanoseconds += elapsedNano;
callCount++;

// Average time every 500 calls (scrolling).
if (callCount % 500 == 0) {
    NSLog(@"[PERF_TEST] Calls: %llu | Avg time per cell: %.3f ms", 
          callCount, (double)totalNanoseconds / callCount / 1000000.0);
}
// }
// [self updateColors];
// ...
// } // end of -(void)updateDisplay
```

### Results 

#### Different cells for Files and for Folders

| Total Rendered Cells | Before Optimization (main) | After Optimization (This PR) | Speedup / Improvement |
|---|---|---|---|
| 1,000 cells | 0.534 ms | 0.409 ms | -23.4% time spent |
| 1,500 cells | 0.539 ms | 0.357 ms | -33.8% time spent |
| 2,000 cells | 0.540 ms | 0.377 ms | -30.2% time spent |
| 2,500 cells | 0.543 ms | 0.389 ms | -28.4% time spent |
| 3,000 cells | 0.533 ms | 0.397 ms | -25.5% time spent |
| Average | 0.538 ms | 0.386 ms | ~1.39x Faster |

### Results 
#### Different cells for Files and for Folders and Icon caching

| Total Rendered Cells | Before Optimization (main) | After Optimization (This PR) | Speedup / Improvement |
|---|---|---|---|
| 1,000 cells | 0.534 ms | 0.161 ms | -69.8% time spent |
| 1,500 cells | 0.539 ms | 0.151 ms | -72.0% time spent |
| 2,000 cells | 0.540 ms | 0.147 ms | -72.8% time spent |
| 2,500 cells | 0.543 ms | 0.144 ms | -73.5% time spent |
| 3,000 cells | 0.533 ms | 0.142 ms | -73.4% time spent |
| Average | 0.538 ms | 0.149 ms | ~3.6x Faster |

### Results 
#### Different cells for Files and Folders and Icon caching and Folders icons set once in init

| Total Rendered Cells | Before Optimization (main) | After Optimization (This PR) | Speedup / Improvement |
|---|---|---|---|
| 1,000 cells | 0.534 ms | 0.138 ms | -74.2% time spent |
| 1,500 cells | 0.539 ms | 0.134 ms | -75.1% time spent |
| 2,000 cells | 0.540 ms | 0.131 ms | -75.7% time spent |
| 2,500 cells | 0.543 ms | 0.129 ms | -76.2% time spent |
| 3,000 cells | 0.533 ms | 0.128 ms | -76.0% time spent |
| Average | 0.538 ms | 0.132 ms | ~4.1x Faster |


