### PR TITLE
ci: do not install ca-certificates

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -44,7 +44,6 @@ runs:
         if [[ "$PKG_FAMILY" == "dnf" ]]; then
           # Fedora/DNF-based installation
           dnf install -y \
-            ca-certificates \
             cmake \
             gettext \
             ninja-build \
@@ -106,7 +105,6 @@ runs:
           # Base packages
           BASE_PACKAGES=(
             appstream
-            ca-certificates
             cmake
             gettext
             libb64-dev

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -666,7 +666,6 @@ jobs:
             bash \
             binutils \
             build-base \
-            ca-certificates \
             cmake \
             curl-dev \
             fast_float \
@@ -835,7 +834,6 @@ jobs:
           set -ex
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            ca-certificates \
             libcurl4-openssl-dev \
             libssl-dev
       - name: Get Source

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
-            ca-certificates \
             cmake \
             g++ \
             gettext \


### PR DESCRIPTION
Remove `ca-certificates` from the list of packages that we install during CI runs.

It's not clear to me whether or not we actually need to install this on github-hosted runners, so let's find out.