### PR TITLE
feat: support the start-minimized settings property

### DIFF
--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -47,7 +47,7 @@ std::string gl_confdir;
 {
     auto const dir = get_default_download_dir();
 
-    auto map = tr::Settings{ 29U };
+    auto map = tr::Settings{ 30U };
     map.try_emplace(TR_KEY_blocklist_updates_enabled, true);
     map.try_emplace(TR_KEY_compact_view, false);
     map.try_emplace(TR_KEY_details_window_height, 500);
@@ -70,6 +70,7 @@ std::string gl_confdir;
     map.try_emplace(TR_KEY_show_tracker_scrapes, false);
     map.try_emplace(TR_KEY_sort_mode, to_variant(DefaultSortMode));
     map.try_emplace(TR_KEY_sort_reversed, false);
+    map.try_emplace(TR_KEY_start_minimized, false);
     map.try_emplace(TR_KEY_statusbar_stats, to_variant(DefaultStatsMode));
     map.try_emplace(TR_KEY_torrent_added_notification_enabled, true);
     map.try_emplace(TR_KEY_torrent_complete_notification_enabled, true);

--- a/gtk/main.cc
+++ b/gtk/main.cc
@@ -130,6 +130,8 @@ int main(int argc, char** argv)
     /* init notifications */
     gtr_notify_init();
 
+    start_iconified |= gtr_pref_flag_get(TR_KEY_start_minimized);
+
     /* init the application for the specified config dir */
     return Application(config_dir, start_paused, start_iconified).run(argc, argv);
 }


### PR DESCRIPTION
Fixes #53. The Qt client could do this before; now the GTK client can, too

Notes: Improved `settings.json` compatibility between the GTK and Qt clients.