### PR TITLE
refactor: add Utils::fromUtf8(std::string_view)

### DIFF
--- a/qt/AddData.cc
+++ b/qt/AddData.cc
@@ -14,7 +14,6 @@
 #include <libtransmission/web-utils.h>
 
 #include "AddData.h"
-#include "QtCompat.h"
 #include "Utils.h"
 
 namespace
@@ -41,8 +40,7 @@ QString getNameFromMagnet(QString const& magnet)
         return QString::fromStdString(tmp.name());
     }
 
-    auto const& hashstr = tmp.info_hash_string();
-    return QString::fromUtf8(std::data(hashstr), static_cast<IF_QT6(qsizetype, int)>(std::size(hashstr)));
+    return Utils::qstringFromUtf8(tmp.info_hash_string());
 }
 
 } // namespace

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -1258,7 +1258,7 @@ void DetailsDialog::onAddTrackerClicked()
     for (auto const& info : announce_list) {
         // for each selected torrent...
         auto sv = info.announce.sv();
-        auto const announce_url = QString::fromUtf8(std::data(sv), static_cast<IF_QT6(qsizetype, int)>(std::size(sv)));
+        auto const announce_url = Utils::qstringFromUtf8(sv);
         for (auto const& id : ids_) {
             // make a note if the torrent doesn't already have the URL
             if (tracker_model_->find(id, announce_url) == -1) {
@@ -1279,7 +1279,7 @@ void DetailsDialog::onAddTrackerClicked()
     } else {
         for (auto const& [ids, urls] : ids_to_urls) {
             auto urls_list = QList<QString>{};
-            urls_list.reserve(static_cast<IF_QT6(qsizetype, int)>(std::size(urls)));
+            urls_list.reserve(static_cast<QtrSizeArgType>(std::size(urls)));
             for (auto const& url : urls) {
                 urls_list << url;
             }

--- a/qt/FaviconCache.cc
+++ b/qt/FaviconCache.cc
@@ -10,7 +10,7 @@
 #include <QPixmap>
 #include <QStandardPaths>
 
-#include "QtCompat.h"
+#include "Utils.h"
 
 using namespace tr::app;
 using Icon = QPixmap;
@@ -19,7 +19,7 @@ template<>
 Icon FaviconCache<Icon>::create_from_file(std::string_view filename) const // NOLINT(readability-identifier-naming)
 {
     auto icon = QPixmap{};
-    if (!icon.load(QString::fromUtf8(std::data(filename), static_cast<IF_QT6(qsizetype, int)>(std::size(filename))))) {
+    if (!icon.load(Utils::qstringFromUtf8(filename))) {
         return {};
     }
 

--- a/qt/FileTreeModel.cc
+++ b/qt/FileTreeModel.cc
@@ -28,7 +28,7 @@ namespace
 class PathIteratorBase
 {
 protected:
-    PathIteratorBase(QString const& path, IF_QT6(qsizetype, int) const slash_index)
+    PathIteratorBase(QString const& path, QtrSizeArgType const slash_index)
         : path_{ path }
         , slash_index_{ slash_index }
     {
@@ -37,7 +37,7 @@ protected:
 
     QString const& path_;
     QString token_;
-    IF_QT6(qsizetype, int) slash_index_;
+    QtrSizeArgType slash_index_;
 
     static QChar const SlashChar;
 };

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -35,7 +35,6 @@
 #include "OptionsDialog.h"
 #include "Prefs.h"
 #include "PrefsDialog.h"
-#include "QtCompat.h"
 #include "RelocateDialog.h"
 #include "Session.h"
 #include "SessionDialog.h"

--- a/qt/MakeDialog.cc
+++ b/qt/MakeDialog.cc
@@ -138,7 +138,7 @@ void MakeProgressDialog::onProgress()
         } else {
             auto err_msg = QString::fromUtf8(
                 std::data(error.message()),
-                static_cast<IF_QT6(qsizetype, int)>(std::size(error.message())));
+                static_cast<QtrSizeArgType>(std::size(error.message())));
             str = tr("Couldn't create \"%1\": %2 (%3)").arg(base).arg(err_msg).arg(error.code());
         }
     }

--- a/qt/NativeIcon.cc
+++ b/qt/NativeIcon.cc
@@ -4,7 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include "NativeIcon.h"
-#include "QtCompat.h"
+#include "Utils.h"
 
 #include <optional>
 #include <string_view>
@@ -446,7 +446,7 @@ QIcon icon(Type const type, QStyle const* const style)
 #if defined(Q_OS_MAC)
     if (auto const key = info.sf_symbol_name; !std::empty(key)) {
         auto icon = QIcon{};
-        auto const name = QString::fromUtf8(std::data(key), std::size(key));
+        auto const name = Utils::qstringFromUtf8(key);
         for (int const pixel_size : pixel_sizes) {
             if (auto const pixmap = loadSFSymbol(name, pixel_size); !pixmap.isNull()) {
                 icon.addPixmap(pixmap);
@@ -474,7 +474,7 @@ QIcon icon(Type const type, QStyle const* const style)
     }
 
     if (auto const key = info.xdg_icon_name; !std::empty(key)) {
-        auto const name = QString::fromUtf8(std::data(key), static_cast<IF_QT6(qsizetype, int)>(std::size(key)));
+        auto const name = Utils::qstringFromUtf8(key);
 
         if (auto icon = QIcon::fromTheme(name); !icon.isNull()) {
             return icon;

--- a/qt/Prefs.h
+++ b/qt/Prefs.h
@@ -19,8 +19,8 @@
 
 #include <libtransmission-app/prefs.h>
 
-#include "QtCompat.h"
 #include "UserMetaType.h"
+#include "Utils.h"
 #include "VariantHelpers.h"
 
 namespace tr::app
@@ -29,7 +29,7 @@ template<>
 struct PrefsStringTraits<QString> {
     [[nodiscard]] static QString from_utf8(std::string_view const str)
     {
-        return QString::fromUtf8(std::data(str), static_cast<IF_QT6(qsizetype, int)>(std::size(str)));
+        return Utils::qstringFromUtf8(str);
     }
 
     [[nodiscard]] static QString home_dir()

--- a/qt/QtCompat.h
+++ b/qt/QtCompat.h
@@ -10,8 +10,10 @@
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #define IF_QT6(ThenValue, ElseValue) ThenValue
+using QtrSizeArgType = qsizetype;
 #else
 #define IF_QT6(ThenValue, ElseValue) ElseValue
+using QtrSizeArgType = int;
 #endif
 
 #endif //TR_QTCOMPAT_H

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -23,7 +23,7 @@
 #include <libtransmission/transmission.h>
 #include <libtransmission/version.h> // LONG_VERSION_STRING
 
-#include "QtCompat.h"
+#include "Utils.h"
 #include "VariantHelpers.h"
 
 using ::trqt::variant_helpers::dictFind;
@@ -296,12 +296,12 @@ RpcResponse RpcClient::parseResponseData(tr_variant& response) const
 
         if (auto* error_map = response_map->find_if<tr_variant::Map>(TR_KEY_error)) {
             if (auto const errmsg = error_map->value_if<std::string_view>(TR_KEY_message)) {
-                ret.errmsg = QString::fromUtf8(std::data(*errmsg), static_cast<IF_QT6(qsizetype, int)>(std::size(*errmsg)));
+                ret.errmsg = Utils::qstringFromUtf8(*errmsg);
             }
 
             if (auto* const data = error_map->find_if<tr_variant::Map>(TR_KEY_data)) {
                 if (auto const errstr = data->value_if<std::string_view>(TR_KEY_error_string)) {
-                    ret.errmsg = QString::fromUtf8(std::data(*errstr), static_cast<IF_QT6(qsizetype, int)>(std::size(*errstr)));
+                    ret.errmsg = Utils::qstringFromUtf8(*errstr);
                 }
 
                 if (auto* const result = data->find_if<tr_variant::Map>(TR_KEY_result)) {

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -38,11 +38,11 @@
 #include "AddData.h"
 #include "Filters.h"
 #include "Prefs.h"
-#include "QtCompat.h"
 #include "RpcQueue.h"
 #include "SessionDialog.h"
 #include "Torrent.h"
 #include "UserMetaType.h"
+#include "Utils.h"
 #include "VariantHelpers.h"
 
 using namespace std::literals;
@@ -296,8 +296,7 @@ void Session::start()
 
         auto const root_path = prefs_.get<QString>(TR_KEY_remote_session_url_base_path);
         auto const relative_path = TrHttpServerRpcRelativePath;
-        url.setPath(
-            root_path + QString::fromUtf8(relative_path.data(), static_cast<IF_QT6(qsizetype, int)>(relative_path.size())));
+        url.setPath(root_path + Utils::qstringFromUtf8(relative_path));
 
         if (prefs_.get<bool>(TR_KEY_remote_session_requires_authentication)) {
             url.setUserName(prefs_.get<QString>(TR_KEY_remote_session_username));
@@ -836,9 +835,7 @@ void Session::addTorrent(AddData const& add_me, tr_variant::Map args_dict)
 
                 if (auto const iter = dup->find(TR_KEY_hash_string); iter != dup->end()) {
                     if (auto const hash = iter->second.value_if<std::string_view>()) {
-                        duplicates_.try_emplace(
-                            add_me.readableShortName(),
-                            QString::fromUtf8(std::data(*hash), static_cast<IF_QT6(qsizetype, int)>(std::size(*hash))));
+                        duplicates_.try_emplace(add_me.readableShortName(), Utils::qstringFromUtf8(*hash));
                         duplicates_timer_.start(1000);
                     }
                 }
@@ -934,8 +931,7 @@ void Session::launchWebInterface() const
 
         auto const root_path = prefs_.get<QString>(TR_KEY_remote_session_url_base_path);
         auto const relative_path = TrHttpServerWebRelativePath;
-        url.setPath(
-            root_path + QString::fromUtf8(relative_path.data(), static_cast<IF_QT6(qsizetype, int)>(relative_path.size())));
+        url.setPath(root_path + Utils::qstringFromUtf8(relative_path));
     } else // local session
     {
         url.setScheme(QStringLiteral("http"));

--- a/qt/Speed.h
+++ b/qt/Speed.h
@@ -10,7 +10,7 @@
 
 #include <libtransmission/values.h>
 
-#include "QtCompat.h"
+#include "Utils.h"
 
 class Speed : public tr::Values::Speed
 {
@@ -56,6 +56,6 @@ public:
     [[nodiscard]] static auto display_name(Speed::Units const units)
     {
         auto const speed_unit_sv = Speed::units().display_name(units);
-        return QString::fromUtf8(std::data(speed_unit_sv), static_cast<IF_QT6(qsizetype, int)>(std::size(speed_unit_sv)));
+        return Utils::qstringFromUtf8(speed_unit_sv);
     }
 };

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -27,8 +27,8 @@
 #include <libtransmission/types.h>
 
 #include "IconCache.h"
-#include "QtCompat.h"
 #include "Speed.h"
+#include "Utils.h"
 
 class QPixmap;
 
@@ -170,7 +170,7 @@ public:
         : data_{ data }
     {
         auto const hashstr = tr_sha1_to_string(data_);
-        data_str_ = QString::fromUtf8(std::data(hashstr), static_cast<IF_QT6(qsizetype, int)>(std::size(hashstr)));
+        data_str_ = Utils::qstringFromUtf8(hashstr);
     }
 
     explicit TorrentHash(std::string_view const str)

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -14,7 +14,6 @@
 #include <libtransmission-app/favicon-cache.h>
 
 #include "Formatter.h"
-#include "QtCompat.h"
 #include "Torrent.h"
 #include "TrackerDelegate.h"
 #include "TrackerModel.h"
@@ -194,10 +193,7 @@ QString TrackerDelegate::getText(TrackerInfo const& inf) const
     str += inf.st.is_backup ? QStringLiteral("<i>") : QStringLiteral("<b>");
     auto const announce_url = inf.st.announce.toStdString();
     if (auto const parsed = tr_urlParse(announce_url); parsed) {
-        str += QStringLiteral("%1:%2")
-                   .arg(
-                       QString::fromUtf8(std::data(parsed->host), static_cast<IF_QT6(qsizetype, int)>(std::size(parsed->host))))
-                   .arg(parsed->port);
+        str += QStringLiteral("%1:%2").arg(Utils::qstringFromUtf8(parsed->host)).arg(parsed->port);
     }
     str += inf.st.is_backup ? QStringLiteral("</i>") : QStringLiteral("</b>");
 

--- a/qt/Utils.cc
+++ b/qt/Utils.cc
@@ -3,6 +3,8 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include <string_view>
+
 #include <QAbstractItemView>
 #include <QApplication>
 #include <QColor>
@@ -18,11 +20,15 @@
 #include <QMimeType>
 #include <QObject>
 #include <QPixmapCache>
+#include <QRect>
+#include <QSpinBox>
 #include <QStyle>
 
 #include <libtransmission/transmission.h>
 
 #include "Utils.h"
+
+#include "QtCompat.h"
 
 // ---
 
@@ -55,6 +61,11 @@ QIcon Utils::getIconFromIndex(QModelIndex const& index)
     default:
         return {};
     }
+}
+
+QString Utils::qstringFromUtf8(std::string_view const str)
+{
+    return QString::fromUtf8(str.data(), static_cast<QtrSizeArgType>(str.size()));
 }
 
 QString Utils::removeTrailingDirSeparator(QString const& path)
@@ -116,4 +127,13 @@ void Utils::updateSpinBoxFormat(QSpinBox* spinBox, char const* context, char con
     if (spinBox->suffix() != units_suffix) {
         spinBox->setSuffix(units_suffix);
     }
+}
+
+void Utils::narrowRect(QRect& rect, int dx1, int dx2, Qt::LayoutDirection direction)
+{
+    if (direction == Qt::RightToLeft) {
+        qSwap(dx1, dx2);
+    }
+
+    rect.adjust(dx1, 0, -dx2, 0);
 }

--- a/qt/Utils.h
+++ b/qt/Utils.h
@@ -5,11 +5,10 @@
 
 #pragma once
 
+#include <string_view>
 #include <utility>
 
 #include <QPointer>
-#include <QRect>
-#include <QSpinBox>
 #include <QString>
 
 class QAbstractItemView;
@@ -17,22 +16,19 @@ class QColor;
 class QHeaderView;
 class QIcon;
 class QModelIndex;
+class QRect;
+class QSpinBox;
 
 class Utils
 {
 public:
     static QIcon getIconFromIndex(QModelIndex const& index);
 
+    [[nodiscard]] static QString qstringFromUtf8(std::string_view str);
+
     static QString removeTrailingDirSeparator(QString const& path);
 
-    static void narrowRect(QRect& rect, int dx1, int dx2, Qt::LayoutDirection direction)
-    {
-        if (direction == Qt::RightToLeft) {
-            qSwap(dx1, dx2);
-        }
-
-        rect.adjust(dx1, 0, -dx2, 0);
-    }
+    static void narrowRect(QRect& rect, int dx1, int dx2, Qt::LayoutDirection direction);
 
     static int measureViewItem(QAbstractItemView const* view, QString const& text);
     static int measureHeaderItem(QHeaderView const* view, QString const& text);

--- a/qt/VariantHelpers.cc
+++ b/qt/VariantHelpers.cc
@@ -21,6 +21,7 @@
 #include "QtCompat.h"
 #include "Speed.h"
 #include "Torrent.h"
+#include "Utils.h"
 
 namespace ser = tr::serializer;
 
@@ -48,9 +49,7 @@ bool change(TrackerStat& setme, tr_variant const* value)
             auto const announce_str = setme.announce.toStdString();
             if (auto const parsed = tr_urlParse(announce_str)) {
                 auto const sitename = parsed->sitename;
-                setme.sitename = QString::fromUtf8(
-                    std::data(sitename),
-                    static_cast<IF_QT6(qsizetype, int)>(std::size(sitename)));
+                setme.sitename = QString::fromUtf8(std::data(sitename), static_cast<QtrSizeArgType>(std::size(sitename)));
             }
         }
 
@@ -68,7 +67,7 @@ namespace
 bool toQString(tr_variant const& src, QString* tgt)
 {
     if (auto const val = src.value_if<std::string_view>()) {
-        *tgt = QString::fromUtf8(std::data(*val), static_cast<IF_QT6(qsizetype, int)>(std::size(*val)));
+        *tgt = Utils::qstringFromUtf8(*val);
         return true;
     }
 

--- a/tests/qt/rpc-test-fixtures.h
+++ b/tests/qt/rpc-test-fixtures.h
@@ -23,7 +23,7 @@ template<typename String>
 [[nodiscard]] QByteArray toQBA(String const& str)
 {
     auto const sv = std::string_view{ str };
-    return { sv.data(), static_cast<IF_QT6(qsizetype, int)>(sv.size()) };
+    return { sv.data(), static_cast<QtrSizeArgType>(sv.size()) };
 }
 
 class FakeReply final : public QNetworkReply


### PR DESCRIPTION
Add a `std::string-view`-to-`QString` helper function.
- avoids having to call data() + size() on the source view
- avoids the IF_QT6() macro for whether 2nd arg is int or qsizetype