### PR TITLE
refactor: add tr::serializer::to_value<T>(tr_variant::Map, tr_quark)

### DIFF
--- a/libtransmission/converters.h
+++ b/libtransmission/converters.h
@@ -223,6 +223,22 @@ template<typename T>
     return {};
 }
 
+// Alternative version of `to_value()` that takes a map + key
+template<typename T>
+[[nodiscard]] bool to_value(tr_variant::Map const& src, tr_quark const key, T* const ptgt)
+{
+    auto const iter = src.find(key);
+    return iter != src.end() && to_value(iter->second, ptgt);
+}
+
+// Alternative version of `to_value()` that takes a map + key and returns a std::optional
+template<typename T>
+[[nodiscard]] std::optional<T> to_value(tr_variant::Map const& src, tr_quark const key)
+{
+    auto const iter = src.find(key);
+    return iter != src.end() ? to_value<T>(iter->second) : std::nullopt;
+}
+
 // returns true iff the value changed
 template<typename T>
 bool set(T& tgt, T src)

--- a/tests/libtransmission/serializer-tests.cc
+++ b/tests/libtransmission/serializer-tests.cc
@@ -342,6 +342,65 @@ TEST_F(SerializerTest, optionalRejectsWrongType)
     EXPECT_EQ(out, "keep"s);
 }
 
+TEST_F(SerializerTest, mapKeyOutParamWritesValue)
+{
+    auto map = tr_variant::Map{};
+    map.insert_or_assign(TR_KEY_seed_ratio_limit, to_variant(2.5));
+    map.insert_or_assign(TR_KEY_address, to_variant("localhost"s));
+
+    auto ratio = 0.0;
+    EXPECT_TRUE(to_value(map, TR_KEY_seed_ratio_limit, &ratio));
+    EXPECT_DOUBLE_EQ(ratio, 2.5);
+
+    auto address = std::string{};
+    EXPECT_TRUE(to_value(map, TR_KEY_address, &address));
+    EXPECT_EQ(address, "localhost"s);
+}
+
+TEST_F(SerializerTest, mapKeyOutParamMissingKeyReturnsFalse)
+{
+    auto const map = tr_variant::Map{};
+
+    auto ratio = 9.0;
+    EXPECT_FALSE(to_value(map, TR_KEY_seed_ratio_limit, &ratio));
+    EXPECT_DOUBLE_EQ(ratio, 9.0);
+}
+
+TEST_F(SerializerTest, mapKeyOutParamWrongTypeReturnsFalse)
+{
+    auto map = tr_variant::Map{};
+    map.insert_or_assign(TR_KEY_dht_enabled, to_variant(true));
+
+    auto out = std::string{ "keep" };
+    EXPECT_FALSE(to_value(map, TR_KEY_dht_enabled, &out));
+    EXPECT_EQ(out, "keep"s);
+}
+
+TEST_F(SerializerTest, mapKeyOptionalReturnsValue)
+{
+    auto map = tr_variant::Map{};
+    map.insert_or_assign(TR_KEY_seed_ratio_limit, to_variant(2.5));
+
+    auto const ratio = to_value<double>(map, TR_KEY_seed_ratio_limit);
+    ASSERT_TRUE(ratio.has_value());
+    EXPECT_DOUBLE_EQ(*ratio, 2.5);
+}
+
+TEST_F(SerializerTest, mapKeyOptionalMissingKeyReturnsNullopt)
+{
+    auto const map = tr_variant::Map{};
+
+    EXPECT_FALSE(to_value<double>(map, TR_KEY_seed_ratio_limit).has_value());
+}
+
+TEST_F(SerializerTest, mapKeyOptionalWrongTypeReturnsNullopt)
+{
+    auto map = tr_variant::Map{};
+    map.insert_or_assign(TR_KEY_dht_enabled, to_variant(true));
+
+    EXPECT_FALSE(to_value<std::string>(map, TR_KEY_dht_enabled).has_value());
+}
+
 // ---
 
 using tr::serializer::Field;


### PR DESCRIPTION
Add a convenience function to do map lookup + tr::serializer conversion.