### PR TITLE
fix: -Wgnu-conditional-omitted-operand

### DIFF
--- a/libtransmission/string-utils.mm
+++ b/libtransmission/string-utils.mm
@@ -56,11 +56,11 @@ std::string tr_strv_to_utf8_string(NSString* str)
 NSString* tr_strv_to_utf8_nsstring(std::string_view const sv)
 {
     NSString* str = [[NSString alloc] initWithBytes:std::data(sv) length:std::size(sv) encoding:NSUTF8StringEncoding];
-    return str ?: @"";
+    return str != nil ? str : @"";
 }
 
 NSString* tr_strv_to_utf8_nsstring(std::string_view const sv, NSString* key, NSString* comment)
 {
     NSString* str = [[NSString alloc] initWithBytes:std::data(sv) length:std::size(sv) encoding:NSUTF8StringEncoding];
-    return str ?: NSLocalizedString(key, comment);
+    return str != nil ? str : NSLocalizedString(key, comment);
 }


### PR DESCRIPTION
fix a minor compiler warning:

> [135/834] Building CXX object libtransmission/CMakeFiles/transmission.dir/string-utils.mm.o
/Users/runner/work/transmission/transmission/src/libtransmission/string-utils.mm:59:17: warning: use of GNU ?: conditional expression extension, omitting middle operand [-Wgnu-conditional-omitted-operand]
   59 |     return str ?: @"";
      |                 ^
/Users/runner/work/transmission/transmission/src/libtransmission/string-utils.mm:65:17: warning: use of GNU ?: conditional expression extension, omitting middle operand [-Wgnu-conditional-omitted-operand]
   65 |     return str ?: NSLocalizedString(key, comment);
      |                 ^
