### PR TITLE
refactor: extend `tr_web` functionality

### DIFF
--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -100,7 +100,7 @@ struct http_announce_data {
 
 bool handleAnnounceResponse(tr_web::FetchResponse const& web_response, tr_announce_response& response)
 {
-    auto const& [status, body, primary_ip, did_connect, did_timeout, vdata] = web_response;
+    auto const& [status, headers, body, primary_ip, did_connect, did_timeout, vdata] = web_response;
     auto const& log_name = static_cast<http_announce_data const*>(vdata)->log_name;
 
     response.did_connect = did_connect;
@@ -133,7 +133,7 @@ bool handleAnnounceResponse(tr_web::FetchResponse const& web_response, tr_announ
 
 void onAnnounceDone(tr_web::FetchResponse const& web_response)
 {
-    auto const& [status, body, primary_ip, did_connect, did_timeout, vdata] = web_response;
+    auto const& [status, headers, body, primary_ip, did_connect, did_timeout, vdata] = web_response;
     auto* const data = static_cast<http_announce_data*>(vdata);
 
     auto const got_all_responses = ++data->requests_answered_count == data->requests_sent_count;
@@ -434,7 +434,7 @@ private:
 
 void onScrapeDone(tr_web::FetchResponse const& web_response)
 {
-    auto const& [status, body, primary_ip, did_connect, did_timeout, vdata] = web_response;
+    auto const& [status, headers, body, primary_ip, did_connect, did_timeout, vdata] = web_response;
     auto* const data = static_cast<scrape_data*>(vdata);
 
     auto& response = data->response();

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1367,7 +1367,7 @@ void onPortTested(tr_web::FetchResponse const& web_response)
 {
     using namespace JsonRpc;
 
-    auto const& [status, body, primary_ip, did_connect, did_timeout, user_data] = web_response;
+    auto const& [status, headers, body, primary_ip, did_connect, did_timeout, user_data] = web_response;
     auto* data = static_cast<tr_rpc_idle_data*>(user_data);
 
     if (auto const addr = tr_address::from_string(primary_ip);
@@ -1432,7 +1432,7 @@ void onBlocklistFetched(tr_web::FetchResponse const& web_response)
 {
     using namespace JsonRpc;
 
-    auto const& [status, body, primary_ip, did_connect, did_timeout, user_data] = web_response;
+    auto const& [status, headers, body, primary_ip, did_connect, did_timeout, user_data] = web_response;
     auto* data = static_cast<struct tr_rpc_idle_data*>(user_data);
     auto* const session = data->session;
 
@@ -1569,7 +1569,7 @@ struct add_torrent_idle_data {
 
 void onMetadataFetched(tr_web::FetchResponse const& web_response)
 {
-    auto const& [status, body, primary_ip, did_connect, did_timeout, user_data] = web_response;
+    auto const& [status, headers, body, primary_ip, did_connect, did_timeout, user_data] = web_response;
     auto* data = static_cast<struct add_torrent_idle_data*>(user_data);
 
     tr_logAddTrace(

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -453,3 +453,30 @@ std::string tr_urlPercentDecode(std::string_view in)
 
     return out;
 }
+
+std::optional<std::pair<std::string_view, std::string_view>> tr_httpParseHeaderLine(std::string_view line)
+{
+    // ignore any trailing CR / LF
+    while (!std::empty(line) && (line.back() == '\r' || line.back() == '\n')) {
+        line.remove_suffix(1U);
+    }
+
+    // a missing colon means this isn't a header field, e.g. the HTTP
+    // status line or the blank line separating the headers from the body
+    auto const colon = line.find(':');
+    if (colon == std::string_view::npos) {
+        return std::nullopt;
+    }
+
+    // trim leading and trailing optional whitespace (spaces and tabs) from
+    // the value, per RFC 7230: header-field = field-name ":" OWS field-value OWS
+    auto value = line.substr(colon + 1U);
+    if (auto const start = value.find_first_not_of(" \t"); start != std::string_view::npos) {
+        auto const end = value.find_last_not_of(" \t"); // != npos since start was found
+        value = value.substr(start, end - start + 1U);
+    } else {
+        value = {};
+    }
+
+    return std::make_pair(line.substr(0U, colon), value);
+}

--- a/libtransmission/web-utils.h
+++ b/libtransmission/web-utils.h
@@ -86,3 +86,10 @@ constexpr void tr_urlPercentEncode(BackInsertIter out, tr_sha1_digest_t const& d
 [[nodiscard]] char const* tr_webGetResponseStr(long response_code);
 
 [[nodiscard]] std::string tr_urlPercentDecode(std::string_view /*url*/);
+
+// Split one HTTP header line ("Name: value") into its name and its value.
+// Leading and trailing optional whitespace (spaces and tabs) is trimmed from
+// the value per RFC 7230, and any trailing CR / LF is ignored.
+// Returns nullopt when the line has no ':' -- e.g. the HTTP status line
+// or the blank line that separates the headers from the body.
+[[nodiscard]] std::optional<std::pair<std::string_view, std::string_view>> tr_httpParseHeaderLine(std::string_view line);

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -60,6 +60,7 @@
 #endif
 #include "libtransmission/env.h"
 #include "libtransmission/log.h"
+#include "libtransmission/string-utils.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/utils.h"
 #include "libtransmission/web.h"
@@ -285,6 +286,10 @@ public:
         ~Task()
         {
             easy_dispose(easy_);
+
+            if (req_header_slist_ != nullptr) {
+                curl_slist_free_all(req_header_slist_);
+            }
         }
 
         [[nodiscard]] constexpr auto* easy() const
@@ -310,6 +315,57 @@ public:
         [[nodiscard]] constexpr auto const& cookies() const
         {
             return options_.cookies;
+        }
+
+        [[nodiscard]] constexpr auto const& body() const
+        {
+            return options_.body;
+        }
+
+        [[nodiscard]] constexpr auto const& username() const
+        {
+            return options_.username;
+        }
+
+        [[nodiscard]] constexpr auto const& password() const
+        {
+            return options_.password;
+        }
+
+        [[nodiscard]] constexpr auto authScheme() const
+        {
+            return options_.auth_scheme;
+        }
+
+        [[nodiscard]] constexpr auto const& netrcFile() const
+        {
+            return options_.netrc_file;
+        }
+
+        [[nodiscard]] constexpr auto const& unixSocketPath() const
+        {
+            return options_.unix_socket_path;
+        }
+
+        [[nodiscard]] constexpr auto const& sslVerify() const
+        {
+            return options_.ssl_verify;
+        }
+
+        [[nodiscard]] constexpr auto const& verbose() const
+        {
+            return options_.verbose;
+        }
+
+        // Build the curl_slist of request headers (owned by this Task) and
+        // return it, or nullptr if there are none to send.
+        [[nodiscard]] curl_slist* make_request_headers()
+        {
+            for (auto const& [name, value] : options_.headers) {
+                req_header_slist_ = curl_slist_append(req_header_slist_, fmt::format("{:s}: {:s}", name, value).c_str());
+            }
+
+            return req_header_slist_;
         }
 
         [[nodiscard]] constexpr auto const& sndbuf() const
@@ -366,6 +422,14 @@ public:
             }
         }
 
+        void add_response_header(std::string_view line)
+        {
+            if (auto const parsed = tr_httpParseHeaderLine(line); parsed) {
+                // store the name lowercased for case-insensitive lookup
+                response.headers.insert_or_assign(tr_strlower(parsed->first), std::string{ parsed->second });
+            }
+        }
+
         void done()
         {
             if (!options_.done_func) {
@@ -404,6 +468,8 @@ public:
         tr_web::FetchOptions options_;
 
         CURL* easy_;
+
+        curl_slist* req_header_slist_ = nullptr;
     };
 
     [[nodiscard]] static unsigned int get_curl_version() noexcept
@@ -536,6 +602,16 @@ public:
         return bytes_used;
     }
 
+    static size_t on_header_received(char* const data, size_t const size, size_t const nmemb, void* const vtask)
+    {
+        size_t const bytes = size * nmemb;
+        auto* const task = static_cast<Task*>(vtask);
+        TR_ASSERT(std::this_thread::get_id() == task->impl.curl_thread->get_id());
+
+        task->add_response_header(std::string_view{ data, bytes });
+        return bytes;
+    }
+
     static int onSocketCreated(void* vtask, curl_socket_t fd, curlsocktype /*purpose*/)
     {
         auto const* const task = static_cast<Task const*>(vtask);
@@ -572,7 +648,9 @@ public:
         (void)curl_easy_setopt(e, CURLOPT_SOCKOPTFUNCTION, onSocketCreated);
         (void)curl_easy_setopt(e, CURLOPT_SOCKOPTDATA, &task);
 
-        if (!curl_ssl_verify) {
+        // per-request override falls back to the env-var-driven default
+        auto const ssl_verify = task.sslVerify().value_or(curl_ssl_verify);
+        if (!ssl_verify) {
 #if LIBCURL_VERSION_NUM >= 0x073400 /* 7.52.0 */
             (void)curl_easy_setopt(e, CURLOPT_SSL_VERIFYHOST, 0L);
             (void)curl_easy_setopt(e, CURLOPT_SSL_VERIFYPEER, 0L);
@@ -604,7 +682,10 @@ public:
 
         (void)curl_easy_setopt(e, CURLOPT_TIMEOUT, static_cast<long>(task.timeoutSecs().count()));
         (void)curl_easy_setopt(e, CURLOPT_URL, task.url().c_str());
-        (void)curl_easy_setopt(e, CURLOPT_VERBOSE, curl_verbose ? 1L : 0L);
+        if (auto const& socket_path = task.unixSocketPath(); socket_path) {
+            (void)curl_easy_setopt(e, CURLOPT_UNIX_SOCKET_PATH, socket_path->c_str());
+        }
+        (void)curl_easy_setopt(e, CURLOPT_VERBOSE, task.verbose().value_or(curl_verbose) ? 1L : 0L);
         (void)curl_easy_setopt(e, CURLOPT_WRITEDATA, &task);
         (void)curl_easy_setopt(e, CURLOPT_WRITEFUNCTION, &tr_web::Impl::onDataReceived);
 
@@ -619,6 +700,42 @@ public:
         if (auto const& file = cookie_file; !std::empty(file)) {
             (void)curl_easy_setopt(e, CURLOPT_COOKIEFILE, file.c_str());
         }
+
+        if (auto const& body = task.body()) {
+            // send the request as an HTTP POST with this body.
+            // set CURLOPT_POSTFIELDSIZE before CURLOPT_COPYPOSTFIELDS so that
+            // curl copies the body binary-safely rather than via strlen().
+            (void)curl_easy_setopt(e, CURLOPT_POSTFIELDSIZE, static_cast<long>(std::size(*body)));
+            (void)curl_easy_setopt(e, CURLOPT_COPYPOSTFIELDS, std::data(*body));
+        }
+
+        if (auto* const headers = task.make_request_headers()) {
+            (void)curl_easy_setopt(e, CURLOPT_HTTPHEADER, headers);
+        }
+
+        if (auto const& username = task.username()) {
+            (void)curl_easy_setopt(e, CURLOPT_USERNAME, username->c_str());
+
+            // curl defaults the password to blank, so only set it when we have one
+            if (auto const& password = task.password()) {
+                (void)curl_easy_setopt(e, CURLOPT_PASSWORD, password->c_str());
+            }
+        }
+
+        if (task.authScheme() == FetchOptions::AuthScheme::Any) {
+            // negotiate whatever scheme the server offers rather than Basic-only
+            (void)curl_easy_setopt(e, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+        }
+
+        if (auto const& netrc = task.netrcFile()) {
+            (void)curl_easy_setopt(e, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
+            if (!std::empty(*netrc)) {
+                (void)curl_easy_setopt(e, CURLOPT_NETRC_FILE, netrc->c_str());
+            }
+        }
+
+        (void)curl_easy_setopt(e, CURLOPT_HEADERFUNCTION, &tr_web::Impl::on_header_received);
+        (void)curl_easy_setopt(e, CURLOPT_HEADERDATA, &task);
 
         if (auto const& proxy_url = mediator.proxyUrl(); proxy_url) {
             (void)curl_easy_setopt(e, CURLOPT_PROXY, proxy_url->c_str());
@@ -823,6 +940,15 @@ public:
 
     std::map<CURL*, uint64_t /*tr_time_msec()*/> paused_easy_handles;
 };
+
+std::optional<std::string_view> tr_web::FetchResponse::header(std::string_view const name) const
+{
+    if (auto const iter = headers.find(tr_strlower(name)); iter != std::end(headers)) {
+        return iter->second;
+    }
+
+    return std::nullopt;
+}
 
 tr_web::tr_web(Mediator& mediator)
     : impl_{ std::make_unique<Impl>(mediator) }

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -10,6 +10,7 @@
 #include <cstdint> // uint64_t
 #include <ctime> // time_t
 #include <functional>
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -23,11 +24,16 @@ public:
     // when a fetch() finishes.
     struct FetchResponse {
         long status = 0; // http server response, e.g. 200
+        std::map<std::string, std::string> headers; // keys are lowercased
         std::string body;
         std::string primary_ip;
         bool did_connect = false;
         bool did_timeout = false;
-        void* user_data = nullptr;
+
+        void* user_data = nullptr; // from FetchOptions::done_func_user_data
+
+        // Case-insensitive lookup of a response header value.
+        [[nodiscard]] std::optional<std::string_view> header(std::string_view const name) const;
     };
 
     // Callback to invoke when fetch() is done
@@ -40,6 +46,11 @@ public:
             ANY,
             V4,
             V6,
+        };
+
+        enum class AuthScheme : uint8_t {
+            Basic, // send credentials preemptively (curl's default)
+            Any, // let curl negotiate any scheme the server offers
         };
 
         FetchOptions(
@@ -65,6 +76,32 @@ public:
         // option concatenated like this: "name1=content1; name2=content2;"
         std::optional<std::string> cookies;
 
+        // If set, the request is sent as an HTTP POST with this request body.
+        // If unset, the request is a GET.
+        std::optional<std::string> body;
+
+        // Extra HTTP request headers to send, keyed by header name,
+        // e.g. headers["Content-Type"] = "application/json".
+        std::map<std::string, std::string> headers;
+
+        // HTTP Basic authentication credentials.
+        // If username is set, it and the password are sent to the server.
+        std::optional<std::string> username;
+        std::optional<std::string> password;
+
+        // Authentication scheme to use when credentials are set.
+        // Basic sends them preemptively; Any lets curl negotiate the server's
+        // scheme (Basic, Digest, NTLM, Negotiate) in a challenge round-trip.
+        AuthScheme auth_scheme = AuthScheme::Basic;
+
+        // If set, credentials are also looked up in a .netrc file (using curl's
+        // CURL_NETRC_OPTIONAL mode). An empty string uses curl's default file
+        // (~/.netrc); a non-empty string names the file to read instead.
+        std::optional<std::string> netrc_file;
+
+        // If set, connect through this Unix domain socket instead of over TCP.
+        std::optional<std::string> unix_socket_path;
+
         // If set, bytes [range->first...range->second] are requested.
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
         std::optional<std::pair<uint64_t, uint64_t>> range;
@@ -80,6 +117,15 @@ public:
 
         // Maximum time to wait before timeout
         std::chrono::seconds timeout_secs = DefaultTimeoutSecs;
+
+        // If set, overrides the default TLS certificate verification (which is
+        // otherwise controlled by the TR_CURL_SSL_NO_VERIFY env var).
+        // Set to false to accept self-signed certs, e.g. a local RPC server's.
+        std::optional<bool> ssl_verify;
+
+        // If set, overrides the default curl verbose logging (which is
+        // otherwise controlled by the TR_CURL_VERBOSE env var).
+        std::optional<bool> verbose;
 
         // Called periodically by the web internals when data is received.
         // Used by webseeds to report to tr_bandwidth for data xfer stats

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -33,7 +33,7 @@ public:
         void* user_data = nullptr; // from FetchOptions::done_func_user_data
 
         // Case-insensitive lookup of a response header value.
-        [[nodiscard]] std::optional<std::string_view> header(std::string_view const name) const;
+        [[nodiscard]] std::optional<std::string_view> header(std::string_view name) const;
     };
 
     // Callback to invoke when fetch() is done

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -400,7 +400,7 @@ void tr_webseed_task::on_data_received(size_t const n_bytes)
 
 void tr_webseed_task::on_partial_data_fetched(tr_web::FetchResponse const& web_response)
 {
-    auto const& [status, body, primary_ip, did_connect, did_timeout, vtask] = web_response;
+    auto const& [status, headers, body, primary_ip, did_connect, did_timeout, vtask] = web_response;
     auto const success = status == 206;
 
     auto* const task = static_cast<tr_webseed_task*>(vtask);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,3 +29,7 @@ endif()
 if(TARGET transmission-show)
     add_dependencies(all-tests transmission-show)
 endif()
+
+if(TARGET transmission-remote-test)
+    add_dependencies(all-tests transmission-remote-test)
+endif()

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -64,6 +64,7 @@ target_sources(libtransmission-test
         values-test.cc
         variant-test.cc
         watchdir-test.cc
+        web-test.cc
         web-utils-test.cc)
 
 if(APPLE)
@@ -91,6 +92,7 @@ target_link_libraries(libtransmission-test
         dht::dht
         transmission::fmt-header-only
         libevent::core
+        libevent::extra
         WideInteger::WideInteger)
 
 tr_setup_gtest_target(libtransmission-test "LT.")

--- a/tests/libtransmission/ip-cache-test.cc
+++ b/tests/libtransmission/ip-cache-test.cc
@@ -221,6 +221,7 @@ TEST_F(IPCacheTest, onResponseIPQuery)
         {
             auto response = tr_web::FetchResponse{
                 .status = http_code,
+                .headers = {},
                 .body = std::string{ AddrStr[k_] },
                 .primary_ip = std::string{},
                 .did_connect = true,

--- a/tests/libtransmission/web-test.cc
+++ b/tests/libtransmission/web-test.cc
@@ -68,7 +68,7 @@ public:
         getsockname(evhttp_bound_socket_get_fd(bound), reinterpret_cast<sockaddr*>(&ss), &sslen);
         port_ = ntohs(reinterpret_cast<sockaddr_in const*>(&ss)->sin_port);
 
-        evhttp_set_gencb(http_, &LoopbackServer::on_request, this);
+        evhttp_set_gencb(http_, &LoopbackServer::onRequest, this);
 
         thread_ = std::thread{ [this]() {
             // Poll instead of a blocking dispatch so teardown doesn't depend
@@ -100,20 +100,20 @@ public:
         return fmt::format("http://127.0.0.1:{:d}{:s}", port_, path);
     }
 
-    void set_handler(Handler handler)
+    void setHandler(Handler handler)
     {
-        auto const lock = std::lock_guard{ mutex_ };
+        auto const lock = std::scoped_lock{ mutex_ };
         handler_ = std::move(handler);
     }
 
-    [[nodiscard]] Request last_request() const
+    [[nodiscard]] Request lastRequest() const
     {
-        auto const lock = std::lock_guard{ mutex_ };
+        auto const lock = std::scoped_lock{ mutex_ };
         return request_;
     }
 
 private:
-    static void on_request(evhttp_request* req, void* vself)
+    static void onRequest(evhttp_request* req, void* vself)
     {
         static_cast<LoopbackServer*>(vself)->handle(req);
     }
@@ -121,7 +121,7 @@ private:
     void handle(evhttp_request* req)
     {
         auto request = Request{};
-        request.method = method_name(evhttp_request_get_command(req));
+        request.method = methodName(evhttp_request_get_command(req));
         request.uri = evhttp_request_get_uri(req);
 
         if (auto* const in = evhttp_request_get_input_buffer(req); in != nullptr) {
@@ -136,7 +136,7 @@ private:
 
         auto handler = Handler{};
         {
-            auto const lock = std::lock_guard{ mutex_ };
+            auto const lock = std::scoped_lock{ mutex_ };
             request_ = std::move(request);
             handler = handler_;
         }
@@ -148,7 +148,7 @@ private:
         }
     }
 
-    [[nodiscard]] static char const* method_name(evhttp_cmd_type cmd)
+    [[nodiscard]] static char const* methodName(evhttp_cmd_type cmd)
     {
         switch (cmd) {
         case EVHTTP_REQ_GET:
@@ -217,7 +217,7 @@ protected:
         return fetch(*web_, std::move(options));
     }
 
-    tr_web::FetchResponse fetch(tr_web& web, tr_web::FetchOptions options)
+    static tr_web::FetchResponse fetch(tr_web& web, tr_web::FetchOptions options)
     {
         auto promise = std::make_shared<std::promise<tr_web::FetchResponse>>();
         auto future = promise->get_future();
@@ -246,7 +246,7 @@ protected:
 
 TEST_F(WebTest, getReturnsBody)
 {
-    server_.set_handler([](evhttp_request* req) { LoopbackServer::reply(req, HTTP_OK, "OK", "hello world"sv); });
+    server_.setHandler([](evhttp_request* req) { LoopbackServer::reply(req, HTTP_OK, "OK", "hello world"sv); });
 
     auto const response = fetch(options());
     EXPECT_EQ(200, response.status);
@@ -260,12 +260,12 @@ TEST_F(WebTest, noBodyIsGet)
 {
     auto const response = fetch(options());
     EXPECT_EQ(200, response.status);
-    EXPECT_EQ("GET"sv, server_.last_request().method);
+    EXPECT_EQ("GET"sv, server_.lastRequest().method);
 }
 
 TEST_F(WebTest, httpErrorStatusIsSurfaced)
 {
-    server_.set_handler([](evhttp_request* req) { LoopbackServer::reply(req, 404, "Not Found", "nope"sv); });
+    server_.setHandler([](evhttp_request* req) { LoopbackServer::reply(req, 404, "Not Found", "nope"sv); });
 
     auto const response = fetch(options());
     EXPECT_EQ(404, response.status);
@@ -280,7 +280,7 @@ TEST_F(WebTest, postSendsBody)
     auto const response = fetch(std::move(opts));
     EXPECT_EQ(200, response.status);
 
-    auto const req = server_.last_request();
+    auto const req = server_.lastRequest();
     EXPECT_EQ("POST"sv, req.method);
     EXPECT_EQ("the request body"sv, req.body);
 }
@@ -293,14 +293,14 @@ TEST_F(WebTest, requestHeadersAreSent)
 
     fetch(std::move(opts));
 
-    auto const req = server_.last_request();
+    auto const req = server_.lastRequest();
     EXPECT_EQ("custom-value"sv, req.headers.at("x-custom-header"));
     EXPECT_EQ("application/json"sv, req.headers.at("content-type"));
 }
 
 TEST_F(WebTest, responseHeadersAreCaptured)
 {
-    server_.set_handler([](evhttp_request* req) {
+    server_.setHandler([](evhttp_request* req) {
         auto* const out = evhttp_request_get_output_headers(req);
         evhttp_add_header(out, "X-Reply-Header", "reply-value");
         LoopbackServer::reply(req, HTTP_OK, "OK", "body"sv);
@@ -326,7 +326,7 @@ TEST_F(WebTest, basicAuthSendsCredentials)
     fetch(std::move(opts));
 
     auto const expected = fmt::format("Basic {:s}", tr_base64_encode("aladdin:opensesame"sv));
-    EXPECT_EQ(expected, server_.last_request().headers.at("authorization"));
+    EXPECT_EQ(expected, server_.lastRequest().headers.at("authorization"));
 }
 
 TEST_F(WebTest, basicAuthEmptyPassword)
@@ -338,7 +338,7 @@ TEST_F(WebTest, basicAuthEmptyPassword)
     fetch(std::move(opts));
 
     auto const expected = fmt::format("Basic {:s}", tr_base64_encode("user:"sv));
-    EXPECT_EQ(expected, server_.last_request().headers.at("authorization"));
+    EXPECT_EQ(expected, server_.lastRequest().headers.at("authorization"));
 }
 
 TEST_F(WebTest, netrcCredentialsAreSent)
@@ -352,7 +352,7 @@ TEST_F(WebTest, netrcCredentialsAreSent)
     fetch(std::move(opts));
 
     auto const expected = fmt::format("Basic {:s}", tr_base64_encode("aladdin:opensesame"sv));
-    EXPECT_EQ(expected, server_.last_request().headers.at("authorization"));
+    EXPECT_EQ(expected, server_.lastRequest().headers.at("authorization"));
 }
 
 TEST_F(WebTest, authSchemeAnyDefersCredentials)
@@ -366,13 +366,13 @@ TEST_F(WebTest, authSchemeAnyDefersCredentials)
 
     // Under CURLAUTH_ANY curl waits for a challenge before sending credentials,
     // so a server that answers 200 immediately never sees an Authorization header.
-    auto const& headers = server_.last_request().headers;
+    auto const& headers = server_.lastRequest().headers;
     EXPECT_EQ(headers.end(), headers.find("authorization"));
 }
 
 TEST_F(WebTest, userDataRoundTrips)
 {
-    auto sentinel = int{ 42 };
+    auto sentinel = 42;
     auto const response = fetch(options("/"sv, &sentinel));
     EXPECT_EQ(&sentinel, response.user_data);
 }
@@ -384,7 +384,7 @@ TEST_F(WebTest, rangeRequestSetsHeader)
 
     fetch(std::move(opts));
 
-    EXPECT_EQ("bytes=0-3"sv, server_.last_request().headers.at("range"));
+    EXPECT_EQ("bytes=0-3"sv, server_.lastRequest().headers.at("range"));
 }
 
 TEST_F(WebTest, cookiesAreSent)
@@ -394,7 +394,7 @@ TEST_F(WebTest, cookiesAreSent)
 
     fetch(std::move(opts));
 
-    EXPECT_EQ("a=b; c=d"sv, server_.last_request().headers.at("cookie"));
+    EXPECT_EQ("a=b; c=d"sv, server_.lastRequest().headers.at("cookie"));
 }
 
 TEST_F(WebTest, userAgentFromMediatorIsSent)
@@ -406,13 +406,13 @@ TEST_F(WebTest, userAgentFromMediatorIsSent)
 
     fetch(*web, options());
 
-    EXPECT_EQ("TestAgent/1.0"sv, server_.last_request().headers.at("user-agent"));
+    EXPECT_EQ("TestAgent/1.0"sv, server_.lastRequest().headers.at("user-agent"));
 }
 
 TEST_F(WebTest, onDataReceivedReportsByteCount)
 {
     static auto constexpr Body = "0123456789abcdef"sv;
-    server_.set_handler([](evhttp_request* req) { LoopbackServer::reply(req, HTTP_OK, "OK", Body); });
+    server_.setHandler([](evhttp_request* req) { LoopbackServer::reply(req, HTTP_OK, "OK", Body); });
 
     auto total = std::size_t{ 0 };
     auto opts = options();
@@ -428,7 +428,7 @@ TEST_F(WebTest, onDataReceivedReportsByteCount)
 TEST_F(WebTest, timeoutIsReported)
 {
     // Handler that never replies, so the transfer exceeds the timeout.
-    server_.set_handler([](evhttp_request* /*req*/) {});
+    server_.setHandler([](evhttp_request* /*req*/) {});
 
     auto opts = options();
     opts.timeout_secs = 1s;

--- a/tests/libtransmission/web-test.cc
+++ b/tests/libtransmission/web-test.cc
@@ -1,0 +1,441 @@
+// This file Copyright © Mnemosaic LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosaic LLC.
+// License text can be found in the licenses/ folder.
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <future>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <utility>
+
+#include <event2/buffer.h>
+#include <event2/event.h>
+#include <event2/http.h>
+#include <event2/keyvalq_struct.h>
+
+#include <fmt/format.h>
+
+#include <libtransmission/crypto-utils.h> // tr_base64_encode()
+#include <libtransmission/net.h> // sockaddr_in, getsockname(), ntohs()
+#include <libtransmission/string-utils.h> // tr_strlower()
+#include <libtransmission/web.h>
+
+#include "test-fixtures.h"
+
+using namespace std::literals;
+
+namespace
+{
+
+// A minimal in-process HTTP server bound to an ephemeral loopback port.
+// It records what each request contained and lets a per-test handler shape
+// the reply. Everything stays on 127.0.0.1, so there's no external network
+// dependency and nothing to flake in CI.
+class LoopbackServer
+{
+public:
+    // What the server saw for the most recent request.
+    struct Request {
+        std::string method;
+        std::string uri;
+        std::string body;
+        std::map<std::string, std::string, std::less<>> headers; // names lowercased
+    };
+
+    // Handler that produces the reply. If none is set, the server replies 200.
+    using Handler = std::function<void(evhttp_request*)>;
+
+    LoopbackServer()
+        : base_{ event_base_new() }
+        , http_{ evhttp_new(base_) }
+    {
+        evhttp_set_allowed_methods(
+            http_,
+            EVHTTP_REQ_GET | EVHTTP_REQ_POST | EVHTTP_REQ_HEAD | EVHTTP_REQ_PUT | EVHTTP_REQ_DELETE | EVHTTP_REQ_OPTIONS);
+
+        auto* const bound = evhttp_bind_socket_with_handle(http_, "127.0.0.1", 0);
+        auto ss = sockaddr_storage{};
+        auto sslen = socklen_t{ sizeof(ss) };
+        getsockname(evhttp_bound_socket_get_fd(bound), reinterpret_cast<sockaddr*>(&ss), &sslen);
+        port_ = ntohs(reinterpret_cast<sockaddr_in const*>(&ss)->sin_port);
+
+        evhttp_set_gencb(http_, &LoopbackServer::on_request, this);
+
+        thread_ = std::thread{ [this]() {
+            // Poll instead of a blocking dispatch so teardown doesn't depend
+            // on libevent being built with cross-thread wakeup support.
+            while (!stop_.load(std::memory_order_acquire)) {
+                event_base_loop(base_, EVLOOP_NONBLOCK);
+                std::this_thread::sleep_for(1ms);
+            }
+        } };
+    }
+
+    ~LoopbackServer()
+    {
+        stop_.store(true, std::memory_order_release);
+        if (thread_.joinable()) {
+            thread_.join();
+        }
+        evhttp_free(http_);
+        event_base_free(base_);
+    }
+
+    LoopbackServer(LoopbackServer const&) = delete;
+    LoopbackServer(LoopbackServer&&) = delete;
+    LoopbackServer& operator=(LoopbackServer const&) = delete;
+    LoopbackServer& operator=(LoopbackServer&&) = delete;
+
+    [[nodiscard]] std::string url(std::string_view path = "/"sv) const
+    {
+        return fmt::format("http://127.0.0.1:{:d}{:s}", port_, path);
+    }
+
+    void set_handler(Handler handler)
+    {
+        auto const lock = std::lock_guard{ mutex_ };
+        handler_ = std::move(handler);
+    }
+
+    [[nodiscard]] Request last_request() const
+    {
+        auto const lock = std::lock_guard{ mutex_ };
+        return request_;
+    }
+
+private:
+    static void on_request(evhttp_request* req, void* vself)
+    {
+        static_cast<LoopbackServer*>(vself)->handle(req);
+    }
+
+    void handle(evhttp_request* req)
+    {
+        auto request = Request{};
+        request.method = method_name(evhttp_request_get_command(req));
+        request.uri = evhttp_request_get_uri(req);
+
+        if (auto* const in = evhttp_request_get_input_buffer(req); in != nullptr) {
+            if (auto const len = evbuffer_get_length(in); len > 0U) {
+                request.body.assign(reinterpret_cast<char const*>(evbuffer_pullup(in, -1)), len);
+            }
+        }
+
+        for (auto const* h = evhttp_request_get_input_headers(req)->tqh_first; h != nullptr; h = h->next.tqe_next) {
+            request.headers.insert_or_assign(tr_strlower(h->key), std::string{ h->value });
+        }
+
+        auto handler = Handler{};
+        {
+            auto const lock = std::lock_guard{ mutex_ };
+            request_ = std::move(request);
+            handler = handler_;
+        }
+
+        if (handler) {
+            handler(req);
+        } else {
+            reply(req, HTTP_OK, "OK", ""sv);
+        }
+    }
+
+    [[nodiscard]] static char const* method_name(evhttp_cmd_type cmd)
+    {
+        switch (cmd) {
+        case EVHTTP_REQ_GET:
+            return "GET";
+        case EVHTTP_REQ_POST:
+            return "POST";
+        case EVHTTP_REQ_HEAD:
+            return "HEAD";
+        case EVHTTP_REQ_PUT:
+            return "PUT";
+        case EVHTTP_REQ_DELETE:
+            return "DELETE";
+        case EVHTTP_REQ_OPTIONS:
+            return "OPTIONS";
+        default:
+            return "OTHER";
+        }
+    }
+
+public:
+    // Convenience: send a reply with the given status, reason and body.
+    static void reply(evhttp_request* req, int code, char const* reason, std::string_view body)
+    {
+        auto* const out = evbuffer_new();
+        evbuffer_add(out, std::data(body), std::size(body));
+        evhttp_send_reply(req, code, reason, out);
+        evbuffer_free(out);
+    }
+
+private:
+    event_base* base_;
+    evhttp* http_;
+    uint16_t port_ = 0;
+
+    std::thread thread_;
+    std::atomic<bool> stop_ = false;
+
+    mutable std::mutex mutex_;
+    Handler handler_;
+    Request request_;
+};
+
+// tr_web needs a Mediator; this one only overrides the user-agent so a test
+// can confirm the header reaches the server.
+class TestMediator final : public tr_web::Mediator
+{
+public:
+    [[nodiscard]] std::optional<std::string_view> userAgent() const override
+    {
+        if (user_agent_) {
+            return std::string_view{ *user_agent_ };
+        }
+        return std::nullopt;
+    }
+
+    std::optional<std::string> user_agent_;
+};
+
+class WebTest : public ::tr::test::SandboxedTest
+{
+protected:
+    // Run a fetch synchronously and return the response. done_func is invoked
+    // from tr_web's own thread, so hand the result back through a promise.
+    tr_web::FetchResponse fetch(tr_web::FetchOptions options)
+    {
+        return fetch(*web_, std::move(options));
+    }
+
+    tr_web::FetchResponse fetch(tr_web& web, tr_web::FetchOptions options)
+    {
+        auto promise = std::make_shared<std::promise<tr_web::FetchResponse>>();
+        auto future = promise->get_future();
+        options.done_func = [promise](tr_web::FetchResponse const& response) {
+            promise->set_value(response);
+        };
+
+        web.fetch(std::move(options));
+
+        if (future.wait_for(15s) != std::future_status::ready) {
+            EXPECT_TRUE(false) << "fetch did not complete";
+            return {};
+        }
+        return future.get();
+    }
+
+    [[nodiscard]] tr_web::FetchOptions options(std::string_view path = "/"sv, void* user_data = nullptr)
+    {
+        return tr_web::FetchOptions{ server_.url(path), nullptr, user_data };
+    }
+
+    TestMediator mediator_;
+    std::unique_ptr<tr_web> web_ = tr_web::create(mediator_);
+    LoopbackServer server_;
+};
+
+TEST_F(WebTest, getReturnsBody)
+{
+    server_.set_handler([](evhttp_request* req) { LoopbackServer::reply(req, HTTP_OK, "OK", "hello world"sv); });
+
+    auto const response = fetch(options());
+    EXPECT_EQ(200, response.status);
+    EXPECT_EQ("hello world"sv, response.body);
+    EXPECT_TRUE(response.did_connect);
+    EXPECT_FALSE(response.did_timeout);
+    EXPECT_EQ("127.0.0.1"sv, response.primary_ip);
+}
+
+TEST_F(WebTest, noBodyIsGet)
+{
+    auto const response = fetch(options());
+    EXPECT_EQ(200, response.status);
+    EXPECT_EQ("GET"sv, server_.last_request().method);
+}
+
+TEST_F(WebTest, httpErrorStatusIsSurfaced)
+{
+    server_.set_handler([](evhttp_request* req) { LoopbackServer::reply(req, 404, "Not Found", "nope"sv); });
+
+    auto const response = fetch(options());
+    EXPECT_EQ(404, response.status);
+    EXPECT_TRUE(response.did_connect);
+}
+
+TEST_F(WebTest, postSendsBody)
+{
+    auto opts = options();
+    opts.body = "the request body";
+
+    auto const response = fetch(std::move(opts));
+    EXPECT_EQ(200, response.status);
+
+    auto const req = server_.last_request();
+    EXPECT_EQ("POST"sv, req.method);
+    EXPECT_EQ("the request body"sv, req.body);
+}
+
+TEST_F(WebTest, requestHeadersAreSent)
+{
+    auto opts = options();
+    opts.headers.insert_or_assign("X-Custom-Header", "custom-value");
+    opts.headers.insert_or_assign("Content-Type", "application/json");
+
+    fetch(std::move(opts));
+
+    auto const req = server_.last_request();
+    EXPECT_EQ("custom-value"sv, req.headers.at("x-custom-header"));
+    EXPECT_EQ("application/json"sv, req.headers.at("content-type"));
+}
+
+TEST_F(WebTest, responseHeadersAreCaptured)
+{
+    server_.set_handler([](evhttp_request* req) {
+        auto* const out = evhttp_request_get_output_headers(req);
+        evhttp_add_header(out, "X-Reply-Header", "reply-value");
+        LoopbackServer::reply(req, HTTP_OK, "OK", "body"sv);
+    });
+
+    auto const response = fetch(options());
+
+    // lookup is case-insensitive
+    ASSERT_TRUE(response.header("x-reply-header"));
+    EXPECT_EQ("reply-value"sv, *response.header("x-reply-header"));
+    EXPECT_EQ("reply-value"sv, *response.header("X-REPLY-HEADER"));
+
+    // a missing header is nullopt
+    EXPECT_FALSE(response.header("X-Does-Not-Exist"));
+}
+
+TEST_F(WebTest, basicAuthSendsCredentials)
+{
+    auto opts = options();
+    opts.username = "aladdin";
+    opts.password = "opensesame";
+
+    fetch(std::move(opts));
+
+    auto const expected = fmt::format("Basic {:s}", tr_base64_encode("aladdin:opensesame"sv));
+    EXPECT_EQ(expected, server_.last_request().headers.at("authorization"));
+}
+
+TEST_F(WebTest, basicAuthEmptyPassword)
+{
+    auto opts = options();
+    opts.username = "user";
+    // no password
+
+    fetch(std::move(opts));
+
+    auto const expected = fmt::format("Basic {:s}", tr_base64_encode("user:"sv));
+    EXPECT_EQ(expected, server_.last_request().headers.at("authorization"));
+}
+
+TEST_F(WebTest, netrcCredentialsAreSent)
+{
+    auto const netrc_path = fmt::format("{:s}/netrc", sandboxDir());
+    createFileWithContents(netrc_path, "machine 127.0.0.1 login aladdin password opensesame\n"sv);
+
+    auto opts = options();
+    opts.netrc_file = netrc_path;
+
+    fetch(std::move(opts));
+
+    auto const expected = fmt::format("Basic {:s}", tr_base64_encode("aladdin:opensesame"sv));
+    EXPECT_EQ(expected, server_.last_request().headers.at("authorization"));
+}
+
+TEST_F(WebTest, authSchemeAnyDefersCredentials)
+{
+    auto opts = options();
+    opts.username = "aladdin";
+    opts.password = "opensesame";
+    opts.auth_scheme = tr_web::FetchOptions::AuthScheme::Any;
+
+    fetch(std::move(opts));
+
+    // Under CURLAUTH_ANY curl waits for a challenge before sending credentials,
+    // so a server that answers 200 immediately never sees an Authorization header.
+    auto const& headers = server_.last_request().headers;
+    EXPECT_EQ(headers.end(), headers.find("authorization"));
+}
+
+TEST_F(WebTest, userDataRoundTrips)
+{
+    auto sentinel = int{ 42 };
+    auto const response = fetch(options("/"sv, &sentinel));
+    EXPECT_EQ(&sentinel, response.user_data);
+}
+
+TEST_F(WebTest, rangeRequestSetsHeader)
+{
+    auto opts = options();
+    opts.range = std::make_pair(uint64_t{ 0 }, uint64_t{ 3 });
+
+    fetch(std::move(opts));
+
+    EXPECT_EQ("bytes=0-3"sv, server_.last_request().headers.at("range"));
+}
+
+TEST_F(WebTest, cookiesAreSent)
+{
+    auto opts = options();
+    opts.cookies = "a=b; c=d";
+
+    fetch(std::move(opts));
+
+    EXPECT_EQ("a=b; c=d"sv, server_.last_request().headers.at("cookie"));
+}
+
+TEST_F(WebTest, userAgentFromMediatorIsSent)
+{
+    // the mediator's user agent is read once when the tr_web is created, so
+    // set it before building a dedicated tr_web for this test
+    mediator_.user_agent_ = "TestAgent/1.0";
+    auto web = tr_web::create(mediator_);
+
+    fetch(*web, options());
+
+    EXPECT_EQ("TestAgent/1.0"sv, server_.last_request().headers.at("user-agent"));
+}
+
+TEST_F(WebTest, onDataReceivedReportsByteCount)
+{
+    static auto constexpr Body = "0123456789abcdef"sv;
+    server_.set_handler([](evhttp_request* req) { LoopbackServer::reply(req, HTTP_OK, "OK", Body); });
+
+    auto total = std::size_t{ 0 };
+    auto opts = options();
+    opts.on_data_received = [&total](std::size_t n_bytes) {
+        total += n_bytes;
+    };
+
+    auto const response = fetch(std::move(opts));
+    EXPECT_EQ(std::size(Body), std::size(response.body));
+    EXPECT_EQ(std::size(Body), total);
+}
+
+TEST_F(WebTest, timeoutIsReported)
+{
+    // Handler that never replies, so the transfer exceeds the timeout.
+    server_.set_handler([](evhttp_request* /*req*/) {});
+
+    auto opts = options();
+    opts.timeout_secs = 1s;
+
+    auto const response = fetch(std::move(opts));
+    EXPECT_EQ(0, response.status);
+    EXPECT_TRUE(response.did_timeout);
+}
+
+} // namespace

--- a/tests/libtransmission/web-utils-test.cc
+++ b/tests/libtransmission/web-utils-test.cc
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef> // size_t
+#include <optional>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -286,4 +287,60 @@ TEST_F(WebUtilsTest, urlPercentEncode)
         tr_urlPercentEncode(std::back_inserter(buf), decoded, escape_reserved);
         EXPECT_EQ(encoded, buf);
     }
+}
+
+TEST_F(WebUtilsTest, httpParseHeaderLine)
+{
+    // a simple "Name: value" pair
+    auto parsed = tr_httpParseHeaderLine("Content-Type: text/plain"sv);
+    ASSERT_TRUE(parsed);
+    EXPECT_EQ("Content-Type"sv, parsed->first);
+    EXPECT_EQ("text/plain"sv, parsed->second);
+
+    // leading spaces and tabs in the value are trimmed
+    parsed = tr_httpParseHeaderLine("X-Foo: \t  bar"sv);
+    ASSERT_TRUE(parsed);
+    EXPECT_EQ("X-Foo"sv, parsed->first);
+    EXPECT_EQ("bar"sv, parsed->second);
+
+    // trailing spaces and tabs in the value are trimmed (RFC 7230 OWS)
+    parsed = tr_httpParseHeaderLine("X-Foo: bar \t "sv);
+    ASSERT_TRUE(parsed);
+    EXPECT_EQ("X-Foo"sv, parsed->first);
+    EXPECT_EQ("bar"sv, parsed->second);
+
+    // both leading and trailing whitespace are trimmed, around CR / LF
+    parsed = tr_httpParseHeaderLine("X-Foo: \t bar \t\r\n"sv);
+    ASSERT_TRUE(parsed);
+    EXPECT_EQ("X-Foo"sv, parsed->first);
+    EXPECT_EQ("bar"sv, parsed->second);
+
+    // a trailing CR / LF is ignored
+    parsed = tr_httpParseHeaderLine("X-Foo: bar\r\n"sv);
+    ASSERT_TRUE(parsed);
+    EXPECT_EQ("X-Foo"sv, parsed->first);
+    EXPECT_EQ("bar"sv, parsed->second);
+
+    // colons in the value are preserved (only the first colon splits)
+    parsed = tr_httpParseHeaderLine("Date: Mon, 01 Jan 2024 00:00:00 GMT"sv);
+    ASSERT_TRUE(parsed);
+    EXPECT_EQ("Date"sv, parsed->first);
+    EXPECT_EQ("Mon, 01 Jan 2024 00:00:00 GMT"sv, parsed->second);
+
+    // a name with an empty value (line ends right after the colon)
+    parsed = tr_httpParseHeaderLine("X-Empty:"sv);
+    ASSERT_TRUE(parsed);
+    EXPECT_EQ("X-Empty"sv, parsed->first);
+    EXPECT_EQ(""sv, parsed->second);
+
+    // a value consisting only of whitespace is empty
+    parsed = tr_httpParseHeaderLine("X-Blank:   \r\n"sv);
+    ASSERT_TRUE(parsed);
+    EXPECT_EQ("X-Blank"sv, parsed->first);
+    EXPECT_EQ(""sv, parsed->second);
+
+    // lines without a colon (the status line, the blank separator) are skipped
+    EXPECT_FALSE(tr_httpParseHeaderLine("HTTP/1.1 200 OK"sv));
+    EXPECT_FALSE(tr_httpParseHeaderLine(""sv));
+    EXPECT_FALSE(tr_httpParseHeaderLine("\r\n"sv));
 }

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -17,3 +17,30 @@ AddShowTest(transmission-show-thor Thor_and_the_Amazon_Women.avi)
 AddShowTest(transmission-show-ubuntu ubuntu-20.04.3-desktop-amd64.iso)
 AddShowTest(transmission-show-ubuntu-hybrid hybrid-single-ubuntu-20.04.3-desktop-amd64.iso)
 AddShowTest(transmission-show-bitcomet-path.utf8 bitcomet.utf-8.special)
+
+if(TARGET transmission-remote)
+    include(GoogleTest)
+
+    add_executable(transmission-remote-test remote-test.cc)
+
+    set_property(
+        TARGET transmission-remote-test
+        PROPERTY FOLDER "tests")
+
+    target_compile_definitions(transmission-remote-test
+        PRIVATE
+            __TRANSMISSION__
+            TR_REMOTE_EXE="$<TARGET_FILE:transmission-remote>")
+
+    target_link_libraries(transmission-remote-test
+        PRIVATE
+            ${TR_NAME}
+            GTest::gtest_main
+            transmission::fmt-header-only
+            libevent::core
+            libevent::extra)
+
+    add_dependencies(transmission-remote-test transmission-remote)
+
+    tr_setup_gtest_target(transmission-remote-test "UR.")
+endif()

--- a/tests/utils/remote-test.cc
+++ b/tests/utils/remote-test.cc
@@ -23,6 +23,7 @@
 #include <fmt/format.h>
 
 #include <libtransmission/net.h> // sockaddr_storage, ntohs()
+#include <libtransmission/utils.h> // tr_lib_init()
 
 #include <gtest/gtest.h>
 
@@ -166,6 +167,8 @@ CommandResult run(std::string const& command)
 
 TEST(RemoteLoopback, performsSessionHandshakeAndSucceeds)
 {
+    tr_lib_init(); // start up Winsock on Windows before the mock server binds
+
     auto server = MockRpcServer{};
 
     auto const command = fmt::format(R"("{:s}" 127.0.0.1:{:d} -l 2>&1)", TR_REMOTE_EXE, server.port());

--- a/tests/utils/remote-test.cc
+++ b/tests/utils/remote-test.cc
@@ -1,0 +1,179 @@
+// This file Copyright © Mnemosaic LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosaic LLC.
+// License text can be found in the licenses/ folder.
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <string_view>
+#include <thread>
+
+#ifndef _WIN32
+#include <sys/wait.h> // WIFEXITED(), WEXITSTATUS()
+#endif
+
+#include <event2/buffer.h>
+#include <event2/event.h>
+#include <event2/http.h>
+
+#include <fmt/format.h>
+
+#include <libtransmission/net.h> // sockaddr_storage, ntohs()
+
+#include <gtest/gtest.h>
+
+using namespace std::literals;
+
+namespace
+{
+
+auto constexpr SessionId = "test-session-id"sv;
+
+// A minimal in-process stand-in for transmission-daemon's RPC endpoint. It
+// mimics just enough of the daemon to exercise transmission-remote end to end:
+// the CSRF handshake (reply 409 with an X-Transmission-Session-Id the client
+// must echo back) followed by a valid, empty success response. Everything
+// stays on 127.0.0.1, so there's no external dependency and nothing to flake.
+class MockRpcServer
+{
+public:
+    MockRpcServer()
+        : base_{ event_base_new() }
+        , http_{ evhttp_new(base_) }
+    {
+        evhttp_set_allowed_methods(http_, EVHTTP_REQ_GET | EVHTTP_REQ_POST | EVHTTP_REQ_HEAD);
+
+        auto* const handle = evhttp_bind_socket_with_handle(http_, "127.0.0.1", 0);
+        auto ss = sockaddr_storage{};
+        auto sslen = socklen_t{ sizeof(ss) };
+        getsockname(evhttp_bound_socket_get_fd(handle), reinterpret_cast<sockaddr*>(&ss), &sslen);
+        port_ = ntohs(reinterpret_cast<sockaddr_in const*>(&ss)->sin_port);
+
+        evhttp_set_gencb(http_, &MockRpcServer::on_request, this);
+
+        thread_ = std::thread{ [this]() {
+            // Poll instead of a blocking dispatch so teardown doesn't depend on
+            // libevent being built with cross-thread wakeup support.
+            while (!stop_.load(std::memory_order_acquire)) {
+                event_base_loop(base_, EVLOOP_NONBLOCK);
+                std::this_thread::sleep_for(1ms);
+            }
+        } };
+    }
+
+    ~MockRpcServer()
+    {
+        stop_.store(true, std::memory_order_release);
+        if (thread_.joinable()) {
+            thread_.join();
+        }
+        evhttp_free(http_);
+        event_base_free(base_);
+    }
+
+    MockRpcServer(MockRpcServer const&) = delete;
+    MockRpcServer& operator=(MockRpcServer const&) = delete;
+
+    [[nodiscard]] uint16_t port() const noexcept
+    {
+        return port_;
+    }
+
+    [[nodiscard]] int request_count() const noexcept
+    {
+        return request_count_.load();
+    }
+
+    [[nodiscard]] bool authenticated_request_seen() const noexcept
+    {
+        return authenticated_request_seen_.load();
+    }
+
+private:
+    static void on_request(evhttp_request* req, void* vself)
+    {
+        static_cast<MockRpcServer*>(vself)->handle(req);
+    }
+
+    void handle(evhttp_request* req)
+    {
+        request_count_.fetch_add(1);
+
+        auto* const in_headers = evhttp_request_get_input_headers(req);
+        auto const* const session_id = evhttp_find_header(in_headers, "X-Transmission-Session-Id");
+        auto* const out_headers = evhttp_request_get_output_headers(req);
+        auto* const out = evbuffer_new();
+
+        if (session_id == nullptr) {
+            // CSRF handshake: reject and hand back a session id to retry with.
+            evhttp_add_header(out_headers, "X-Transmission-Session-Id", std::string{ SessionId }.c_str());
+            evhttp_send_reply(req, 409, "Conflict", out);
+        } else {
+            authenticated_request_seen_.store(std::string_view{ session_id } == SessionId);
+            evhttp_add_header(out_headers, "Content-Type", "application/json");
+            static auto constexpr Body = R"({"result":"success","arguments":{}})"sv;
+            evbuffer_add(out, std::data(Body), std::size(Body));
+            evhttp_send_reply(req, 200, "OK", out);
+        }
+
+        evbuffer_free(out);
+    }
+
+    event_base* base_;
+    evhttp* http_;
+    uint16_t port_ = 0;
+
+    std::thread thread_;
+    std::atomic<bool> stop_ = false;
+    std::atomic<int> request_count_ = 0;
+    std::atomic<bool> authenticated_request_seen_ = false;
+};
+
+struct CommandResult {
+    int exit_code = -1;
+    std::string output;
+};
+
+// Run a command, capturing its combined stdout+stderr and exit code.
+CommandResult run(std::string const& command)
+{
+#ifdef _WIN32
+    auto* const pipe = _popen(command.c_str(), "r");
+#else
+    auto* const pipe = popen(command.c_str(), "r");
+#endif
+    if (pipe == nullptr) {
+        return {};
+    }
+
+    auto output = std::string{};
+    auto buffer = std::array<char, 4096>{};
+    while (std::fgets(std::data(buffer), std::size(buffer), pipe) != nullptr) {
+        output += std::data(buffer);
+    }
+
+#ifdef _WIN32
+    return { _pclose(pipe), output };
+#else
+    auto const rc = pclose(pipe);
+    return { WIFEXITED(rc) ? WEXITSTATUS(rc) : -1, output };
+#endif
+}
+
+TEST(RemoteLoopback, performsSessionHandshakeAndSucceeds)
+{
+    auto server = MockRpcServer{};
+
+    auto const command = fmt::format(R"("{:s}" 127.0.0.1:{:d} -l 2>&1)", TR_REMOTE_EXE, server.port());
+    auto const result = run(command);
+
+    EXPECT_EQ(0, result.exit_code) << result.output;
+    EXPECT_EQ(2, server.request_count()) << "expected a 409 handshake followed by an authenticated retry";
+    EXPECT_TRUE(server.authenticated_request_seen());
+}
+
+} // namespace

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -8,7 +8,6 @@ foreach(P create edit remote show)
     target_link_libraries(${TR_NAME}-${P}
         PRIVATE
             ${TR_NAME}
-            CURL::libcurl
             transmission::fmt-header-only
             libevent::core)
 

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -13,15 +13,15 @@
 #include <cstdlib>
 #include <cstring> /* strcmp */
 #include <ctime>
+#include <future>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <set>
 #include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
-
-#include <curl/curl.h>
 
 #include <fmt/chrono.h>
 #include <fmt/format.h>
@@ -43,6 +43,7 @@
 #include <libtransmission/values.h>
 #include <libtransmission/variant.h>
 #include <libtransmission/version.h>
+#include <libtransmission/web.h>
 
 using namespace std::literals;
 
@@ -67,6 +68,18 @@ char constexpr Usage[] = "transmission-remote " LONG_VERSION_STRING
                          "\n"
                          "See the man page for detailed explanations and many examples.";
 
+class RemoteWebMediator final : public tr_web::Mediator
+{
+public:
+    [[nodiscard]] std::optional<std::string_view> userAgent() const override
+    {
+        return std::string_view{ user_agent_ };
+    }
+
+private:
+    std::string const user_agent_ = fmt::format("{:s}/{:s}", MyName, LONG_VERSION_STRING);
+};
+
 struct RemoteConfig {
     std::string auth;
     std::string filter;
@@ -80,6 +93,11 @@ struct RemoteConfig {
     bool use_ssl = false;
 
     api_compat::Style network_style = api_compat::Style::Tr4;
+
+    // Shared HTTP client, created lazily on the first request. web_mediator is
+    // declared before web so that web (which references it) is destroyed first.
+    RemoteWebMediator web_mediator;
+    std::unique_ptr<tr_web> web;
 };
 
 // --- Display Utilities
@@ -789,27 +807,8 @@ auto constexpr ListKeys = std::to_array<tr_quark>({
 });
 static_assert(ListKeys[std::size(ListKeys) - 1] != tr_quark{});
 
-[[nodiscard]] size_t write_func(void* ptr, size_t size, size_t nmemb, void* vbuf)
-{
-    auto const n_bytes = size * nmemb;
-    static_cast<std::string*>(vbuf)->append(static_cast<char const*>(ptr), n_bytes);
-    return n_bytes;
-}
-
 namespace header_utils
 {
-// `${name}: {$value}` --> std::pair<name, value>
-[[nodiscard]] std::optional<std::pair<std::string_view, std::string_view>> parse_header(std::string_view const line)
-{
-    static auto constexpr Delimiter = ": "sv;
-    if (auto const pos = line.find(Delimiter); pos != std::string_view::npos) {
-        auto const name = tr_strv_strip(line.substr(0, pos));
-        auto const value = tr_strv_strip(line.substr(pos + std::size(Delimiter)));
-        return std::make_pair(name, value);
-    }
-    return {};
-}
-
 void warn_if_unsupported_rpc_version(std::string_view const semver)
 {
     static auto constexpr ExpectedMajor = TrRpcVersionSemverMajor;
@@ -824,31 +823,18 @@ void warn_if_unsupported_rpc_version(std::string_view const semver)
 }
 } // namespace header_utils
 
-// look for a session id in the header
-// in case the server gives back a 409
-[[nodiscard]] size_t parse_response_header(void* ptr, size_t size, size_t nmemb, void* vconfig)
+// Pull the session id (needed to retry a 409) and the RPC-version header out
+// of a response, mirroring what the old curl header callback used to do.
+void update_config_from_response(tr_web::FetchResponse const& response, RemoteConfig& config)
 {
-    using namespace header_utils;
-    static auto const session_id_header = tr_strlower(TrRpcSessionIdHeader);
-    static auto const rpc_version_header = tr_strlower(TrRpcVersionHeader);
-
-    auto& config = *static_cast<RemoteConfig*>(vconfig);
-
-    auto const line = std::string_view{ static_cast<char const*>(ptr), size * nmemb };
-
-    if (auto const parsed = parse_header(line)) {
-        auto const [key, val] = *parsed;
-        auto const key_lower = tr_strlower(key);
-
-        if (key_lower == session_id_header) {
-            config.session_id = val;
-        } else if (key_lower == rpc_version_header) {
-            config.network_style = api_compat::Style::Tr5;
-            warn_if_unsupported_rpc_version(val);
-        }
+    if (auto const id = response.header(TrRpcSessionIdHeader); id) {
+        config.session_id = std::string{ *id };
     }
 
-    return std::size(line);
+    if (auto const version = response.header(TrRpcVersionHeader); version) {
+        config.network_style = api_compat::Style::Tr5;
+        header_utils::warn_if_unsupported_rpc_version(*version);
+    }
 }
 
 [[nodiscard]] std::string get_status_string(tr_variant::Map const& t)
@@ -2094,66 +2080,6 @@ int process_response(char const* rpcurl, std::string_view const response, Remote
 
 namespace flush_utils
 {
-CURL* tr_curl_easy_init(std::string* writebuf, RemoteConfig& config)
-{
-    CURL* curl = curl_easy_init();
-    (void)curl_easy_setopt(curl, CURLOPT_USERAGENT, fmt::format("{:s}/{:s}", MyName, LONG_VERSION_STRING).c_str());
-    (void)curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_func);
-    (void)curl_easy_setopt(curl, CURLOPT_WRITEDATA, writebuf);
-    (void)curl_easy_setopt(curl, CURLOPT_HEADERDATA, &config);
-    (void)curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, parse_response_header);
-    (void)curl_easy_setopt(curl, CURLOPT_POST, 1);
-    (void)curl_easy_setopt(curl, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
-    (void)curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
-    (void)curl_easy_setopt(curl, CURLOPT_VERBOSE, config.debug);
-    (void)curl_easy_setopt(
-        curl,
-        CURLOPT_ENCODING,
-        ""); /* "" tells curl to fill in the blanks with what it was compiled to support */
-
-    if (auto const& str = config.unix_socket_path; !std::empty(str)) {
-        (void)curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH, str.c_str());
-    }
-
-    if (auto const& str = config.netrc; !std::empty(str)) {
-        (void)curl_easy_setopt(curl, CURLOPT_NETRC_FILE, str.c_str());
-    }
-
-    if (auto const& str = config.auth; !std::empty(str)) {
-        (void)curl_easy_setopt(curl, CURLOPT_USERPWD, str.c_str());
-    }
-
-    if (config.use_ssl) {
-        // do not verify subject/hostname
-        (void)curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
-
-        // since most certs will be self-signed, do not verify against CA
-        (void)curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
-    }
-
-    if (auto const& str = config.session_id; !std::empty(str)) {
-        auto const h = fmt::format("{:s}: {:s}", TrRpcSessionIdHeader, str);
-        auto* const custom_headers = curl_slist_append(nullptr, h.c_str());
-
-        (void)curl_easy_setopt(curl, CURLOPT_HTTPHEADER, custom_headers);
-        (void)curl_easy_setopt(curl, CURLOPT_PRIVATE, custom_headers);
-    }
-
-    return curl;
-}
-
-void tr_curl_easy_cleanup(CURL* curl)
-{
-    struct curl_slist* custom_headers = nullptr;
-    curl_easy_getinfo(curl, CURLINFO_PRIVATE, &custom_headers);
-
-    curl_easy_cleanup(curl);
-
-    if (custom_headers != nullptr) {
-        curl_slist_free_all(custom_headers);
-    }
-}
-
 [[nodiscard]] long get_timeout_secs(std::string_view req)
 {
     if (tr_strv_contains(req, R"("method":"blocklist-update")") || tr_strv_contains(req, R"("method":"blocklist_update")")) {
@@ -2161,6 +2087,63 @@ void tr_curl_easy_cleanup(CURL* curl)
     }
 
     return 60L; /* default value */
+}
+
+// Lazily create the shared tr_web used for every request in this run.
+[[nodiscard]] tr_web& web_for(RemoteConfig& config)
+{
+    if (!config.web) {
+        config.web = tr_web::create(config.web_mediator);
+    }
+
+    return *config.web;
+}
+
+// Issue one RPC request and block until tr_web hands back the response.
+[[nodiscard]] tr_web::FetchResponse blocking_fetch(RemoteConfig& config, std::string const& url, std::string const& payload)
+{
+    auto promise = std::make_shared<std::promise<tr_web::FetchResponse>>();
+    auto future = promise->get_future();
+
+    auto options = tr_web::FetchOptions{
+        url,
+        [promise](tr_web::FetchResponse const& response) { promise->set_value(response); },
+        nullptr,
+        std::chrono::seconds{ get_timeout_secs(payload) },
+    };
+
+    options.body = payload;
+
+    // match the old curl setup: negotiate whatever auth scheme the server
+    // offers and always allow an (optional) .netrc lookup
+    options.auth_scheme = tr_web::FetchOptions::AuthScheme::Any;
+    options.netrc_file = config.netrc;
+    options.verbose = config.debug;
+
+    if (config.use_ssl) {
+        // most RPC servers sit behind a self-signed cert
+        options.ssl_verify = false;
+    }
+
+    if (!std::empty(config.unix_socket_path)) {
+        options.unix_socket_path = config.unix_socket_path;
+    }
+
+    if (!std::empty(config.session_id)) {
+        options.headers.insert_or_assign(std::string{ TrRpcSessionIdHeader }, config.session_id);
+    }
+
+    if (auto const& auth = config.auth; !std::empty(auth)) {
+        if (auto const colon = auth.find(':'); colon != std::string::npos) {
+            options.username = auth.substr(0, colon);
+            options.password = auth.substr(colon + 1U);
+        } else {
+            options.username = auth;
+        }
+    }
+
+    web_for(config).fetch(std::move(options));
+    return future.get();
 }
 } // namespace flush_utils
 
@@ -2173,54 +2156,43 @@ int flush(char const* rpcurl, tr_variant* const var, RemoteConfig& config)
     auto const scheme = config.use_ssl ? "https"sv : "http"sv;
     auto const rpcurl_http = fmt::format("{:s}://{:s}", scheme, rpcurl);
 
-    auto buf = std::string{};
-    auto* curl = tr_curl_easy_init(&buf, config);
-    (void)curl_easy_setopt(curl, CURLOPT_URL, rpcurl_http.c_str());
-    (void)curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload.c_str());
-    (void)curl_easy_setopt(curl, CURLOPT_TIMEOUT, get_timeout_secs(payload));
-
     if (config.debug) {
         fmt::print(stderr, "posting:\n--------\n{:s}\n--------\n", payload);
     }
 
+    auto const response = blocking_fetch(config, rpcurl_http, payload);
+
+    // pull the session id / rpc version out of the response headers
+    update_config_from_response(response, config);
+
     auto status = EXIT_SUCCESS;
-    if (auto const res = curl_easy_perform(curl); res != CURLE_OK) {
-        fmt::print(stderr, "Unable to send request to '{}': {}\n", rpcurl_http, curl_easy_strerror(res));
-        status |= EXIT_FAILURE;
-    } else {
-        long response;
-        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);
+    switch (response.status) {
+    case 200:
+        status |= process_response(rpcurl, response.body, config);
+        break;
 
-        switch (response) {
-        case 200:
-            status |= process_response(rpcurl, buf, config);
-            break;
-
-        case 204:
-            if (!config.json) {
-                fmt::print("{:s} acknowledged notification\n", rpcurl);
-            }
-            break;
-
-        case 409:
-            // Session id failed. Our curl header func has already
-            // pulled the new session id from this response's headers.
-            // Build a new CURL* and try again
-            tr_curl_easy_cleanup(curl);
-            curl = nullptr;
-            status |= flush(rpcurl, var, config);
-            break;
-
-        default:
-            fmt::print(stderr, "Unexpected response: {:s}\n", buf);
-            status |= EXIT_FAILURE;
-            break;
+    case 204:
+        if (!config.json) {
+            fmt::print("{:s} acknowledged notification\n", rpcurl);
         }
-    }
+        break;
 
-    /* cleanup */
-    if (curl != nullptr) {
-        tr_curl_easy_cleanup(curl);
+    case 409:
+        // Session id failed. update_config_from_response() has already pulled
+        // the new session id from this response's headers, so try again.
+        status |= flush(rpcurl, var, config);
+        break;
+
+    case 0:
+        // no HTTP response: connection failure or timeout
+        fmt::print(stderr, "Unable to send request to '{}'\n", rpcurl_http);
+        status |= EXIT_FAILURE;
+        break;
+
+    default:
+        fmt::print(stderr, "Unexpected response: {:s}\n", response.body);
+        status |= EXIT_FAILURE;
+        break;
     }
 
     var->clear();


### PR DESCRIPTION
Another piece in project to reduce parallel code / duplicated code.

- Extends `tr_web` functionality to support authorization, POST, and header getting/setting,
- Updates `transmission-remote` to use the `tr_web` API instead of using libcurl directly.
- Adds our first live `tr_web` tests via a loopback server!
- Adds our first live (very basic) `transmission-remote` tests via a loopback server!

This refactor is a prerequisite to moving `qt/RpcClient` and `qt/RpcQueue` into `libtransmission-app` where we can have a reusable RPC client that can be used by more than just `transmission-qt`.

AI disclosure: I have reviewed all code in this PR. Design by me. libcurl usage nitpicks and bugfixes by Claude. All tests by Claude with review by me.

*edited to add:* `+1,027 -143` looks scary, but the delta for production code is mostly flat. >700 LOC are new tests +  new test cmake.