### PR TITLE
refactor: add multi-Serializer capabilities to `tr::serializer`

### DIFF
--- a/libtransmission-app/prefs.h
+++ b/libtransmission-app/prefs.h
@@ -52,12 +52,12 @@ public:
 
     explicit Prefs(tr::Settings const& settings)
     {
-        tr::serializer::load(*this, Fields, settings);
+        tr::serializer::load(settings, *this, Fields);
     }
 
     explicit Prefs(std::string_view config_dir)
     {
-        tr::serializer::load(*this, Fields, tr_sessionLoadSettings(config_dir));
+        tr::serializer::load(tr_sessionLoadSettings(config_dir), *this, Fields);
     }
 
     Prefs(Prefs&&) = delete;
@@ -68,7 +68,7 @@ public:
 
     [[nodiscard]] std::pair<tr_quark, tr_variant> keyval(tr_quark const key) const
     {
-        if (auto val = tr::serializer::to_variant(*this, key)) {
+        if (auto val = tr::serializer::to_variant(key, *this)) {
             return { key, std::move(*val) };
         }
 
@@ -77,7 +77,7 @@ public:
 
     void set(tr_quark const key, tr_variant const& var)
     {
-        if (tr::serializer::set_from_variant(*this, key, var)) {
+        if (tr::serializer::set_from_variant(key, var, *this)) {
             on_changed(key);
         }
     }
@@ -85,7 +85,7 @@ public:
     template<typename T>
     void set(tr_quark const key, T const& val)
     {
-        if (tr::serializer::set(*this, key, val)) {
+        if (tr::serializer::set(key, val, *this)) {
             on_changed(key);
         }
     }
@@ -95,7 +95,7 @@ public:
     template<typename T>
     [[nodiscard]] T get(tr_quark const key) const
     {
-        auto const val = tr::serializer::get<T>(*this, key);
+        auto const val = tr::serializer::get<T>(key, *this);
         assert(val.has_value());
         return val.value_or(T{});
     }

--- a/libtransmission/serializer.h
+++ b/libtransmission/serializer.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <concepts>
 #include <cstddef>
 #include <optional>
@@ -116,13 +117,191 @@ concept Serializable = requires {
     { std::tuple_size_v<std::remove_cvref_t<decltype(T::Fields)>> } -> std::convertible_to<std::size_t>;
 } && detail::is_fields_tuple_v<std::remove_cvref_t<decltype(T::Fields)>>;
 
-template<Serializable S>
-[[nodiscard]] std::optional<tr_variant> to_variant(S const& src, tr_quark key);
-
-template<typename T, Serializable S>
-[[nodiscard]] std::optional<T> get(S const& src, tr_quark key)
+/**
+ * Compile-time check that no serialization key is shared between the
+ * given Serializable types' `Fields`. Example:
+ * static_assert(has_unique_keys<SessionSettings, RpcServerSettings>());
+ */
+template<Serializable... S>
+[[nodiscard]] constexpr bool has_unique_keys()
 {
-    if (auto value = to_variant(src, key)) {
+    constexpr auto Total = (std::size_t{ 0 } + ... + std::tuple_size_v<std::remove_cvref_t<decltype(S::Fields)>>);
+
+    auto keys = std::array<tr_quark, Total>{};
+    auto idx = std::size_t{ 0 };
+    auto append_keys = [&keys, &idx](auto const& fields) {
+        std::apply([&keys, &idx](auto const&... field) { ((keys[idx++] = field.key), ...); }, fields);
+    };
+    (append_keys(S::Fields), ...);
+
+    std::ranges::sort(keys);
+    return std::ranges::adjacent_find(keys) == std::end(keys);
+}
+
+/**
+ * Returns `true` iff any of the given Serializables has a field with `key`.
+ * Example: has_key(TR_KEY_peer_port, session_settings, rpc_server_settings)
+ */
+template<Serializable... S>
+[[nodiscard]] bool has_key(tr_quark key, S const&... /*objs*/)
+{
+    auto fields_contain = [key](auto const& fields) {
+        auto found = false;
+        std::apply([key, &found](auto const&... field) { ((found = found || field.key == key), ...); }, fields);
+        return found;
+    };
+    return (fields_contain(S::Fields) || ...);
+}
+
+/**
+ * Compile-time check whether any of the given Serializable types has a
+ * field with `key`. Takes the Serializables as template arguments so it
+ * can be used in constant expressions. Example:
+ * static_assert(has_key<SessionSettings, RpcServerSettings>(TR_KEY_utp_enabled));
+ */
+template<Serializable... S>
+[[nodiscard]] constexpr bool has_key(tr_quark key)
+{
+    auto fields_contain = [key](auto const& fields) {
+        auto found = false;
+        std::apply([key, &found](auto const&... field) { ((found = found || field.key == key), ...); }, fields);
+        return found;
+    };
+    return (fields_contain(S::Fields) || ...);
+}
+
+namespace detail
+{
+
+// --- Group B workers: operate on a single Serializable, keyed by `tr_quark` ---
+
+template<Serializable S>
+[[nodiscard]] std::optional<tr_variant> to_variant_one(S const& src, tr_quark key)
+{
+    auto result = std::optional<tr_variant>{};
+    auto try_field = [&](auto const& field) {
+        if (field.key != key) {
+            return false;
+        }
+
+        auto map = tr_variant::Map{ 1U };
+        field.save(&src, map);
+
+        if (auto const iter = map.find(key); iter != std::end(map)) {
+            result = iter->second.clone();
+        }
+
+        return true;
+    };
+
+    std::apply([&](auto const&... field) { (try_field(field) || ...); }, S::Fields);
+    return result;
+}
+
+// returns `true` iff `key` names a field in `S`; sets `changed` iff its value changed
+template<Serializable S>
+bool set_from_variant_one(S& tgt, tr_quark key, tr_variant const& value, bool& changed)
+{
+    auto matched = false;
+    auto try_field = [&](auto const& field) {
+        if (field.key != key) {
+            return false;
+        }
+
+        matched = true;
+        using FieldType = std::remove_cvref_t<decltype(field)>;
+        changed = set(tgt.*(FieldType::MemberPointer), value);
+        return true;
+    };
+
+    std::apply([&](auto const&... field) { (try_field(field) || ...); }, S::Fields);
+    return matched;
+}
+
+// returns `true` iff `key` names a field in `S`; sets `type_ok`/`changed` accordingly
+template<typename T, Serializable S>
+bool set_one(S& tgt, tr_quark key, T& val, bool& type_ok, bool& changed)
+{
+    auto matched = false;
+    auto try_field = [&](auto const& field) {
+        if (field.key != key) {
+            return false;
+        }
+
+        matched = true;
+        using FieldType = std::remove_cvref_t<decltype(field)>;
+        if constexpr (std::is_same_v<T, typename FieldType::value_type>) {
+            changed = set(tgt.*(FieldType::MemberPointer), std::move(val));
+        } else {
+            type_ok = false;
+        }
+
+        return true;
+    };
+
+    std::apply([&](auto const&... field) { (try_field(field) || ...); }, S::Fields);
+    return matched;
+}
+
+// --- Group A workers: operate on a coupled (object, Fields) pair ---
+
+template<typename T, typename Fields>
+void save_one(T const& src, Fields const& fields, tr_variant::Map& map)
+{
+    std::apply([&src, &map](auto const&... field) { (field.save(&src, map), ...); }, fields);
+}
+
+template<typename T, typename Fields, typename ChangedKeys>
+void load_one(T& tgt, Fields const& fields, tr_variant::Map const& src, ChangedKeys& changed_keys)
+{
+    std::apply(
+        [&tgt, &src, &changed_keys](auto const&... field) {
+            (
+                [&] {
+                    if (field.load(&tgt, src)) {
+                        changed_keys.emplace_back(field.key);
+                    }
+                }(),
+                ...);
+        },
+        fields);
+}
+
+// Sum of `tuple_size` over the `Fields` (odd-indexed) elements of a flattened
+// pack of (object, Fields) pairs.
+template<typename ArgTuple, std::size_t... PairIndex>
+[[nodiscard]] consteval std::size_t pair_fields_capacity(std::index_sequence<PairIndex...> /*pairs*/)
+{
+    return (
+        std::size_t{ 0 } + ... + std::tuple_size_v<std::remove_cvref_t<std::tuple_element_t<(2 * PairIndex) + 1, ArgTuple>>>);
+}
+
+} // namespace detail
+
+/**
+ * Get the value of `key` as a variant, searching one or more Serializables in
+ * order. The first object whose `Fields` contains `key` wins; use
+ * `has_unique_keys()` to guarantee at most one owner.
+ */
+template<Serializable S, Serializable... Ss>
+[[nodiscard]] std::optional<tr_variant> to_variant(tr_quark const key, S const& src, Ss const&... srcs)
+{
+    auto result = detail::to_variant_one(src, key);
+    if constexpr (sizeof...(Ss) != 0U) {
+        auto try_next = [&result, key](auto const& obj) {
+            if (!result) {
+                result = detail::to_variant_one(obj, key);
+            }
+        };
+        (try_next(srcs), ...);
+    }
+    return result;
+}
+
+template<typename T, Serializable S, Serializable... Ss>
+[[nodiscard]] std::optional<T> get(tr_quark const key, S const& src, Ss const&... srcs)
+{
+    if (auto value = to_variant(key, src, srcs...)) {
         return to_value<T>(*value);
     }
 
@@ -165,123 +344,160 @@ constexpr bool set(S& tgt, T val)
     return true;
 }
 
-template<Serializable S>
-[[nodiscard]] std::optional<tr_variant> to_variant(S const& src, tr_quark key)
-{
-    auto result = std::optional<tr_variant>{};
-    auto try_field = [&](auto const& field) {
-        if (field.key != key) {
-            return false;
-        }
-
-        auto map = tr_variant::Map{ 1U };
-        field.save(&src, map);
-
-        if (auto const iter = map.find(key); iter != std::end(map)) {
-            result = iter->second.clone();
-        }
-
-        return true;
-    };
-
-    std::apply([&](auto const&... field) { (try_field(field) || ...); }, S::Fields);
-    return result;
-}
-
-template<Serializable S>
-bool set_from_variant(S& tgt, tr_quark key, tr_variant const& value)
-{
-    auto changed = false;
-    auto try_field = [&](auto const& field) {
-        if (field.key != key) {
-            return false;
-        }
-
-        using FieldType = std::remove_cvref_t<decltype(field)>;
-        changed = set(tgt.*(FieldType::MemberPointer), value);
-        return true;
-    };
-
-    std::apply([&](auto const&... field) { (try_field(field) || ...); }, S::Fields);
-    return changed;
-}
-
-template<typename T, Serializable S>
-bool set(S& tgt, tr_quark key, T val)
+/**
+ * Set `key` to `val` in whichever of the given Serializables owns it. Returns
+ * `true` iff a matching field was found, had the same value type, and changed.
+ */
+template<typename T, Serializable S, Serializable... Ss>
+bool set(tr_quark const key, T val, S& tgt, Ss&... tgts)
 {
     auto type_ok = true;
     auto changed = false;
-
-    auto try_field = [&](auto const& field) {
-        if (field.key != key) {
-            return false;
+    auto matched = false;
+    auto try_next = [&](auto& obj) {
+        if (!matched) {
+            matched = detail::set_one(obj, key, val, type_ok, changed);
         }
-
-        using FieldType = std::remove_cvref_t<decltype(field)>;
-        if constexpr (std::is_same_v<T, typename FieldType::value_type>) {
-            changed = set(tgt.*(FieldType::MemberPointer), std::move(val));
-        } else {
-            type_ok = false;
-        }
-
-        return true;
     };
-
-    std::apply([&](auto const&... field) { (try_field(field) || ...); }, S::Fields);
+    try_next(tgt);
+    (try_next(tgts), ...);
     return type_ok && changed;
 }
 
 /**
- * Load fields from a variant map into a target object.
+ * Apply a variant `value` to `key` in whichever of the given Serializables owns
+ * it. Returns `true` iff a matching field was found and its value changed.
+ */
+template<Serializable S, Serializable... Ss>
+bool set_from_variant(tr_quark const key, tr_variant const& value, S& tgt, Ss&... tgts)
+{
+    auto changed = false;
+    auto matched = false;
+    auto try_next = [&](auto& obj) {
+        if (!matched) {
+            auto obj_changed = false;
+            if (detail::set_from_variant_one(obj, key, value, obj_changed)) {
+                matched = true;
+                changed = obj_changed;
+            }
+        }
+    };
+    try_next(tgt);
+    (try_next(tgts), ...);
+    return changed;
+}
+
+/**
+ * Load a source variant map into one or more coupled (target, Fields) pairs.
  * Missing keys are silently ignored (fields retain their existing values).
  *
- * @param tgt The object to populate
- * @param fields A tuple of Field<> descriptors
- * @param src The source variant (expected to be a Map)
- * @return changed_keys sorted keys of fields that changed
+ * @param src    The source variant map
+ * @param args   One or more (target object, Fields tuple) pairs
+ * @return       sorted keys of fields that changed, across all pairs
+ *
+ * Example: load(src, session_settings, SessionSettings::Fields, rpc, RpcServerSettings::Fields)
  */
-template<typename T, typename Fields>
-auto load(T& tgt, Fields const& fields, tr_variant::Map const& src)
+template<typename... Args>
+auto load(tr_variant::Map const& src, Args&&... args)
 {
-    auto changed_keys = small::vector<tr_quark, std::tuple_size_v<Fields>>{};
-    std::apply(
-        [&tgt, &src, &changed_keys](auto const&... field) {
-            (
-                [&] {
-                    if (field.load(&tgt, src)) {
-                        changed_keys.emplace_back(field.key);
-                    }
-                }(),
-                ...);
-        },
-        fields);
+    static_assert(
+        sizeof...(Args) != 0U && sizeof...(Args) % 2U == 0U,
+        "load() expects a source followed by one or more (target, Fields) pairs");
+
+    constexpr auto PairCount = sizeof...(Args) / 2U;
+    auto arg_tuple = std::forward_as_tuple(std::forward<Args>(args)...);
+    using ArgTuple = std::remove_cvref_t<decltype(arg_tuple)>;
+    constexpr auto Capacity = detail::pair_fields_capacity<ArgTuple>(std::make_index_sequence<PairCount>{});
+
+    auto changed_keys = small::vector<tr_quark, Capacity>{};
+    [&]<std::size_t... PairIndex>(std::index_sequence<PairIndex...> /*pairs*/) {
+        (detail::load_one(std::get<2U * PairIndex>(arg_tuple), std::get<(2U * PairIndex) + 1U>(arg_tuple), src, changed_keys),
+         ...);
+    }(std::make_index_sequence<PairCount>{});
+
     std::ranges::sort(changed_keys);
     return changed_keys;
 }
 
-template<typename T, typename Fields>
-auto load(T& tgt, Fields const& fields, tr_variant const& src)
+template<typename... Args>
+auto load(tr_variant const& src, Args&&... args)
 {
+    static_assert(
+        sizeof...(Args) != 0U && sizeof...(Args) % 2U == 0U,
+        "load() expects a source followed by one or more (target, Fields) pairs");
+
+    constexpr auto PairCount = sizeof...(Args) / 2U;
+    using ArgTuple = std::tuple<Args&&...>;
+    constexpr auto Capacity = detail::pair_fields_capacity<ArgTuple>(std::make_index_sequence<PairCount>{});
+
     if (auto const* const map = src.get_if<tr_variant::Map>()) {
-        return load(tgt, fields, *map);
+        return load(*map, std::forward<Args>(args)...);
     }
 
-    return small::vector<tr_quark, std::tuple_size_v<Fields>>{};
+    return small::vector<tr_quark, Capacity>{};
 }
 
 /**
- * Save an object's fields to a variant map.
+ * Load a source into one or more Serializables, inferring each target's
+ * `Fields`. Delegates to the (target, Fields)-pair overload above.
  *
- * @param src    The object to serialize
- * @param fields A tuple of Field<> descriptors
- * @return       A tr_variant::Map containing the serialized fields
+ * Example: load(src, session_settings, alt_speed_settings, rpc_server_settings)
  */
-template<typename T, typename Fields>
-[[nodiscard]] tr_variant::Map save(T const& src, Fields const& fields)
+template<Serializable S, Serializable... Ss>
+auto load(tr_variant::Map const& src, S& tgt, Ss&... tgts)
 {
-    auto map = tr_variant::Map{ std::tuple_size_v<std::remove_cvref_t<Fields>> };
-    std::apply([&src, &map](auto const&... field) { (field.save(&src, map), ...); }, fields);
+    static_assert(has_unique_keys<S, Ss...>(), "load() requires the objects to have globally unique keys");
+    return std::apply(
+        [&src](auto&&... args) { return load(src, args...); },
+        std::tuple_cat(std::forward_as_tuple(tgt, S::Fields), std::forward_as_tuple(tgts, Ss::Fields)...));
+}
+
+template<Serializable S, Serializable... Ss>
+auto load(tr_variant const& src, S& tgt, Ss&... tgts)
+{
+    static_assert(has_unique_keys<S, Ss...>(), "load() requires the objects to have globally unique keys");
+    return std::apply(
+        [&src](auto&&... args) { return load(src, args...); },
+        std::tuple_cat(std::forward_as_tuple(tgt, S::Fields), std::forward_as_tuple(tgts, Ss::Fields)...));
+}
+
+/**
+ * Save one or more coupled (object, Fields) pairs into a single variant map.
+ *
+ * @param args One or more (source object, Fields tuple) pairs
+ * @return     A tr_variant::Map containing the serialized fields of every pair
+ *
+ * Example: save(session_settings, SessionSettings::Fields, rpc, RpcServerSettings::Fields)
+ */
+template<typename... Args>
+[[nodiscard]] tr_variant::Map save(Args const&... args)
+{
+    static_assert(sizeof...(Args) != 0U && sizeof...(Args) % 2U == 0U, "save() expects one or more (object, Fields) pairs");
+
+    constexpr auto PairCount = sizeof...(Args) / 2U;
+    auto const arg_tuple = std::forward_as_tuple(args...);
+    using ArgTuple = std::remove_cvref_t<decltype(arg_tuple)>;
+
+    auto map = tr_variant::Map{ detail::pair_fields_capacity<ArgTuple>(std::make_index_sequence<PairCount>{}) };
+    [&]<std::size_t... PairIndex>(std::index_sequence<PairIndex...> /*pairs*/) {
+        (detail::save_one(std::get<2U * PairIndex>(arg_tuple), std::get<(2U * PairIndex) + 1U>(arg_tuple), map), ...);
+    }(std::make_index_sequence<PairCount>{});
     return map;
+}
+
+/**
+ * Save one or more Serializables into a single variant map, inferring each
+ * object's `Fields`. Delegates to the (object, Fields)-pair overload above.
+ *
+ * Example: save(session_settings, alt_speed_settings, rpc_server_settings)
+ */
+template<Serializable S, Serializable... Ss>
+[[nodiscard]] tr_variant::Map save(S const& obj, Ss const&... objs)
+{
+    static_assert(has_unique_keys<S, Ss...>(), "save() requires the objects to have globally unique keys");
+    return std::apply(
+        [](auto const&... args) { return save(args...); },
+        std::tuple_cat(std::forward_as_tuple(obj, S::Fields), std::forward_as_tuple(objs, Ss::Fields)...));
 }
 
 } // namespace tr::serializer

--- a/libtransmission/session-settings.h
+++ b/libtransmission/session-settings.h
@@ -66,18 +66,13 @@ public:
 
     void load(tr::Settings const& src)
     {
-        tr::serializer::load(*this, Fields, src);
+        tr::serializer::load(src, *this, Fields);
 
         if (src.contains(TR_KEY_preferred_transports)) {
             fixup_from_preferred_transports();
         } else {
             fixup_to_preferred_transports();
         }
-    }
-
-    [[nodiscard]] tr::Settings save() const
-    {
-        return tr::serializer::save(*this, Fields);
     }
 
     [[nodiscard]] static constexpr auto const& fields() noexcept
@@ -236,12 +231,7 @@ public:
 
     void load(tr::Settings const& src)
     {
-        tr::serializer::load(*this, Fields, src);
-    }
-
-    [[nodiscard]] tr::Settings save() const
-    {
-        return tr::serializer::save(*this, Fields);
+        tr::serializer::load(src, *this, Fields);
     }
 
     [[nodiscard]] static constexpr auto const& fields() noexcept
@@ -283,12 +273,7 @@ public:
 
     void load(tr::Settings const& src)
     {
-        tr::serializer::load(*this, Fields, src);
-    }
-
-    [[nodiscard]] tr::Settings save() const
-    {
-        return tr::serializer::save(*this, Fields);
+        tr::serializer::load(src, *this, Fields);
     }
 
     [[nodiscard]] static constexpr auto const& fields() noexcept
@@ -332,4 +317,10 @@ public:
         Field<&RpcServerSettings::whitelist_str>{ TR_KEY_rpc_whitelist },
         Field<&RpcServerSettings::is_whitelist_enabled>{ TR_KEY_rpc_whitelist_enabled });
 };
+
+[[nodiscard]] constexpr bool is_settings_key(tr_quark const key)
+{
+    return tr::serializer::has_key<tr::RpcServerSettings, tr::SessionAltSpeedSettings, tr::SessionSettings>(key);
+}
+
 } // namespace tr

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -68,6 +68,8 @@ struct tr_ctor;
 using namespace std::literals;
 using namespace tr::Values;
 
+static_assert(tr::serializer::has_unique_keys<tr::SessionSettings, tr::SessionAltSpeedSettings, tr::RpcServerSettings>());
+
 namespace
 {
 [[nodiscard]] auto get_settings_filename(std::string_view const config_dir)
@@ -426,10 +428,7 @@ tr_address tr_session::bind_address(tr_address_type type) const noexcept
 
 tr::Settings tr_sessionGetDefaultSettings()
 {
-    auto ret = tr::Settings{};
-    ret.merge(tr::SessionSettings{}.save());
-    ret.merge(tr::SessionAltSpeedSettings{}.save());
-    ret.merge(tr::RpcServerSettings{}.save());
+    auto ret = tr::serializer::save(tr::SessionSettings{}, tr::SessionAltSpeedSettings{}, tr::RpcServerSettings{});
 
     // TODO(5.0.0): remove this if block
     // N.B. Because `tr::SessionSettings::load()` calls
@@ -447,10 +446,7 @@ tr::Settings tr_sessionGetDefaultSettings()
 
 tr::Settings tr_sessionGetSettings(tr_session const* session)
 {
-    auto settings = tr::Settings{};
-    settings.merge(session->settings_.save());
-    settings.merge(session->alt_speeds_.settings().save());
-    settings.merge(session->rpc_server_->settings().save());
+    auto settings = tr::serializer::save(session->settings_, session->alt_speeds_.settings(), session->rpc_server_->settings());
     settings.insert_or_assign(TR_KEY_message_level, tr::serializer::to_variant(tr_logGetLevel()));
     return settings;
 }

--- a/libtransmission/stats.cc
+++ b/libtransmission/stats.cc
@@ -56,7 +56,7 @@ tr_session_stats tr_stats::load_old_stats(std::string_view const config_dir)
 
     api_compat::convert_incoming_data(*var);
     auto ret = tr_session_stats{};
-    serializer::load(ret, Fields, *var);
+    serializer::load(*var, ret, Fields);
     return ret;
 }
 

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -127,6 +127,15 @@ public:
             return 0U;
         }
 
+        // std::erase_if-style helper: removes every element for which
+        // `pred(std::pair<tr_quark, tr_variant> const&)` is true and
+        // returns the number of elements removed.
+        template<typename Predicate>
+        auto erase_if(Predicate pred)
+        {
+            return std::erase_if(vec_, std::move(pred));
+        }
+
         constexpr bool replace_key(tr_quark const old_key, tr_quark const new_key)
         {
             if (contains(new_key)) {

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -715,7 +715,7 @@ void Session::updateStats(tr_variant const& args_dict, tr_session_stats& stats)
         tr::serializer::Field<&tr_session_stats::sessionCount>{ TR_KEY_session_count },
         tr::serializer::Field<&tr_session_stats::uploadedBytes>{ TR_KEY_uploaded_bytes },
     };
-    tr::serializer::load(stats, Fields, args_dict);
+    tr::serializer::load(args_dict, stats, Fields);
 
     stats.ratio = static_cast<float>(tr_getRatio(stats.uploadedBytes, stats.downloadedBytes));
 }

--- a/qt/VariantHelpers.cc
+++ b/qt/VariantHelpers.cc
@@ -30,17 +30,17 @@ namespace trqt::variant_helpers
 
 bool change(Peer& setme, tr_variant const* value)
 {
-    return !ser::load(setme, Peer::Fields, *value).empty();
+    return !ser::load(*value, setme, Peer::Fields).empty();
 }
 
 bool change(TorrentFile& setme, tr_variant const* value)
 {
-    return !ser::load(setme, TorrentFile::Fields, *value).empty();
+    return !ser::load(*value, setme, TorrentFile::Fields).empty();
 }
 
 bool change(TrackerStat& setme, tr_variant const* value)
 {
-    auto const changed_keys = ser::load(setme, TrackerStat::Fields, *value);
+    auto const changed_keys = ser::load(*value, setme, TrackerStat::Fields);
     auto const site_changed = std::ranges::binary_search(changed_keys, TR_KEY_announce) ||
         std::ranges::binary_search(changed_keys, TR_KEY_sitename);
 

--- a/tests/libtransmission/serializer-tests.cc
+++ b/tests/libtransmission/serializer-tests.cc
@@ -462,7 +462,7 @@ TEST_F(SerializerTest, fieldSaveLoad)
     // Load back into a new instance
     auto actual = Endpoint{};
     EXPECT_NE(actual, expected);
-    load(actual, Endpoint::Fields, var);
+    load(var, actual, Endpoint::Fields);
     EXPECT_EQ(actual, expected);
 }
 
@@ -471,7 +471,7 @@ TEST_F(SerializerTest, fieldLoadIgnoresMissingKeys)
     auto endpoint = Endpoint{ .address = "default", .port = tr_port::from_host(9999) };
     auto const original = endpoint;
 
-    load(endpoint, Endpoint::Fields, tr_variant::make_map());
+    load(tr_variant::make_map(), endpoint, Endpoint::Fields);
 
     // Should remain unchanged
     EXPECT_EQ(original, endpoint);
@@ -482,7 +482,7 @@ TEST_F(SerializerTest, fieldLoadIgnoresNonMap)
     auto endpoint = Endpoint{ .address = "default", .port = tr_port::from_host(9999) };
     auto const original = endpoint;
 
-    load(endpoint, Endpoint::Fields, tr_variant{ 42 });
+    load(tr_variant{ 42 }, endpoint, Endpoint::Fields);
 
     // Should remain unchanged
     EXPECT_EQ(original, endpoint);
@@ -492,18 +492,18 @@ TEST_F(SerializerTest, serializableGetByKey)
 {
     auto const endpoint = Endpoint{ .address = "localhost", .port = tr_port::from_host(TrDefaultPeerPort) };
 
-    auto const addr = get<std::string>(endpoint, TR_KEY_address);
+    auto const addr = get<std::string>(TR_KEY_address, endpoint);
     ASSERT_TRUE(addr.has_value());
     EXPECT_EQ(*addr, "localhost");
 
-    auto const port = get<tr_port>(endpoint, TR_KEY_port);
+    auto const port = get<tr_port>(TR_KEY_port, endpoint);
     ASSERT_TRUE(port.has_value());
     EXPECT_EQ(*port, tr_port::from_host(TrDefaultPeerPort));
 
-    auto const missing = get<std::string>(endpoint, TR_KEY_comment);
+    auto const missing = get<std::string>(TR_KEY_comment, endpoint);
     EXPECT_FALSE(missing.has_value());
 
-    auto const wrong_type = get<int>(endpoint, TR_KEY_address);
+    auto const wrong_type = get<int>(TR_KEY_address, endpoint);
     EXPECT_FALSE(wrong_type.has_value());
 }
 
@@ -511,16 +511,16 @@ TEST_F(SerializerTest, serializableSetByKey)
 {
     auto endpoint = Endpoint{ .address = "localhost", .port = tr_port::from_host(TrDefaultPeerPort) };
 
-    EXPECT_TRUE(set(endpoint, TR_KEY_address, std::string{ "example.com" }));
+    EXPECT_TRUE(set(TR_KEY_address, std::string{ "example.com" }, endpoint));
     EXPECT_EQ(endpoint.address, "example.com");
 
-    EXPECT_FALSE(set(endpoint, TR_KEY_address, std::string{ "example.com" }));
+    EXPECT_FALSE(set(TR_KEY_address, std::string{ "example.com" }, endpoint));
 
-    EXPECT_FALSE(set(endpoint, TR_KEY_comment, std::string{ "no field" }));
+    EXPECT_FALSE(set(TR_KEY_comment, std::string{ "no field" }, endpoint));
 
-    EXPECT_FALSE(set(endpoint, TR_KEY_address, 42));
+    EXPECT_FALSE(set(TR_KEY_address, 42, endpoint));
 
-    EXPECT_TRUE(set(endpoint, TR_KEY_port, tr_port::from_host(1234)));
+    EXPECT_TRUE(set(TR_KEY_port, tr_port::from_host(1234), endpoint));
     EXPECT_EQ(endpoint.port, tr_port::from_host(1234));
 }
 
@@ -528,28 +528,28 @@ TEST_F(SerializerTest, serializableToVariantByKey)
 {
     auto const endpoint = Endpoint{ .address = "localhost", .port = tr_port::from_host(TrDefaultPeerPort) };
 
-    auto const address = to_variant(endpoint, TR_KEY_address);
+    auto const address = to_variant(TR_KEY_address, endpoint);
     ASSERT_TRUE(address);
     EXPECT_EQ("localhost"sv, address->value_if<std::string_view>().value_or(""sv));
 
-    auto const port = to_variant(endpoint, TR_KEY_port);
+    auto const port = to_variant(TR_KEY_port, endpoint);
     ASSERT_TRUE(port);
     EXPECT_EQ(TrDefaultPeerPort, port->value_if<int64_t>().value_or(-1));
 
-    EXPECT_FALSE(to_variant(endpoint, TR_KEY_comment));
+    EXPECT_FALSE(to_variant(TR_KEY_comment, endpoint));
 }
 
 TEST_F(SerializerTest, serializableSetFromVariantByKey)
 {
     auto endpoint = Endpoint{ .address = "localhost", .port = tr_port::from_host(TrDefaultPeerPort) };
 
-    EXPECT_TRUE(set_from_variant(endpoint, TR_KEY_address, tr_variant{ "example.com"sv }));
+    EXPECT_TRUE(set_from_variant(TR_KEY_address, tr_variant{ "example.com"sv }, endpoint));
     EXPECT_EQ("example.com", endpoint.address);
-    EXPECT_FALSE(set_from_variant(endpoint, TR_KEY_address, tr_variant{ "example.com"sv }));
-    EXPECT_FALSE(set_from_variant(endpoint, TR_KEY_address, tr_variant{ 123 }));
-    EXPECT_FALSE(set_from_variant(endpoint, TR_KEY_comment, tr_variant{ "unused"sv }));
+    EXPECT_FALSE(set_from_variant(TR_KEY_address, tr_variant{ "example.com"sv }, endpoint));
+    EXPECT_FALSE(set_from_variant(TR_KEY_address, tr_variant{ 123 }, endpoint));
+    EXPECT_FALSE(set_from_variant(TR_KEY_comment, tr_variant{ "unused"sv }, endpoint));
 
-    EXPECT_TRUE(set_from_variant(endpoint, TR_KEY_port, tr_variant{ int64_t{ 1234 } }));
+    EXPECT_TRUE(set_from_variant(TR_KEY_port, tr_variant{ int64_t{ 1234 } }, endpoint));
     EXPECT_EQ(tr_port::from_host(1234), endpoint.port);
 }
 
@@ -557,12 +557,12 @@ TEST_F(SerializerTest, serializableSetFromVariantUsesFloatingChangePolicy)
 {
     auto floating = Floating{ .ratio = std::numeric_limits<double>::quiet_NaN() };
 
-    EXPECT_TRUE(set_from_variant(floating, TR_KEY_seed_ratio_limit, tr_variant{ std::numeric_limits<double>::quiet_NaN() }));
+    EXPECT_TRUE(set_from_variant(TR_KEY_seed_ratio_limit, tr_variant{ std::numeric_limits<double>::quiet_NaN() }, floating));
     EXPECT_TRUE(std::isnan(floating.ratio));
 
-    EXPECT_TRUE(set_from_variant(floating, TR_KEY_seed_ratio_limit, tr_variant{ 2.5 }));
+    EXPECT_TRUE(set_from_variant(TR_KEY_seed_ratio_limit, tr_variant{ 2.5 }, floating));
     EXPECT_DOUBLE_EQ(2.5, floating.ratio);
-    EXPECT_FALSE(set_from_variant(floating, TR_KEY_seed_ratio_limit, tr_variant{ 2.5 }));
+    EXPECT_FALSE(set_from_variant(TR_KEY_seed_ratio_limit, tr_variant{ 2.5 }, floating));
 }
 
 TEST_F(SerializerTest, serializableConstexprGetSet)

--- a/tests/libtransmission/settings-test.cc
+++ b/tests/libtransmission/settings-test.cc
@@ -29,7 +29,7 @@ TEST_F(SettingsTest, canInstantiate)
 {
     auto settings = tr_session::Settings{};
 
-    auto map = settings.save();
+    auto map = tr::serializer::save(settings);
     EXPECT_FALSE(std::empty(map));
 }
 
@@ -55,7 +55,7 @@ TEST_F(SettingsTest, canSaveBools)
     auto const expected_value = !settings.seed_queue_enabled;
     settings.seed_queue_enabled = expected_value;
 
-    auto const map = settings.save();
+    auto const map = tr::serializer::save(settings);
     auto const val = map.value_if<bool>(Key);
     ASSERT_TRUE(val);
     EXPECT_EQ(expected_value, *val);
@@ -83,7 +83,7 @@ TEST_F(SettingsTest, canSaveDoubles)
     auto const expected_value = !default_value;
     settings.seed_queue_enabled = expected_value;
 
-    auto const map = settings.save();
+    auto const map = tr::serializer::save(settings);
     auto const val = map.value_if<bool>(Key);
     ASSERT_TRUE(val);
     EXPECT_EQ(expected_value, *val);
@@ -119,7 +119,7 @@ TEST_F(SettingsTest, canSaveEncryptionMode)
     EXPECT_NE(SourceValue, settings.seed_queue_enabled);
     settings.encryption_mode = SourceValue;
 
-    auto const map = settings.save();
+    auto const map = tr::serializer::save(settings);
     auto const val = map.value_if<std::string_view>(Key);
     ASSERT_TRUE(val);
     EXPECT_EQ(ExpectedValue, *val);
@@ -156,7 +156,7 @@ TEST_F(SettingsTest, canSaveLogLevel)
     ASSERT_NE(ExpectedValue, default_value);
 
     settings.log_level = ExpectedValue;
-    auto const map = settings.save();
+    auto const map = tr::serializer::save(settings);
     auto const val = map.value_if<int64_t>(Key);
     ASSERT_TRUE(val);
     EXPECT_EQ(ExpectedValue, *val);
@@ -193,7 +193,7 @@ TEST_F(SettingsTest, canSaveMode)
     ASSERT_NE(ExpectedValue, default_value);
 
     settings.umask = ExpectedValue;
-    auto const map = settings.save();
+    auto const map = tr::serializer::save(settings);
     auto const val = map.value_if<std::string_view>(Key);
     ASSERT_TRUE(val);
     EXPECT_EQ("0777"sv, *val);
@@ -240,7 +240,7 @@ TEST_F(SettingsTest, canSavePort)
     ASSERT_NE(ExpectedValue, default_value);
 
     settings.peer_port = ExpectedValue;
-    auto const map = settings.save();
+    auto const map = tr::serializer::save(settings);
     auto const val = map.value_if<int64_t>(Key);
     ASSERT_TRUE(val);
     EXPECT_EQ(ExpectedValue.host(), *val);
@@ -277,7 +277,7 @@ TEST_F(SettingsTest, canSavePreallocation)
     ASSERT_NE(ExpectedValue, default_value);
 
     settings.preallocation_mode = ExpectedValue;
-    auto const map = settings.save();
+    auto const map = tr::serializer::save(settings);
     auto const val = map.value_if<int64_t>(Key);
     ASSERT_TRUE(val);
     EXPECT_EQ(static_cast<int64_t>(ExpectedValue), *val);
@@ -314,7 +314,7 @@ TEST_F(SettingsTest, canSaveSizeT)
     auto const expected_value = settings.queue_stalled_minutes + 5U;
 
     settings.queue_stalled_minutes = expected_value;
-    auto const map = settings.save();
+    auto const map = tr::serializer::save(settings);
     auto const val = map.value_if<int64_t>(Key);
     ASSERT_TRUE(val);
     EXPECT_EQ(expected_value, static_cast<size_t>(*val));
@@ -343,7 +343,7 @@ TEST_F(SettingsTest, canSaveString)
     EXPECT_NE(ChangedValue, tr_session::Settings{}.bind_address_ipv4);
 
     settings.bind_address_ipv4 = ChangedValue;
-    auto const map = settings.save();
+    auto const map = tr::serializer::save(settings);
     auto const val = map.value_if<std::string_view>(Key);
     ASSERT_TRUE(val);
     EXPECT_EQ(ChangedValue, *val);
@@ -377,12 +377,12 @@ TEST_F(SettingsTest, canSaveNullableString)
     EXPECT_EQ(std::nullopt, settings.proxy_url);
 
     settings.proxy_url = ChangedValue;
-    auto map = settings.save();
+    auto map = tr::serializer::save(settings);
     auto const sv = map.value_if<std::string_view>(Key);
     EXPECT_EQ(ChangedValue, sv);
 
     settings.proxy_url = std::nullopt;
-    map = settings.save();
+    map = tr::serializer::save(settings);
     auto const null_p = map.value_if<std::nullptr_t>(Key);
     EXPECT_TRUE(null_p);
 }
@@ -417,7 +417,7 @@ TEST_F(SettingsTest, canSaveDiffServ)
     ASSERT_NE(ChangedValue, settings.peer_socket_diffserv);
 
     settings.peer_socket_diffserv = ChangedValue;
-    auto const map = settings.save();
+    auto const map = tr::serializer::save(settings);
     auto const val = map.value_if<std::string_view>(Key);
     ASSERT_TRUE(val);
     EXPECT_EQ("cs1"sv, *val);
@@ -453,7 +453,7 @@ TEST_F(SettingsTest, canSaveVerify)
     ASSERT_NE(ChangedValue, settings.torrent_added_verify_mode);
 
     settings.torrent_added_verify_mode = ChangedValue;
-    auto const map = settings.save();
+    auto const map = tr::serializer::save(settings);
     auto const val = map.value_if<std::string_view>(Key);
     ASSERT_TRUE(val);
     EXPECT_EQ("full"sv, *val);
@@ -520,7 +520,7 @@ TEST_F(SettingsTest, canSavePreferredTransport)
     ASSERT_NE(setting_value, default_value);
 
     settings.preferred_transports = setting_value;
-    auto const map = settings.save();
+    auto const map = tr::serializer::save(settings);
     auto* const l = map.find_if<tr_variant::Vector>(Key);
     ASSERT_NE(l, nullptr);
     ASSERT_EQ(std::size(ExpectedValue), std::size(*l));
@@ -633,7 +633,7 @@ TEST_F(SettingsTest, canSaveSleepPerSecondsDuringVerify)
     ASSERT_NE(ExpectedValue, default_value);
 
     settings.sleep_per_seconds_during_verify = ExpectedValue;
-    auto const map = settings.save();
+    auto const map = tr::serializer::save(settings);
     auto const val_raw = map.value_if<int64_t>(Key);
     ASSERT_TRUE(val_raw);
     EXPECT_EQ(ExpectedValue, std::chrono::milliseconds{ *val_raw });
@@ -643,7 +643,7 @@ TEST_F(SettingsTest, canInstantiateAltSpeedSettings)
 {
     auto settings = tr::SessionAltSpeedSettings{};
 
-    auto map = settings.save();
+    auto map = tr::serializer::save(settings);
     EXPECT_FALSE(std::empty(map));
 }
 
@@ -661,7 +661,7 @@ TEST_F(SettingsTest, canLoadAndSaveAltSpeedSettings)
     EXPECT_TRUE(settings.scheduler_enabled);
     EXPECT_EQ(321U, settings.speed_up_kbyps);
 
-    auto const out = settings.save();
+    auto const out = tr::serializer::save(settings);
     EXPECT_EQ(true, out.value_if<bool>(TR_KEY_alt_speed_enabled));
     EXPECT_EQ(true, out.value_if<bool>(TR_KEY_alt_speed_time_enabled));
     EXPECT_EQ(321, out.value_if<int64_t>(TR_KEY_alt_speed_up));
@@ -671,7 +671,7 @@ TEST_F(SettingsTest, canInstantiateRpcServerSettings)
 {
     auto settings = tr::RpcServerSettings{};
 
-    auto map = settings.save();
+    auto map = tr::serializer::save(settings);
     EXPECT_FALSE(std::empty(map));
 }
 
@@ -691,7 +691,7 @@ TEST_F(SettingsTest, canLoadAndSaveRpcServerSettings)
     EXPECT_EQ("alice"sv, settings.username);
     EXPECT_EQ(9091, settings.port.host());
 
-    auto const out = settings.save();
+    auto const out = tr::serializer::save(settings);
     EXPECT_EQ(true, out.value_if<bool>(TR_KEY_rpc_enabled));
     EXPECT_EQ(true, out.value_if<bool>(TR_KEY_rpc_authentication_required));
     EXPECT_EQ("alice"sv, out.value_if<std::string_view>(TR_KEY_rpc_username));


### PR DESCRIPTION
I'm going to try and get the `Prefs` rewrite finished this weekend!

This PR lets us load, save, set, and get from multiple `Serializable` containers at once. 

Example use:

```c++
auto settings = tr::serializer::save(session->settings_, session->alt_speeds_.settings(), session->rpc_server_->settings());
```

Stores the key/value pairs of all three containers into a single tr_variant::Map and returns it.
