### PR TITLE
fix: potential out-of-bounds array access in json parse code

### DIFF
--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -208,12 +208,13 @@ private:
 std::optional<tr_variant> tr_variant_serde::parse_json(std::string_view input)
 {
     auto* begin = std::data(input);
+    auto size = std::size(input);
     if (begin == nullptr) {
         // RapidJSON will dereference a nullptr otherwise
         begin = "";
+        size = 0;
     }
 
-    auto const size = std::size(input);
     auto top = tr_variant{};
     auto handler = parse_helpers::json_to_variant_handler{ &top };
     auto ms = rapidjson::MemoryStream{ begin, size };


### PR DESCRIPTION
With the old code, RapidJSON can access out-of-bounds memory if someone managed to pass `std::string_view{ nullptr, 4U }` into `parse_json()`.

Notes: Fixed possible crash when reading malformed JSON