### PR TITLE
refactor: remove experimental tr_peer_stat fields

### DIFF
--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -942,14 +942,6 @@ public:
         add(upload_request_count_string);
         add(download_request_count_number);
         add(download_request_count_string);
-        add(blocks_downloaded_count_number);
-        add(blocks_downloaded_count_string);
-        add(blocks_uploaded_count_number);
-        add(blocks_uploaded_count_string);
-        add(reqs_cancelled_by_client_count_number);
-        add(reqs_cancelled_by_client_count_string);
-        add(reqs_cancelled_by_peer_count_number);
-        add(reqs_cancelled_by_peer_count_string);
         add(encryption_stock_id);
         add(flags);
         add(torrent_name);
@@ -969,14 +961,6 @@ public:
     Gtk::TreeModelColumn<Glib::ustring> upload_request_count_string;
     Gtk::TreeModelColumn<decltype(tr_peer_stat::active_reqs_to_peer)> download_request_count_number;
     Gtk::TreeModelColumn<Glib::ustring> download_request_count_string;
-    Gtk::TreeModelColumn<decltype(tr_peer_stat::blocks_to_client)> blocks_downloaded_count_number;
-    Gtk::TreeModelColumn<Glib::ustring> blocks_downloaded_count_string;
-    Gtk::TreeModelColumn<decltype(tr_peer_stat::blocks_to_peer)> blocks_uploaded_count_number;
-    Gtk::TreeModelColumn<Glib::ustring> blocks_uploaded_count_string;
-    Gtk::TreeModelColumn<decltype(tr_peer_stat::cancels_to_peer)> reqs_cancelled_by_client_count_number;
-    Gtk::TreeModelColumn<Glib::ustring> reqs_cancelled_by_client_count_string;
-    Gtk::TreeModelColumn<decltype(tr_peer_stat::cancels_to_client)> reqs_cancelled_by_peer_count_number;
-    Gtk::TreeModelColumn<Glib::ustring> reqs_cancelled_by_peer_count_string;
     Gtk::TreeModelColumn<Glib::ustring> encryption_stock_id;
     Gtk::TreeModelColumn<Glib::ustring> flags;
     Gtk::TreeModelColumn<Glib::ustring> torrent_name;
@@ -1041,22 +1025,6 @@ void refreshPeerRow(Gtk::TreeModel::iterator const& iter, tr_peer_stat const& pe
         up_count = std::to_string(peer.active_reqs_to_client);
     }
 
-    if (peer.blocks_to_peer > 0) {
-        blocks_to_peer = std::to_string(peer.blocks_to_peer);
-    }
-
-    if (peer.blocks_to_client > 0) {
-        blocks_to_client = std::to_string(peer.blocks_to_client);
-    }
-
-    if (peer.cancels_to_peer > 0) {
-        cancelled_by_client = std::to_string(peer.cancels_to_peer);
-    }
-
-    if (peer.cancels_to_client > 0) {
-        cancelled_by_peer = std::to_string(peer.cancels_to_client);
-    }
-
     (*iter)[peer_cols.progress] = static_cast<int>(100.0 * peer.progress);
     (*iter)[peer_cols.upload_request_count_number] = peer.active_reqs_to_client;
     (*iter)[peer_cols.upload_request_count_string] = up_count;
@@ -1068,14 +1036,6 @@ void refreshPeerRow(Gtk::TreeModel::iterator const& iter, tr_peer_stat const& pe
     (*iter)[peer_cols.upload_rate_string] = up_speed_string;
     (*iter)[peer_cols.flags] = peer.flag_str;
     (*iter)[peer_cols.was_updated] = true;
-    (*iter)[peer_cols.blocks_downloaded_count_number] = peer.blocks_to_client;
-    (*iter)[peer_cols.blocks_downloaded_count_string] = blocks_to_client;
-    (*iter)[peer_cols.blocks_uploaded_count_number] = peer.blocks_to_peer;
-    (*iter)[peer_cols.blocks_uploaded_count_string] = blocks_to_peer;
-    (*iter)[peer_cols.reqs_cancelled_by_client_count_number] = peer.cancels_to_peer;
-    (*iter)[peer_cols.reqs_cancelled_by_client_count_string] = cancelled_by_client;
-    (*iter)[peer_cols.reqs_cancelled_by_peer_count_number] = peer.cancels_to_client;
-    (*iter)[peer_cols.reqs_cancelled_by_peer_count_string] = cancelled_by_peer;
 }
 
 } // namespace
@@ -1323,10 +1283,6 @@ void setPeerViewColumns(Gtk::TreeView* peer_view)
 
     if (more) {
         view_columns.push_back(&peer_cols.download_request_count_string);
-        view_columns.push_back(&peer_cols.blocks_downloaded_count_string);
-        view_columns.push_back(&peer_cols.blocks_uploaded_count_string);
-        view_columns.push_back(&peer_cols.reqs_cancelled_by_client_count_string);
-        view_columns.push_back(&peer_cols.reqs_cancelled_by_peer_count_string);
     }
 
     view_columns.push_back(&peer_cols.progress);
@@ -1368,26 +1324,6 @@ void setPeerViewColumns(Gtk::TreeView* peer_view)
             c = Gtk::make_managed<Gtk::TreeViewColumn>(_("Up Reqs"), *r);
             c->add_attribute(r->property_text(), *col);
             sort_col = &peer_cols.upload_request_count_number;
-        } else if (*col == peer_cols.blocks_downloaded_count_string) {
-            auto* r = Gtk::make_managed<Gtk::CellRendererText>();
-            c = Gtk::make_managed<Gtk::TreeViewColumn>(_("Dn Blocks"), *r);
-            c->add_attribute(r->property_text(), *col);
-            sort_col = &peer_cols.blocks_downloaded_count_number;
-        } else if (*col == peer_cols.blocks_uploaded_count_string) {
-            auto* r = Gtk::make_managed<Gtk::CellRendererText>();
-            c = Gtk::make_managed<Gtk::TreeViewColumn>(_("Up Blocks"), *r);
-            c->add_attribute(r->property_text(), *col);
-            sort_col = &peer_cols.blocks_uploaded_count_number;
-        } else if (*col == peer_cols.reqs_cancelled_by_client_count_string) {
-            auto* r = Gtk::make_managed<Gtk::CellRendererText>();
-            c = Gtk::make_managed<Gtk::TreeViewColumn>(_("We Cancelled"), *r);
-            c->add_attribute(r->property_text(), *col);
-            sort_col = &peer_cols.reqs_cancelled_by_client_count_number;
-        } else if (*col == peer_cols.reqs_cancelled_by_peer_count_string) {
-            auto* r = Gtk::make_managed<Gtk::CellRendererText>();
-            c = Gtk::make_managed<Gtk::TreeViewColumn>(_("They Cancelled"), *r);
-            c->add_attribute(r->property_text(), *col);
-            sort_col = &peer_cols.reqs_cancelled_by_peer_count_number;
         } else if (*col == peer_cols.download_rate_string) {
             auto* r = Gtk::make_managed<Gtk::CellRendererText>();
             r->property_xalign() = 1.0F;

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -241,10 +241,6 @@ struct tr_peer {
 
     tr_swarm* const swarm;
 
-    tr_recentHistory<uint16_t> blocks_sent_to_peer;
-
-    tr_recentHistory<uint16_t> cancels_sent_to_client;
-
     tr_bitfield active_requests;
 
     /// The following fields are only to be used in peer-mgr.cc.
@@ -255,12 +251,6 @@ struct tr_peer {
 
     // how many bad pieces this piece has contributed to
     uint8_t strikes = 0;
-
-    // how many blocks this peer has sent us
-    tr_recentHistory<uint16_t> blocks_sent_to_client;
-
-    // how many requests we made to this peer and then canceled
-    tr_recentHistory<uint16_t> cancels_sent_to_peer;
 
     tr_recentHistory<size_t> bytes_sent_to_client;
     tr_recentHistory<size_t> bytes_sent_to_peer;

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -901,7 +901,6 @@ private:
                 auto* const tor = s->tor;
                 auto const loc = tor->piece_loc(event.pieceIndex, event.offset);
                 s->cancel_all_requests_for_block(loc.block, peer);
-                peer->blocks_sent_to_client.add(tr_time(), 1);
                 peer->blame.set(loc.piece);
                 s->got_block(tor, loc.block); // put this line before calling tr_torrent callback
                 tor->on_block_received(loc.block);
@@ -1596,11 +1595,6 @@ namespace peer_stat_helpers
     stats.is_downloading_from = peer->is_active(tr_direction::PeerToClient);
     stats.is_uploading_to = peer->is_active(tr_direction::ClientToPeer);
     stats.is_seed = peer->is_seed();
-
-    stats.blocks_to_peer = peer->blocks_sent_to_peer.count(now, CancelHistorySec);
-    stats.blocks_to_client = peer->blocks_sent_to_client.count(now, CancelHistorySec);
-    stats.cancels_to_peer = peer->cancels_sent_to_peer.count(now, CancelHistorySec);
-    stats.cancels_to_client = peer->cancels_sent_to_client.count(now, CancelHistorySec);
 
     stats.bytes_to_peer = peer->bytes_sent_to_peer.count(now, CancelHistorySec);
     stats.bytes_to_client = peer->bytes_sent_to_client.count(now, CancelHistorySec);

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -388,7 +388,6 @@ public:
 
     void cancel_block_request(tr_block_index_t block)
     {
-        cancels_sent_to_peer.add(tr_time(), 1);
         active_requests.unset(block);
         publish(tr_peer_event::SentCancel(tor_.block_info(), block));
         protocol_send_cancel(peer_request::from_block(tor_, block));
@@ -589,7 +588,7 @@ private:
 
     void maybe_send_metadata_requests(time_t now) const;
     [[nodiscard]] size_t add_next_metadata_piece();
-    [[nodiscard]] size_t add_next_block(time_t now_sec, uint64_t now_msec);
+    [[nodiscard]] size_t add_next_block(uint64_t now_msec);
 
     [[nodiscard]] size_t fill_output_buffer_impl(time_t now_sec, uint64_t now_msec);
     void fill_output_buffer(time_t now_sec, uint64_t now_msec)
@@ -1457,7 +1456,6 @@ ReadResult tr_peerMsgsImpl::process_peer_message(uint8_t id, MessageReader& payl
             r.index = payload.to_uint32();
             r.offset = payload.to_uint32();
             r.length = payload.to_uint32();
-            cancels_sent_to_client.add(tr_time(), 1);
             logtrace(this, fmt::format("got a Cancel {:d}:{:d}->{:d}", r.index, r.offset, r.length));
 
             auto& requests = peer_requested_;
@@ -1883,7 +1881,7 @@ void tr_peerMsgsImpl::check_request_timeout(time_t const now)
     // fulfill piece requests
     for (;;) {
         auto const old_len = n_bytes_written;
-        n_bytes_written += add_next_block(now_sec, now_msec);
+        n_bytes_written += add_next_block(now_msec);
         if (old_len == n_bytes_written) {
             break;
         }
@@ -1922,7 +1920,7 @@ void tr_peerMsgsImpl::check_request_timeout(time_t const now)
     return protocol_send_message(BtPeerMsgs::Ltep, ut_metadata_id_, tr_variant_serde::benc().to_string(std::move(tmp)), *data);
 }
 
-[[nodiscard]] size_t tr_peerMsgsImpl::add_next_block(time_t now_sec, uint64_t now_msec)
+[[nodiscard]] size_t tr_peerMsgsImpl::add_next_block(uint64_t const now_msec)
 {
     if (std::empty(peer_requested_) || io_->get_write_buffer_space(now_msec) == 0U) {
         return {};
@@ -1951,7 +1949,6 @@ void tr_peerMsgsImpl::check_request_timeout(time_t const now)
     }
 
     if (ok) {
-        blocks_sent_to_peer.add(now_sec, 1);
         auto const piece_data = std::string_view{ reinterpret_cast<char const*>(std::data(buf)), req.length };
         return protocol_send_message(BtPeerMsgs::Piece, req.index, req.offset, piece_data);
     }

--- a/libtransmission/types.h
+++ b/libtransmission/types.h
@@ -389,17 +389,6 @@ struct tr_peer_stat {
 
     float progress = {};
 
-    // THESE NEXT FOUR FIELDS ARE EXPERIMENTAL.
-    // Don't rely on them; they'll probably go away
-    // how many blocks we've sent to this peer in the last 120 seconds
-    uint32_t blocks_to_peer = {};
-    // how many blocks this client's sent to us in the last 120 seconds
-    uint32_t blocks_to_client = {};
-    // how many requests to this peer that we've cancelled in the last 120 seconds
-    uint32_t cancels_to_peer = {};
-    // how many requests this peer made of us, then cancelled, in the last 120 seconds
-    uint32_t cancels_to_client = {};
-
     uint16_t port = {};
     uint8_t from = {};
 


### PR DESCRIPTION
Remove these fields from `tr_peer_stat`.

They've _always_ been marked as unsupported, and the only way to see them was in the GTK UI, in an opt-in setting.

```c++
  // THESE NEXT FOUR FIELDS ARE EXPERIMENTAL.
  // Don't rely on them; they'll probably go away
  // how many blocks we've sent to this peer in the last 120 seconds
  uint32_t blocks_to_peer = {};
  // how many blocks this client's sent to us in the last 120 seconds
  uint32_t blocks_to_client = {};
  // how many requests to this peer that we've cancelled in the last 120 seconds
  uint32_t cancels_to_peer = {};
  // how many requests this peer made of us, then cancelled, in the last 120 seconds
  uint32_t cancels_to_client = {};
```