### PR TITLE
refactor: change `tr_bitfield` to use `std::span`

### DIFF
--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -4,9 +4,9 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm> // std::copy, std::fill_n, std::min, std::max
-#include <bit>
 #include <cstddef>
 #include <cstdint>
+#include <span>
 #include <vector> // std::vector
 
 #include "libtransmission/bitfield.h"
@@ -30,43 +30,32 @@ namespace
     return ((bit_count + 7) >> 3);
 }
 
-void setAllTrue(uint8_t* array, size_t bit_count)
+void setAllTrue(std::span<std::byte> const bytes, size_t const bit_count)
 {
-    uint8_t constexpr Val = 0xFF;
-    /* Only ever called internally with in-use bit counts. Impossible
-       for bitcount > SIZE_MAX - 8. */
-    size_t const n = getBytesNeededSafe(bit_count);
+    static auto constexpr Val = std::byte{ 0xFF };
+    // Only ever called internally with in-use bit counts. Impossible
+    // for bitcount > SIZE_MAX - 8.
+    auto const n = getBytesNeededSafe(bit_count);
 
-    if (n > 0) {
-        std::fill_n(array, n, Val);
-        /* -bit_count & 7U. Since bitcount is unsigned do ~bitcount +
-           1 to replace -bitcount as linters warn about negating
-           unsigned types. Any compiler will optimize ~x + 1 to -x in
-           the backend. */
-        uint32_t const shift = ((~bit_count) + 1) & 7U;
-        array[n - 1] = Val << shift;
-    }
-}
-
-[[nodiscard]] size_t rawCountFlags(uint8_t const* flags, size_t n) noexcept
-{
-    auto ret = size_t{};
-
-    for (auto const* const end = flags + n; flags != end; ++flags) {
-        ret += std::popcount(*flags);
+    TR_ASSERT(bytes.size() >= n);
+    if (n <= 0U || bytes.size() < n) {
+        return;
     }
 
-    return ret;
+    auto const used = bytes.first(n);
+    std::ranges::fill(used, Val);
+
+    // -bit_count & 7U. Since bitcount is unsigned do ~bitcount +
+    // 1 to replace -bitcount as linters warn about negating
+    // unsigned types. Any compiler will optimize ~x + 1 to -x in
+    // the backend.
+    uint32_t const shift = ((~bit_count) + 1) & 7U;
+    used.back() = Val << shift;
 }
 
 } // namespace
 
 // ---
-
-size_t tr_bitfield::count_flags() const noexcept
-{
-    return rawCountFlags(std::data(flags_), std::size(flags_));
-}
 
 size_t tr_bitfield::count_flags(size_t begin, size_t end) const noexcept
 {
@@ -86,22 +75,22 @@ size_t tr_bitfield::count_flags(size_t begin, size_t end) const noexcept
     TR_ASSERT(!std::empty(flags_));
 
     if (first_byte == last_byte) {
-        uint8_t val = flags_[first_byte];
+        auto val = flags_[first_byte];
 
         auto i = begin & 7U;
         val <<= i;
         i = (begin - end) & 7U;
         val >>= i;
-        ret = std::popcount(val);
+        ret = popcount(val);
     } else {
         size_t const walk_end = std::min(std::size(flags_), last_byte);
 
         /* first byte */
         size_t const first_shift = begin & 7U;
-        uint8_t val = flags_[first_byte];
+        auto val = flags_[first_byte];
         val <<= first_shift;
         /* No need to shift back val for correct popcount. */
-        ret = std::popcount(val);
+        ret = popcount(val);
 
         /* middle bytes */
 
@@ -109,12 +98,12 @@ size_t tr_bitfield::count_flags(size_t begin, size_t end) const noexcept
            popcnt instruction on many architectures. */
         size_t tmp_accum = 0;
         for (size_t i = first_byte + 1; i < walk_end;) {
-            tmp_accum += std::popcount(flags_[i]);
+            tmp_accum += popcount(flags_[i]);
             i += 2;
             if (i > walk_end) {
                 break;
             }
-            ret += std::popcount(flags_[i - 1]);
+            ret += popcount(flags_[i - 1]);
         }
         ret += tmp_accum;
 
@@ -128,7 +117,7 @@ size_t tr_bitfield::count_flags(size_t begin, size_t end) const noexcept
             val = flags_[last_byte];
             val >>= last_shift;
             /* No need to shift back val for correct popcount. */
-            ret += std::popcount(val);
+            ret += popcount(val);
         }
     }
 
@@ -156,7 +145,7 @@ bool tr_bitfield::is_valid() const
     return std::empty(flags_) || true_count_ == count_flags();
 }
 
-std::vector<uint8_t> tr_bitfield::raw() const
+std::vector<std::byte> tr_bitfield::raw() const
 {
     /* Impossible for bit_count_ to exceed SIZE_MAX - 8 */
     auto const n = getBytesNeededSafe(bit_count_);
@@ -165,10 +154,10 @@ std::vector<uint8_t> tr_bitfield::raw() const
         return flags_;
     }
 
-    auto raw = std::vector<uint8_t>(n);
+    auto raw = std::vector<std::byte>(n);
 
     if (has_all()) {
-        setAllTrue(std::data(raw), bit_count_);
+        setAllTrue(raw, bit_count_);
     }
 
     return raw;
@@ -184,7 +173,7 @@ void tr_bitfield::ensure_bits_alloced(size_t n)
     if (std::size(flags_) < bytes_needed) {
         flags_.resize(bytes_needed);
         if (has_all) {
-            setAllTrue(std::data(flags_), true_count_);
+            setAllTrue(flags_, true_count_);
         }
     }
 }
@@ -259,35 +248,35 @@ void tr_bitfield::set_has_all() noexcept
     TR_ASSERT(is_valid());
 }
 
-void tr_bitfield::set_raw(uint8_t const* raw, size_t byte_count)
+void tr_bitfield::set_raw(std::span<std::byte const> const raw)
 {
-    flags_.assign(raw, raw + byte_count);
+    flags_.assign(raw.begin(), raw.end());
 
     // ensure any excess bits at the end of the array are set to '0'.
-    if (byte_count == getBytesNeededSafe(bit_count_)) {
-        auto const excess_bit_count = (byte_count * 8) - bit_count_;
+    if (raw.size() == getBytesNeededSafe(bit_count_)) {
+        auto const excess_bit_count = (raw.size() * 8) - bit_count_;
 
         TR_ASSERT(excess_bit_count <= 7);
 
         if (excess_bit_count != 0) {
-            flags_.back() &= 0xff << excess_bit_count;
+            flags_.back() &= std::byte{ 0xff } << excess_bit_count;
         }
     }
 
     rebuild_true_count();
 }
 
-void tr_bitfield::set_from_bools(bool const* flags, size_t n)
+void tr_bitfield::set_from_bools(std::span<bool const> const flags)
 {
     size_t true_count = 0;
 
     free_array();
-    ensure_bits_alloced(n);
+    ensure_bits_alloced(flags.size());
 
-    for (size_t i = 0; i < n; ++i) {
+    for (size_t i = 0; i < flags.size(); ++i) {
         if (flags[i]) {
             ++true_count;
-            flags_[i >> 3U] |= (0x80 >> (i & 7U));
+            flags_[i >> 3U] |= (std::byte{ 0x80 } >> (i & 7U));
         }
     }
 
@@ -307,11 +296,11 @@ void tr_bitfield::set(size_t nth, bool value)
     /* Already tested that val != nth bit so just swap */
     auto& byte = flags_[nth >> 3U];
 #ifdef TR_ENABLE_ASSERTS
-    auto const old_byte_pop = std::popcount(byte);
+    auto const old_byte_pop = popcount(byte);
 #endif
-    byte ^= 0x80 >> (nth & 7U);
+    byte ^= std::byte{ 0x80 } >> (nth & 7U);
 #ifdef TR_ENABLE_ASSERTS
-    auto const new_byte_pop = std::popcount(byte);
+    auto const new_byte_pop = popcount(byte);
 #endif
 
     if (value) {
@@ -351,8 +340,8 @@ void tr_bitfield::set_span(size_t begin, size_t end, bool value)
     auto walk = begin >> 3;
     auto const last_byte = end >> 3;
 
-    unsigned char first_mask = 0xff >> (begin & 7U);
-    unsigned char last_mask = 0xff << ((~end) & 7U);
+    auto first_mask = std::byte{ 0xff } >> (begin & 7U);
+    auto last_mask = std::byte{ 0xff } << ((~end) & 7U);
     if (value) {
         if (walk == last_byte) {
             flags_[walk] |= first_mask & last_mask;
@@ -362,7 +351,7 @@ void tr_bitfield::set_span(size_t begin, size_t end, bool value)
                count(begin, end) */
             flags_[last_byte] |= last_mask;
             if (++walk < last_byte) {
-                std::fill_n(std::data(flags_) + walk, last_byte - walk, 0xff);
+                std::ranges::fill(std::span{ flags_ }.subspan(walk, last_byte - walk), std::byte{ 0xff });
             }
         }
 
@@ -378,7 +367,7 @@ void tr_bitfield::set_span(size_t begin, size_t end, bool value)
                count(begin, end) */
             flags_[last_byte] &= last_mask;
             if (++walk < last_byte) {
-                std::fill_n(std::data(flags_) + walk, last_byte - walk, 0);
+                std::ranges::fill(std::span{ flags_ }.subspan(walk, last_byte - walk), std::byte{});
             }
         }
 
@@ -439,7 +428,7 @@ bool tr_bitfield::intersects(tr_bitfield const& that) const noexcept
     }
 
     for (size_t i = 0, n = std::min(std::size(flags_), std::size(that.flags_)); i < n; ++i) {
-        if ((flags_[i] & that.flags_[i]) != 0U) {
+        if ((flags_[i] & that.flags_[i]) != std::byte{}) {
             return true;
         }
     }

--- a/libtransmission/bitfield.h
+++ b/libtransmission/bitfield.h
@@ -9,9 +9,13 @@
 #error only libtransmission should #include this header.
 #endif
 
+#include <bit>
 #include <cstddef> // size_t
 #include <cstdint> // uint8_t
+#include <span>
 #include <vector> // std::vector
+
+#include "libtransmission/tr-macros.h"
 
 /**
  * @brief Implementation of the BitTorrent spec's Bitfield array of bits.
@@ -53,13 +57,20 @@ public:
     {
         set_span(begin, end, false);
     }
-    void set_from_bools(bool const* flags, size_t n);
+    void set_from_bools(std::span<bool const> flags);
 
     // "raw" here is in BEP0003 format: "The first byte of the bitfield
     // corresponds to indices 0 - 7 from high bit to low bit, respectively.
     // The next one 8-15, etc. Spare bits at the end are set to zero."
-    void set_raw(uint8_t const* raw, size_t byte_count);
-    [[nodiscard]] std::vector<uint8_t> raw() const;
+    void set_raw(std::span<std::byte const> raw);
+    [[nodiscard]] std::vector<std::byte> raw() const;
+
+    template<typename R>
+        requires(!requires(R const& range) { std::span<std::byte const>{ range }; })
+    void set_raw(R const& raw)
+    {
+        set_raw(std::as_bytes(std::span<typename R::value_type const>{ raw }));
+    }
 
     [[nodiscard]] constexpr bool has_all() const noexcept
     {
@@ -113,7 +124,14 @@ public:
     [[nodiscard]] bool intersects(tr_bitfield const& that) const noexcept;
 
 private:
-    [[nodiscard]] size_t count_flags() const noexcept;
+    [[nodiscard]] TR_CONSTEXPR_VEC size_t count_flags() const noexcept
+    {
+        auto ret = size_t{};
+        for (auto const flag : flags_) {
+            ret += popcount(flag);
+        }
+        return ret;
+    }
     [[nodiscard]] size_t count_flags(size_t begin, size_t end) const noexcept;
 
     [[nodiscard]] constexpr bool test_flag(size_t n) const
@@ -122,7 +140,7 @@ private:
             return false;
         }
 
-        return (flags_[n >> 3U] << (n & 7U) & 0x80) != 0;
+        return (flags_[n >> 3U] << (n & 7U) & std::byte{ 0x80 }) != std::byte{};
     }
 
     void ensure_bits_alloced(size_t n);
@@ -131,7 +149,7 @@ private:
     void free_array() noexcept
     {
         // move-assign to ensure the reserve memory is cleared
-        flags_ = std::vector<uint8_t>{};
+        flags_ = std::vector<std::byte>{};
     }
 
     void increment_true_count(size_t inc) noexcept;
@@ -142,7 +160,12 @@ private:
         set_true_count(count_flags());
     }
 
-    std::vector<uint8_t> flags_;
+    [[nodiscard]] static constexpr int popcount(std::byte const value) noexcept
+    {
+        return std::popcount(std::to_integer<uint8_t>(value));
+    }
+
+    std::vector<std::byte> flags_;
 
     size_t bit_count_ = 0;
     size_t true_count_ = 0;

--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -91,7 +91,7 @@ void tr_completion::amount_done(float* tab, size_t n_tabs) const
     }
 }
 
-std::vector<uint8_t> tr_completion::create_piece_bitfield() const
+std::vector<std::byte> tr_completion::create_piece_bitfield() const
 {
     size_t const n = block_info_->piece_count();
     auto pieces = tr_bitfield{ n };
@@ -101,7 +101,7 @@ std::vector<uint8_t> tr_completion::create_piece_bitfield() const
     for (tr_piece_index_t piece = 0; piece < n; ++piece) {
         flags[piece] = has_piece(piece);
     }
-    pieces.set_from_bools(flags.get(), n);
+    pieces.set_from_bools({ flags.get(), n });
 
     return pieces.raw();
 }

--- a/libtransmission/completion.h
+++ b/libtransmission/completion.h
@@ -111,7 +111,7 @@ struct tr_completion {
         return TR_LEECH;
     }
 
-    [[nodiscard]] std::vector<uint8_t> create_piece_bitfield() const;
+    [[nodiscard]] std::vector<std::byte> create_piece_bitfield() const;
 
     [[nodiscard]] size_t count_missing_blocks_in_piece(tr_piece_index_t piece) const
     {

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -253,10 +253,10 @@ ReadState tr_handshake::read_handshake(tr_peerIo* peer_io)
     }
 
     // reserved bytes / flags
-    auto reserved = std::array<uint8_t, HandshakeFlagsBytes>{};
+    auto reserved = std::array<std::byte, HandshakeFlagsBytes>{};
     auto flags = tr_bitfield{ HandshakeFlagsBits };
     peer_io->read_bytes(std::data(reserved), std::size(reserved));
-    flags.set_raw(std::data(reserved), std::size(reserved));
+    flags.set_raw(reserved);
     peer_io->set_supports_dht(flags.test(DhtFlag));
     peer_io->set_supports_ltep(flags.test(LtepFlag));
     peer_io->set_supports_fext(flags.test(FextFlag));

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1430,7 +1430,7 @@ ReadResult tr_peerMsgsImpl::process_peer_message(uint8_t id, MessageReader& payl
     case BtPeerMsgs::Bitfield:
         logtrace(this, "got a bitfield");
         have_ = tr_bitfield{ tor_.has_metainfo() ? tor_.piece_count() : std::size(payload) * 8 };
-        have_.set_raw(reinterpret_cast<uint8_t const*>(std::data(payload)), std::size(payload));
+        have_.set_raw(payload);
         peer_info->set_seed(is_seed());
         publish(tr_peer_event::GotBitfield(&have_));
 

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -400,7 +400,7 @@ void raw_to_bitfield(tr_bitfield& bitfield, std::string_view const raw)
     } else if (raw == "all"sv) {
         bitfield.set_has_all();
     } else {
-        bitfield.set_raw(reinterpret_cast<uint8_t const*>(std::data(raw)), std::size(raw));
+        bitfield.set_raw(raw);
     }
 }
 
@@ -536,7 +536,7 @@ tr_resume::fields_t load_progress(tr_variant::Map const& map, tr_torrent* tor, t
             err = "Invalid value for 'blocks'";
         }
     } else if (auto const raw = prog->value_if<std::string_view>(TR_KEY_bitfield); raw) {
-        blocks.set_raw(reinterpret_cast<uint8_t const*>(std::data(*raw)), std::size(*raw));
+        blocks.set_raw(*raw);
     } else {
         err = "Couldn't find 'blocks' or 'bitfield'";
     }

--- a/tests/libtransmission/bitfield-test.cc
+++ b/tests/libtransmission/bitfield-test.cc
@@ -72,7 +72,7 @@ TEST(Bitfield, ctorFromFlagArray)
         bool const have_none = true_count == 0;
 
         auto bf = tr_bitfield(n);
-        bf.set_from_bools(std::data(flags), std::size(flags));
+        bf.set_from_bools(flags);
 
         EXPECT_EQ(n, bf.size());
         EXPECT_EQ(have_all, bf.has_all());
@@ -87,22 +87,22 @@ TEST(Bitfield, ctorFromFlagArray)
 
 TEST(Bitfield, setRaw)
 {
-    auto constexpr TestByte = uint8_t{ 10 };
+    auto constexpr TestByte = std::byte{ 10 };
     auto constexpr TestByteTrueBits = 2;
 
-    auto raw = std::vector<uint8_t>(100, TestByte);
+    auto raw = std::vector(100, TestByte);
 
     auto bf = tr_bitfield(std::size(raw) * 8);
-    bf.set_raw(std::data(raw), std::size(raw));
+    bf.set_raw(raw);
     EXPECT_EQ(TestByteTrueBits * std::size(raw), bf.count());
 
     // The first byte of the bitfield corresponds to indices 0 - 7
     // from high bit to low bit, respectively. The next one 8-15, etc.
     // Spare bits at the end are set to zero.
-    auto test = uint8_t{};
+    auto test = std::byte{};
     for (int i = 0; i < 8; ++i) {
         if (bf.test(i)) {
-            test |= (1 << (7 - i));
+            test |= (std::byte{ 1 } << (7 - i));
         }
     }
     EXPECT_EQ(TestByte, test);
@@ -113,18 +113,18 @@ TEST(Bitfield, setRaw)
     bf.set_has_all();
     raw = bf.raw();
     EXPECT_EQ(std::size(bf) / 8, std::size(raw));
-    EXPECT_EQ(std::numeric_limits<unsigned char>::max(), raw[0]);
+    EXPECT_EQ(std::byte{ 0xFF }, raw[0]);
 
     // check that the spare bits t the end are zero
     bf = tr_bitfield{ 1 };
-    uint8_t const by = std::numeric_limits<uint8_t>::max();
-    bf.set_raw(&by, 1);
+    static constexpr auto By = std::byte{ 0xFF };
+    bf.set_raw({ &By, 1U });
     EXPECT_TRUE(bf.has_all());
     EXPECT_FALSE(bf.has_none());
     EXPECT_EQ(1U, bf.count());
     raw = bf.raw();
     EXPECT_EQ(1U, std::size(raw));
-    EXPECT_EQ(1 << 7, raw[0]);
+    EXPECT_EQ(std::byte{ 1 } << 7, raw[0]);
 }
 
 TEST(Bitfield, bitfields)

--- a/tests/libtransmission/completion-test.cc
+++ b/tests/libtransmission/completion-test.cc
@@ -342,7 +342,7 @@ TEST_F(CompletionTest, createPieceBitfield)
     // and test that the new bitfield matches
     auto const pieces_raw_bitfield = completion.create_piece_bitfield();
     tr_bitfield pieces{ size_t{ block_info.piece_count() } };
-    pieces.set_raw(std::data(pieces_raw_bitfield), std::size(pieces_raw_bitfield));
+    pieces.set_raw(pieces_raw_bitfield);
     for (uint64_t i = 0; i < block_info.piece_count(); ++i) {
         EXPECT_EQ(completion.has_piece(i), pieces.test(i));
     }


### PR DESCRIPTION
- `tr_bitfield` methods no longer handles pointers.
- New `tr_bitfield::set_raw()` overload that takes any range can construct `std::span`.
- Switched to `std::byte` to represent bytes as this is the de-facto data type for `std::span` (`std::as_bytes()` returns `std::span<std::byte>`).

There should be no change in behaviour.