### PR TITLE
refactor: add `tr::platform` namespace, make `get_home_dir()` public

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -169,7 +169,7 @@ void onTorrentFileDownloaded(tr_web::FetchResponse const& response)
 
     tr_optind = ind;
 
-    return tr_getDefaultConfigDir(MyConfigName);
+    return tr::platform::get_default_config_dir(MyConfigName);
 }
 
 // ---

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -176,7 +176,7 @@ namespace
 
     tr_optind = ind;
 
-    return tr_getDefaultConfigDir(MyName);
+    return tr::platform::get_default_config_dir(MyName);
 }
 
 auto onFileAdded(tr_session* session, std::string_view dirname, std::string_view basename)

--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -36,7 +36,7 @@ std::string gl_confdir;
         return dir;
     }
 
-    return tr_getDefaultDownloadDir();
+    return tr::platform::get_download_dir();
 }
 
 /**

--- a/gtk/main.cc
+++ b/gtk/main.cc
@@ -121,7 +121,7 @@ int main(int argc, char** argv)
 
     /* set up the config dir */
     if (std::empty(config_dir)) {
-        config_dir = tr_getDefaultConfigDir(AppConfigDirName);
+        config_dir = tr::platform::get_default_config_dir(AppConfigDirName);
     }
 
     gtr_pref_init(config_dir);

--- a/libtransmission-app/prefs.h
+++ b/libtransmission-app/prefs.h
@@ -33,7 +33,6 @@ namespace tr::app
  *
  * Specializations should provide:
  *  - `static StringType from_utf8(std::string_view);`
- *  - `static StringType home_dir();`
  */
 template<typename StringType>
 struct PrefsStringTraits;
@@ -140,11 +139,11 @@ private:
     // whether we run an in-process session or are connected to a remote one.
     // Members are kept in descending-alignment order to minimize struct padding.
     std::chrono::sys_seconds blocklist_date_;
-    StringType dir_watch_ = Traits::from_utf8(tr_getDefaultDownloadDir());
+    StringType dir_watch_ = Traits::from_utf8(tr::platform::get_download_dir());
     StringType filter_text_;
     StringType filter_trackers_;
     StringType main_window_layout_order_ = Traits::from_utf8("menu,toolbar,filter,list,statusbar");
-    StringType open_dialog_folder_ = Traits::home_dir();
+    StringType open_dialog_folder_ = Traits::from_utf8(tr::platform::get_home_dir());
     StringType session_remote_host_ = Traits::from_utf8("localhost");
     StringType session_remote_password_;
     StringType session_remote_url_base_path_ = Traits::from_utf8("/transmission/");
@@ -189,7 +188,7 @@ private:
     // Kept in descending-alignment order to minimize struct padding.
     StringType blocklist_url_;
     StringType default_trackers_;
-    StringType download_dir_ = Traits::from_utf8(tr_getDefaultDownloadDir());
+    StringType download_dir_ = Traits::from_utf8(tr::platform::get_download_dir());
     StringType incomplete_dir_;
     StringType rpc_password_;
     StringType rpc_username_;

--- a/libtransmission/platform.cc
+++ b/libtransmission/platform.cc
@@ -71,7 +71,109 @@ auto win32_get_known_folder(REFKNOWNFOLDERID folder_id)
 }
 #endif
 
-std::string getHomeDir()
+std::string xdgConfigHome()
+{
+    if (auto dir = tr_env_get_string("XDG_CONFIG_HOME"sv); !std::empty(dir)) {
+        return dir;
+    }
+
+    return fmt::format("{:s}/.config"sv, tr::platform::get_home_dir());
+}
+
+std::string getXdgEntryFromUserDirs(std::string_view key)
+{
+    auto content = std::vector<char>{};
+    if (auto const filename = fmt::format("{:s}/{:s}"sv, xdgConfigHome(), "user-dirs.dirs"sv);
+        !tr_sys_path_exists(filename) || !tr_file_read(filename, content) || std::empty(content)) {
+        return {};
+    }
+
+    // search for key="val" and extract val
+    auto const search = fmt::format("{:s}=\"", key);
+    auto const [key_first, key_last] = std::ranges::search(content, search);
+    if (key_first == key_last) {
+        return {};
+    }
+    auto const end = std::find(key_last, content.end(), '"');
+    if (end == content.end()) {
+        return {};
+    }
+    auto val = std::string{ key_last, end };
+
+    // if val contains "$HOME", replace that with tr::platform::get_home_dir()
+    auto constexpr Home = "$HOME"sv;
+    if (auto const [home_first, home_last] = std::ranges::search(val, Home); home_first != home_last) {
+        val.replace(home_first, home_last, tr::platform::get_home_dir());
+    }
+
+    return val;
+}
+
+[[nodiscard]] bool isWebClientDir(std::string_view path)
+{
+    auto const filename = tr_pathbuf{ path, '/', "index.html"sv };
+    bool const found = tr_sys_path_exists(filename);
+    tr_logAddTrace(fmt::format("Searching for web interface file '{:s}'", filename));
+    return found;
+}
+} // namespace
+
+// ---
+
+namespace tr::platform
+{
+std::string get_default_config_dir(std::string_view appname)
+{
+    if (std::empty(appname)) {
+        appname = "Transmission"sv;
+    }
+
+    if (auto dir = tr_env_get_string("TRANSMISSION_HOME"sv); !std::empty(dir)) {
+        return dir;
+    }
+
+#ifdef __APPLE__
+
+    return fmt::format("{:s}/Library/Application Support/{:s}"sv, tr::platform::get_home_dir(), appname);
+
+#elif defined(_WIN32)
+
+    auto const appdata = win32_get_known_folder(FOLDERID_LocalAppData);
+    return fmt::format("{:s}/{:s}"sv, appdata, appname);
+
+#elif defined(__HAIKU__)
+
+    char buf[PATH_MAX];
+    find_directory(B_USER_SETTINGS_DIRECTORY, -1, true, buf, sizeof(buf));
+    return fmt::format("{:s}/{:s}"sv, buf, appname);
+
+#else
+
+    return fmt::format("{:s}/{:s}"sv, xdgConfigHome(), appname);
+
+#endif
+}
+
+std::string get_download_dir()
+{
+    if (auto dir = getXdgEntryFromUserDirs("XDG_DOWNLOAD_DIR"sv); !std::empty(dir)) {
+        return dir;
+    }
+
+#ifdef _WIN32
+    if (auto dir = win32_get_known_folder(FOLDERID_Downloads); !std::empty(dir)) {
+        return dir;
+    }
+#endif
+
+#ifdef __HAIKU__
+    return fmt::format("{:s}/Desktop"sv, tr::platform::get_home_dir());
+#endif
+
+    return fmt::format("{:s}/Downloads"sv, tr::platform::get_home_dir());
+}
+
+std::string get_home_dir()
 {
     if (auto dir = tr_env_get_string("HOME"sv); !std::empty(dir)) {
         return dir;
@@ -97,106 +199,7 @@ std::string getHomeDir()
 
     return {};
 }
-
-std::string xdgConfigHome()
-{
-    if (auto dir = tr_env_get_string("XDG_CONFIG_HOME"sv); !std::empty(dir)) {
-        return dir;
-    }
-
-    return fmt::format("{:s}/.config"sv, getHomeDir());
-}
-
-std::string getXdgEntryFromUserDirs(std::string_view key)
-{
-    auto content = std::vector<char>{};
-    if (auto const filename = fmt::format("{:s}/{:s}"sv, xdgConfigHome(), "user-dirs.dirs"sv);
-        !tr_sys_path_exists(filename) || !tr_file_read(filename, content) || std::empty(content)) {
-        return {};
-    }
-
-    // search for key="val" and extract val
-    auto const search = fmt::format("{:s}=\"", key);
-    auto const [key_first, key_last] = std::ranges::search(content, search);
-    if (key_first == key_last) {
-        return {};
-    }
-    auto const end = std::find(key_last, content.end(), '"');
-    if (end == content.end()) {
-        return {};
-    }
-    auto val = std::string{ key_last, end };
-
-    // if val contains "$HOME", replace that with getHomeDir()
-    auto constexpr Home = "$HOME"sv;
-    if (auto const [home_first, home_last] = std::ranges::search(val, Home); home_first != home_last) {
-        val.replace(home_first, home_last, getHomeDir());
-    }
-
-    return val;
-}
-
-[[nodiscard]] bool isWebClientDir(std::string_view path)
-{
-    auto const filename = tr_pathbuf{ path, '/', "index.html"sv };
-    bool const found = tr_sys_path_exists(filename);
-    tr_logAddTrace(fmt::format("Searching for web interface file '{:s}'", filename));
-    return found;
-}
-} // namespace
-
-// ---
-
-std::string tr_getDefaultConfigDir(std::string_view appname)
-{
-    if (std::empty(appname)) {
-        appname = "Transmission"sv;
-    }
-
-    if (auto dir = tr_env_get_string("TRANSMISSION_HOME"sv); !std::empty(dir)) {
-        return dir;
-    }
-
-#ifdef __APPLE__
-
-    return fmt::format("{:s}/Library/Application Support/{:s}"sv, getHomeDir(), appname);
-
-#elif defined(_WIN32)
-
-    auto const appdata = win32_get_known_folder(FOLDERID_LocalAppData);
-    return fmt::format("{:s}/{:s}"sv, appdata, appname);
-
-#elif defined(__HAIKU__)
-
-    char buf[PATH_MAX];
-    find_directory(B_USER_SETTINGS_DIRECTORY, -1, true, buf, sizeof(buf));
-    return fmt::format("{:s}/{:s}"sv, buf, appname);
-
-#else
-
-    return fmt::format("{:s}/{:s}"sv, xdgConfigHome(), appname);
-
-#endif
-}
-
-std::string tr_getDefaultDownloadDir()
-{
-    if (auto dir = getXdgEntryFromUserDirs("XDG_DOWNLOAD_DIR"sv); !std::empty(dir)) {
-        return dir;
-    }
-
-#ifdef _WIN32
-    if (auto dir = win32_get_known_folder(FOLDERID_Downloads); !std::empty(dir)) {
-        return dir;
-    }
-#endif
-
-#ifdef __HAIKU__
-    return fmt::format("{:s}/Desktop"sv, getHomeDir());
-#endif
-
-    return fmt::format("{:s}/Downloads"sv, getHomeDir());
-}
+} // namespace tr::platform
 
 // ---
 
@@ -268,7 +271,7 @@ std::string tr_getWebClientDir([[maybe_unused]] tr_session const* session)
     if (auto tmp = tr_env_get_string("XDG_DATA_HOME"sv); !std::empty(tmp)) {
         candidates.emplace_back(std::move(tmp));
     } else {
-        candidates.emplace_back(fmt::format("{:s}/.local/share"sv, getHomeDir()));
+        candidates.emplace_back(fmt::format("{:s}/.local/share"sv, tr::platform::get_home_dir()));
     }
 
     /* XDG_DATA_DIRS are the backup directories */

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -791,7 +791,7 @@ void tr_sessionSet(tr_session* session, tr::Settings const& settings)
 
 std::string tr::SessionSettings::get_default_download_dir()
 {
-    return tr_getDefaultDownloadDir();
+    return tr::platform::get_download_dir();
 }
 
 void tr::SessionSettings::fixup_from_preferred_transports()

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -30,6 +30,28 @@ struct tr_session;
 struct tr_torrent;
 struct tr_torrent_metainfo;
 
+namespace tr::platform
+{
+
+// return the env var 'TRANSMISSION_HOME' if it is set.
+// otherwise, return `${HOME}/Library/Application Support/${appname}` on macOS
+// otherwise, return `${FOLDERID_LocalAppData}/${appname}` on Windows
+// otherwise, return `${XDG_CONFIG_HOME:-{$HOME}/.config}/${appname}`
+[[nodiscard]] std::string get_default_config_dir(std::string_view appname);
+
+// return the env var 'XDG_DOWNLOAD_DIR' if it is set and exists.
+// otherwise, returns FOLDERID_Downloads if we're on Windows and it's set and exists
+// otherwise, returns `${HOME}/Desktop` if we're on Haiku
+// otherwise, returns `${HOME}/Downloads`
+[[nodiscard]] std::string get_download_dir();
+
+// return the env var 'HOME' if it is set.
+// otherwise, return FOLDERID_Profile if we're on Windows and it's set.
+// otherwise, return getpwuid_r(getuid())
+[[nodiscard]] std::string get_home_dir();
+
+} // namespace tr::platform
+
 // --- Startup & Shutdown
 
 /**
@@ -42,28 +64,6 @@ struct tr_torrent_metainfo;
  *
  * @{
  */
-
-/**
- * @brief get Transmission's default configuration file directory.
- *
- * The default configuration directory is determined this way:
- * -# If the `TRANSMISSION_HOME` environment variable is set, its value is used.
- * -# On Darwin, `"${HOME}/Library/Application Support/${appname}"` is used.
- * -# On Windows, `"${CSIDL_APPDATA}/${appname}"` is used.
- * -# If `XDG_CONFIG_HOME` is set, `"${XDG_CONFIG_HOME}/${appname}"` is used.
- * -# `"${HOME}/.config/${appname}"` is used as a last resort.
- */
-[[nodiscard]] std::string tr_getDefaultConfigDir(std::string_view appname);
-
-/**
- * @brief returns Transmission's default download directory.
- *
- * The default download directory is determined this way:
- * -# If the `HOME` environment variable is set, `"${HOME}/Downloads"` is used.
- * -# On Windows, `"${CSIDL_MYDOCUMENTS}/Downloads"` is used.
- * -# Otherwise, `getpwuid(getuid())->pw_dir + "/Downloads"` is used.
- */
-[[nodiscard]] std::string tr_getDefaultDownloadDir();
 
 // Get a session's default settings
 [[nodiscard]] tr::Settings tr_sessionGetDefaultSettings();

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -481,7 +481,7 @@ static void removeKeRangerRansomware()
 
         initUnits();
 
-        auto const default_config_dir = tr_getDefaultConfigDir("Transmission");
+        auto const default_config_dir = tr::platform::get_default_config_dir("Transmission");
         _fLib = tr_sessionInit(default_config_dir, YES, settings);
         _fConfigDirectory = @(default_config_dir.c_str());
 

--- a/qt/main.cc
+++ b/qt/main.cc
@@ -243,7 +243,7 @@ int tr_main(int argc, char** argv)
 
     // set the fallback config dir
     if (config_dir.isNull()) {
-        config_dir = QString::fromStdString(tr_getDefaultConfigDir("transmission"));
+        config_dir = QString::fromStdString(tr::platform::get_default_config_dir("transmission"));
     }
 
     // initialize the prefs

--- a/tests/libtransmission/platform-test.cc
+++ b/tests/libtransmission/platform-test.cc
@@ -34,7 +34,7 @@ TEST_F(PlatformTest, defaultDownloadDirXdg)
     setenv("XDG_CONFIG_HOME", LIBTRANSMISSION_TEST_ASSETS_DIR, 1);
 
     auto const expected = fmt::format("{:s}/UserDirsDownloads"sv, sandboxDir());
-    auto const actual = tr_getDefaultDownloadDir();
+    auto const actual = tr::platform::get_download_dir();
     EXPECT_EQ(expected, actual);
 
     unsetenv("XDG_CONFIG_HOME");
@@ -47,7 +47,7 @@ TEST_F(PlatformTest, defaultDownloadDir)
     setenv("HOME", sandboxDir().c_str(), 1);
 
     auto const expected = fmt::format("{:s}/Downloads"sv, sandboxDir());
-    auto const actual = tr_getDefaultDownloadDir();
+    auto const actual = tr::platform::get_download_dir();
     EXPECT_EQ(expected, actual);
 
     unsetenv("HOME");
@@ -59,7 +59,7 @@ TEST_F(PlatformTest, defaultConfigDirEnv)
     setenv("TRANSMISSION_HOME", sandboxDir().c_str(), 1);
 
     auto const expected = sandboxDir();
-    auto const actual = tr_getDefaultConfigDir("appname");
+    auto const actual = tr::platform::get_default_config_dir("appname");
     EXPECT_EQ(expected, actual);
 
     unsetenv("TRANSMISSION_HOME");
@@ -72,7 +72,7 @@ TEST_F(PlatformTest, defaultConfigDirXdgConfig)
     setenv("XDG_CONFIG_HOME", sandboxDir().c_str(), 1);
 
     auto const expected = fmt::format("{:s}/appname", sandboxDir());
-    auto const actual = tr_getDefaultConfigDir("appname");
+    auto const actual = tr::platform::get_default_config_dir("appname");
     EXPECT_EQ(expected, actual);
 
     unsetenv("XDG_CONFIG_HOME");
@@ -86,7 +86,7 @@ TEST_F(PlatformTest, defaultConfigDirXdgConfigHome)
     setenv("HOME", home.c_str(), 1);
 
     auto const expected = fmt::format("{:s}/.config/appname", home.sv());
-    auto const actual = tr_getDefaultConfigDir("appname");
+    auto const actual = tr::platform::get_default_config_dir("appname");
     EXPECT_EQ(expected, actual);
 
     unsetenv("HOME");


### PR DESCRIPTION
Minor cleanup / modernization of the platform utils public API.