### PR TITLE
fix: new clang-22 warnings

### DIFF
--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -306,6 +306,9 @@ private:
 
         auto const mcast_sockaddr = tr_socket_address::from_string(McastSockAddr[ip_protocol]);
         TR_ASSERT(mcast_sockaddr);
+        if (!mcast_sockaddr) {
+            return false;
+        }
         auto const [mcast_ss, mcast_sslen] = mcast_sockaddr->to_sockaddr();
 
         auto const [bind_ss, bind_sslen] = tr_socket_address::to_sockaddr(tr_address::any(ip_protocol), mcast_sockaddr->port());

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -325,8 +325,8 @@ struct JsonWriter {
         // workaround for this issue: in Writer::String() at
         // rapidjson/writer.h:205: `RAPIDJSON_ASSERT(str != 0);`
         // that fails when val.data() is nullptr when val.empty()
-        auto const size = std::size(val);
-        writer.String(size != 0U ? std::data(val) : "", size);
+        char const* data = std::data(val);
+        writer.String(data != nullptr ? data : "", std::size(val));
     }
 
     void operator()(tr_variant::Vector const& val) const

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -325,8 +325,11 @@ struct JsonWriter {
         // workaround for this issue: in Writer::String() at
         // rapidjson/writer.h:205: `RAPIDJSON_ASSERT(str != 0);`
         // that fails when val.data() is nullptr when val.empty()
-        char const* data = std::data(val);
-        writer.String(data != nullptr ? data : "", std::size(val));
+        if (std::empty(val)) {
+            writer.String("", 0U);
+        } else {
+            writer.String(std::data(val), std::size(val));
+        }
     }
 
     void operator()(tr_variant::Vector const& val) const

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -325,8 +325,8 @@ struct JsonWriter {
         // workaround for this issue: in Writer::String() at
         // rapidjson/writer.h:205: `RAPIDJSON_ASSERT(str != 0);`
         // that fails when val.data() is nullptr when val.empty()
-        char const* data = std::data(val);
-        writer.String(data != nullptr ? data : "", std::size(val));
+        auto const size = std::size(val);
+        writer.String(size != 0U ? std::data(val) : "", size);
     }
 
     void operator()(tr_variant::Vector const& val) const


### PR DESCRIPTION
Fix a pair of warnings I hit while building with clang-22 + clang-tidy-22