### PR TITLE
perf: make tr_torrent_queue faster

### DIFF
--- a/libtransmission/torrent-queue.cc
+++ b/libtransmission/torrent-queue.cc
@@ -4,7 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
-#include <ranges>
+#include <iterator>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -23,48 +23,59 @@ using namespace std::literals;
 }
 } // namespace
 
+void tr_torrent_queue::set_pos_of(tr_torrent_id_t const id, size_t const pos)
+{
+    auto const uid = static_cast<size_t>(id);
+    if (uid >= std::size(pos_of_)) {
+        pos_of_.resize(uid + 1U, NotQueued);
+    }
+    pos_of_[uid] = pos;
+}
+
+void tr_torrent_queue::reindex(size_t const first, size_t const last) noexcept
+{
+    for (auto pos = first; pos < last; ++pos) {
+        pos_of_[static_cast<size_t>(queue_[pos])] = pos;
+    }
+}
+
 size_t tr_torrent_queue::add(tr_torrent_id_t const id)
 {
+    auto const pos = std::size(queue_);
     queue_.push_back(id);
+    set_pos_of(id, pos);
     set_dirty();
-    return std::size(queue_) - 1U;
+    return pos;
 }
 
 void tr_torrent_queue::remove(tr_torrent_id_t const id)
 {
-    auto const pos = std::cmp_less(id, std::size(pos_cache_)) ? pos_cache_[id] : 0U;
-    if (pos < std::size(queue_) && queue_[pos] == id) {
-        using diff_type = decltype(queue_)::difference_type;
-        queue_.erase(std::begin(queue_) + static_cast<diff_type>(pos));
-    } else {
-        std::erase(queue_, id);
+    auto const pos = get_pos(id);
+    if (pos >= std::size(queue_)) {
+        return; // not queued
     }
+
+    using diff_type = decltype(queue_)::difference_type;
+    queue_.erase(std::begin(queue_) + static_cast<diff_type>(pos));
+    pos_of_[static_cast<size_t>(id)] = NotQueued;
+
+    // everything after the removed slot shifted down by one
+    reindex(pos, std::size(queue_));
     set_dirty();
 }
 
-size_t tr_torrent_queue::get_pos(tr_torrent_id_t const id)
+size_t tr_torrent_queue::get_pos(tr_torrent_id_t const id) const noexcept
 {
     auto const uid = static_cast<size_t>(id);
-    if (auto n_cache = std::size(pos_cache_);
-        uid >= n_cache || pos_cache_[uid] >= std::size(queue_) || id != queue_[pos_cache_[uid]]) {
-        auto it = std::ranges::find(queue_, id);
-        if (it == std::ranges::cend(queue_)) {
-            return MaxQueuePosition;
-        }
-
-        pos_cache_.resize(std::max(uid + 1U, n_cache));
-        pos_cache_[uid] = std::ranges::distance(std::ranges::cbegin(queue_), it);
-    }
-
-    return pos_cache_[uid];
+    return uid < std::size(pos_of_) ? pos_of_[uid] : NotQueued;
 }
 
 // returns the list of torrent IDs whose queue position changed
 std::vector<tr_torrent_id_t> tr_torrent_queue::set_pos(tr_torrent_id_t const id, size_t new_pos)
 {
-    auto const old_pos = get_pos(id);
     auto const n_queue = std::size(queue_);
-    if (old_pos >= n_queue || queue_[old_pos] != id) {
+    auto const old_pos = get_pos(id);
+    if (old_pos >= n_queue) {
         return {};
     }
 
@@ -90,6 +101,8 @@ std::vector<tr_torrent_id_t> tr_torrent_queue::set_pos(tr_torrent_id_t const id,
         std::rotate(old_it, old_next_it, new_next_it);
     }
 
+    // only the ids in [min, max] were permuted by the rotate
+    reindex(std::min(old_pos, new_pos), std::max(old_pos, new_pos) + 1U);
     set_dirty();
     return ret;
 }

--- a/libtransmission/torrent-queue.h
+++ b/libtransmission/torrent-queue.h
@@ -39,7 +39,7 @@ public:
     size_t add(tr_torrent_id_t id);
     void remove(tr_torrent_id_t id);
 
-    [[nodiscard]] size_t get_pos(tr_torrent_id_t id);
+    [[nodiscard]] size_t get_pos(tr_torrent_id_t id) const noexcept;
     [[nodiscard]] std::vector<tr_torrent_id_t> set_pos(tr_torrent_id_t id, size_t new_pos);
 
     [[nodiscard]] TR_CONSTEXPR_VEC auto size() const noexcept
@@ -64,10 +64,25 @@ private:
         is_dirty_ = is_dirty;
     }
 
+    // Records that `id` currently lives at `pos`, growing pos_of_ as needed.
+    void set_pos_of(tr_torrent_id_t id, size_t pos);
+
+    // Rewrites pos_of_ for the ids in queue_[first, last) so it stays in sync
+    // with the queue after a mutation. Both bounds must be <= queue_.size().
+    void reindex(size_t first, size_t last) noexcept;
+
+    // queue_[pos] is the id at queue position `pos`.
     std::vector<tr_torrent_id_t> queue_;
-    std::vector<size_t> pos_cache_;
+
+    // pos_of_[id] is the queue position of `id`, or NotQueued if absent.
+    // Kept eagerly in sync with `queue_` so that `get_pos()` is always O(1).
+    std::vector<size_t> pos_of_;
 
     bool is_dirty_ = false;
 
     Mediator const& mediator_;
+
+    // Sentinel stored in `pos_of_` for ids that are not in the queue.
+    // A real queue position can never reach this value.
+    static auto constexpr NotQueued = MaxQueuePosition;
 };

--- a/tests/libtransmission/torrent-queue-test.cc
+++ b/tests/libtransmission/torrent-queue-test.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <fstream>
+#include <algorithm>
 #include <map>
 #include <memory>
 #include <string_view>
@@ -171,4 +172,143 @@ TEST_F(TorrentQueueTest, toFromFile)
     for (size_t i = 0; i < std::size(filenames); ++i) {
         EXPECT_EQ(filenames[i], owned[i]->store_filename());
     }
+}
+
+// The queue is pure id/position bookkeeping, so the tests below exercise the
+// data structure directly with raw ids (no tr_torrent objects needed). This
+// keeps the edge-case coverage focused on the queue's invariants.
+
+TEST_F(TorrentQueueTest, getPosOfAbsentIdReturnsMax)
+{
+    static auto constexpr Max = tr_torrent_queue::MaxQueuePosition;
+
+    auto queue = tr_torrent_queue{ mediator_ };
+
+    // nothing is queued yet
+    EXPECT_EQ(Max, queue.get_pos(1));
+
+    queue.add(10);
+    queue.add(20);
+    queue.add(30);
+    EXPECT_EQ(0U, queue.get_pos(10));
+    EXPECT_EQ(1U, queue.get_pos(20));
+    EXPECT_EQ(2U, queue.get_pos(30));
+
+    // ids that were never added: in a gap, past the end, and negative
+    EXPECT_EQ(Max, queue.get_pos(5));
+    EXPECT_EQ(Max, queue.get_pos(15));
+    EXPECT_EQ(Max, queue.get_pos(999));
+    EXPECT_EQ(Max, queue.get_pos(-1));
+
+    // adding a much larger id must backfill the gap with the "not queued"
+    // sentinel rather than leaving it pointing at a bogus position
+    queue.add(100);
+    EXPECT_EQ(3U, queue.get_pos(100));
+    EXPECT_EQ(Max, queue.get_pos(50));
+}
+
+TEST_F(TorrentQueueTest, removeAbsentIdIsNoop)
+{
+    static auto constexpr Max = tr_torrent_queue::MaxQueuePosition;
+
+    auto queue = tr_torrent_queue{ mediator_ };
+    queue.add(10);
+    queue.add(20);
+    queue.add(30);
+
+    // removing ids that aren't queued must not disturb the queue
+    queue.remove(999);
+    queue.remove(15);
+    EXPECT_EQ(3U, queue.size());
+    EXPECT_EQ(0U, queue.get_pos(10));
+    EXPECT_EQ(1U, queue.get_pos(20));
+    EXPECT_EQ(2U, queue.get_pos(30));
+
+    // remove from the middle: the tail shifts down and stays queryable in O(1)
+    queue.remove(20);
+    EXPECT_EQ(2U, queue.size());
+    EXPECT_EQ(0U, queue.get_pos(10));
+    EXPECT_EQ(1U, queue.get_pos(30));
+    EXPECT_EQ(Max, queue.get_pos(20));
+
+    // removing the same id again is a no-op
+    queue.remove(20);
+    EXPECT_EQ(2U, queue.size());
+    EXPECT_EQ(0U, queue.get_pos(10));
+    EXPECT_EQ(1U, queue.get_pos(30));
+}
+
+TEST_F(TorrentQueueTest, setPosClampsAndIgnoresAbsent)
+{
+    auto queue = tr_torrent_queue{ mediator_ };
+    for (auto const id : { 10, 20, 30, 40 }) {
+        queue.add(id);
+    }
+
+    // absent id -> no change
+    EXPECT_TRUE(queue.set_pos(999, 0U).empty());
+    EXPECT_EQ(4U, queue.size());
+
+    // new_pos past the end clamps to the back (queue_move_bottom relies on this)
+    auto changed = queue.set_pos(10, tr_torrent_queue::MaxQueuePosition);
+    std::ranges::sort(changed);
+    EXPECT_EQ((std::vector<tr_torrent_id_t>{ 10, 20, 30, 40 }), changed);
+    EXPECT_EQ(3U, queue.get_pos(10));
+    EXPECT_EQ(0U, queue.get_pos(20));
+    EXPECT_EQ(1U, queue.get_pos(30));
+    EXPECT_EQ(2U, queue.get_pos(40));
+
+    // moving to the position it already holds -> no change
+    EXPECT_TRUE(queue.set_pos(10, 3U).empty());
+}
+
+TEST_F(TorrentQueueTest, queueConsistencyAfterMutations)
+{
+    auto queue = tr_torrent_queue{ mediator_ };
+
+    auto live = std::vector<tr_torrent_id_t>{};
+    auto next_id = tr_torrent_id_t{ 1 };
+
+    // pos_of_ must be a bijection between live ids and [0, size)
+    auto const check_dense = [&queue, &live]() {
+        auto seen = std::vector<bool>(std::size(live), false);
+        ASSERT_EQ(std::size(live), queue.size());
+        for (auto const id : live) {
+            auto const pos = queue.get_pos(id);
+            ASSERT_LT(pos, std::size(live));
+            ASSERT_FALSE(seen[pos]); // every position is used exactly once
+            seen[pos] = true;
+        }
+    };
+
+    // grow the queue past a couple of pos_of_ reallocations
+    for (auto i = 0; i < 64; ++i) {
+        auto const id = next_id++;
+        queue.add(id);
+        live.push_back(id);
+    }
+    check_dense();
+
+    // a batch of reorders spanning the whole queue
+    (void)queue.set_pos(live[10], 0U);
+    (void)queue.set_pos(live[0], tr_torrent_queue::MaxQueuePosition);
+    (void)queue.set_pos(live[30], 5U);
+    check_dense();
+
+    // remove several ids from various positions (incl. front and back)
+    for (auto const id : { live[5], live[0], live[63], live[20] }) {
+        queue.remove(id);
+        std::erase(live, id);
+    }
+    check_dense();
+
+    // keep assigning monotonically increasing ids, then reorder again
+    for (auto i = 0; i < 8; ++i) {
+        auto const id = next_id++;
+        queue.add(id);
+        live.push_back(id);
+    }
+    (void)queue.set_pos(live.back(), 0U);
+    (void)queue.set_pos(live.front(), 3U);
+    check_dense();
 }


### PR DESCRIPTION
Added a second vector for faster two-way mapping between torrent ID and queue position for faster lookup. Add more tests. `tr_torrent_queue`'s public API is unchanged.

AI disclosure: Claude Opus 4.8 reviewed & revised my draft, then I reviewed Claude's. Claude added all the tests and wrote up this performance analysis. All code has been written or reviewed by me.

## `tr_torrent_queue` performance: before → after

Let **N** = torrents in the queue, **d** = move distance in `set_pos` (`|old−new|`), **k** = tail length after a `remove`, **M** = torrents processed in a batch (e.g. a sort).

| Operation | Before | After |
|---|---|---|
| `get_pos` | O(1) on cache hit, **O(N)** on miss | **O(1)** always |
| `add` | O(1) amortized (cache not seeded) | O(1) amortized (index seeded) |
| `remove` | **O(N)** + leaves whole tail's cache stale | **O(k)** (erase-shift + eager reindex), worst O(N) |
| `set_pos` | **O(N)** + leaves moved range stale | **O(d)** (rotate + reindex that range), worst O(N) |
| `size` / `to_file` / `from_file` | O(1) / O(N) / O(N) | unchanged |

### Why the aggregate cost is the real win

`get_pos` is the hot path — it's called once per element in every `CompareQueuePosition` sort and on every status/RPC query. The old lazy cache went stale in bulk after each `remove`/`set_pos` and repaired only **one** entry per call via linear find:

| Aggregate pattern | Before | After |
|---|---|---|
| Sort M torrents by queue position (post-mutation) | **O(M·N·log M)** | **O(M log M)** |
| Sort/seed all N torrents | **O(N²)** | **O(N log N)** |
| `queue_move_*` of M torrents (M×`set_pos`) | **O(M·N)** | **O(M·d)** ≤ O(M·N) |

- `get_pos` went from *potentially O(N) every call* to *guaranteed O(1)*, killing the O(N²) blowups that hurt most at thousands of torrents.
- `set_pos` tightened from O(N) to **O(d)** — moving an item one slot in a 10k queue is now O(1) work instead of O(10k). The eager reindex adds no asymptotic cost since the rotate already touches that range.
- `remove`, `set_pos` remain linear in their affected range in the worst case — that's inherent: dense RPC positions and `set_pos`'s changed-id return value both require touching that many slots.

**Memory:** unchanged profile — `pos_of_` is a dense id-indexed vector sized to the max id seen, same as the old `pos_cache_` and consistent with `tr_torrents::by_id_`.

Notes: Improved libtransmission code to use less CPU.

