### PR TITLE
feat: add "show extra peer details" option to Qt client

### DIFF
--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -345,25 +345,27 @@ Files are returned in the order they are laid out in the torrent. References to 
 
 | Key | Value Type | transmission.h source
 |:--|:--|:--
-| `address`              | string     | tr_peer_stat
-| `bytes_to_client`      | number     | tr_peer_stat
-| `bytes_to_peer`        | number     | tr_peer_stat
-| `client_is_choked`     | boolean    | tr_peer_stat
-| `client_is_interested` | boolean    | tr_peer_stat
-| `client_name`          | string     | tr_peer_stat
-| `flag_str`             | string     | tr_peer_stat
-| `is_downloading_from`  | boolean    | tr_peer_stat
-| `is_encrypted`         | boolean    | tr_peer_stat
-| `is_incoming`          | boolean    | tr_peer_stat
-| `is_uploading_to`      | boolean    | tr_peer_stat
-| `is_utp`               | boolean    | tr_peer_stat
-| `peer_id`              | string     | tr_peer_stat
-| `peer_is_choked`       | boolean    | tr_peer_stat
-| `peer_is_interested`   | boolean    | tr_peer_stat
-| `port`                 | number     | tr_peer_stat
-| `progress`             | double     | tr_peer_stat
-| `rate_to_client` (B/s) | number     | tr_peer_stat
-| `rate_to_peer` (B/s)   | number     | tr_peer_stat
+| `active_reqs_to_client` | number    | tr_peer_stat
+| `active_reqs_to_peer`   | number     | tr_peer_stat
+| `address`               | string     | tr_peer_stat
+| `bytes_to_client`       | number     | tr_peer_stat
+| `bytes_to_peer`         | number     | tr_peer_stat
+| `client_is_choked`      | boolean    | tr_peer_stat
+| `client_is_interested`  | boolean    | tr_peer_stat
+| `client_name`           | string     | tr_peer_stat
+| `flag_str`              | string     | tr_peer_stat
+| `is_downloading_from`   | boolean    | tr_peer_stat
+| `is_encrypted`          | boolean    | tr_peer_stat
+| `is_incoming`           | boolean    | tr_peer_stat
+| `is_uploading_to`       | boolean    | tr_peer_stat
+| `is_utp`                | boolean    | tr_peer_stat
+| `peer_id`               | string     | tr_peer_stat
+| `peer_is_choked`        | boolean    | tr_peer_stat
+| `peer_is_interested`    | boolean    | tr_peer_stat
+| `port`                  | number     | tr_peer_stat
+| `progress`              | double     | tr_peer_stat
+| `rate_to_client` (B/s)  | number     | tr_peer_stat
+| `rate_to_peer` (B/s)    | number     | tr_peer_stat
 
 `peers_from`: an object containing:
 
@@ -1123,6 +1125,8 @@ Transmission 4.2.0 (`rpc_version_semver` 6.1.0, `rpc_version`: ?)
 
 | Method | Description
 |:---|:---
+| `torrent_get` | new arg `peers.active_reqs_to_client`
+| `torrent_get` | new arg `peers.active_reqs_to_peer`
 | `torrent_get` | new arg `webseeds_ex`
 | `torrent_get` | **DEPRECATED** `webseeds`. Use `webseeds_ex` instead.
 | `session_get` | new arg `recent_download_paths`

--- a/libtransmission-app/prefs.h
+++ b/libtransmission-app/prefs.h
@@ -72,6 +72,7 @@ struct AppPrefs {
     bool session_remote_auth_ = false;
     bool session_remote_https_ = false;
     bool show_backup_trackers_ = false;
+    bool show_extra_peer_details_ = false;
     bool show_notification_on_add_ = true;
     bool show_notification_on_complete_ = true;
     bool show_tracker_scrapes_ = false;
@@ -113,6 +114,7 @@ struct AppPrefs {
         Field<&AppPrefs::session_remote_url_base_path_>{ TR_KEY_remote_session_url_base_path },
         Field<&AppPrefs::session_remote_username_>{ TR_KEY_remote_session_username },
         Field<&AppPrefs::show_backup_trackers_>{ TR_KEY_show_backup_trackers },
+        Field<&AppPrefs::show_extra_peer_details_>{ TR_KEY_show_extra_peer_details },
         Field<&AppPrefs::show_notification_on_add_>{ TR_KEY_torrent_added_notification_enabled },
         Field<&AppPrefs::show_notification_on_complete_>{ TR_KEY_torrent_complete_notification_enabled },
         Field<&AppPrefs::show_tracker_scrapes_>{ TR_KEY_show_tracker_scrapes },

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -23,6 +23,8 @@ namespace
 auto constexpr MyStatic = std::array<std::string_view, TR_N_KEYS>{
     ""sv,
     "activeTorrentCount"sv, // rpc
+    "active_reqs_to_client"sv, // rpc
+    "active_reqs_to_peer"sv, // rpc
     "active_torrent_count"sv, // rpc
     "activity-date"sv, // .resume
     "activityDate"sv, // rpc

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -34,6 +34,8 @@ enum // NOLINT(performance-enum-size)
 {
     TR_KEY_NONE, /* represented as an empty string */
     TR_KEY_active_torrent_count_camel_APICOMPAT,
+    TR_KEY_active_reqs_to_client, // rpc
+    TR_KEY_active_reqs_to_peer, // rpc
     TR_KEY_active_torrent_count, /* rpc */
     TR_KEY_activity_date_kebab_APICOMPAT,
     TR_KEY_activity_date_camel_APICOMPAT,

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -590,7 +590,9 @@ namespace make_torrent_field_helpers
     auto peers_vec = tr_variant::Vector{};
     peers_vec.reserve(std::size(peers));
     for (auto const& peer : peers) {
-        auto peer_map = tr_variant::Map{ 19U };
+        auto peer_map = tr_variant::Map{ 21U };
+        peer_map.try_emplace(TR_KEY_active_reqs_to_client, peer.active_reqs_to_client);
+        peer_map.try_emplace(TR_KEY_active_reqs_to_peer, peer.active_reqs_to_peer);
         peer_map.try_emplace(TR_KEY_address, peer.addr);
         peer_map.try_emplace(TR_KEY_client_is_choked, peer.client_is_choked);
         peer_map.try_emplace(TR_KEY_client_is_interested, peer.client_is_interested);

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -117,7 +117,9 @@ enum // peer columns
 {
     COL_LOCK,
     COL_UP,
+    COL_UP_REQS,
     COL_DOWN,
+    COL_DOWN_REQS,
     COL_PERCENT,
     COL_STATUS,
     COL_ADDRESS,
@@ -175,8 +177,14 @@ public:
         case COL_UP:
             return peer_.rate_to_peer < i->peer_.rate_to_peer;
 
+        case COL_UP_REQS:
+            return peer_.active_reqs_to_client < i->peer_.active_reqs_to_client;
+
         case COL_DOWN:
             return peer_.rate_to_client < i->peer_.rate_to_client;
+
+        case COL_DOWN_REQS:
+            return peer_.active_reqs_to_peer < i->peer_.active_reqs_to_peer;
 
         case COL_PERCENT:
             return peer_.progress < i->peer_.progress;
@@ -261,9 +269,10 @@ DetailsDialog::DetailsDialog(Session& session, Prefs& prefs, TorrentModel const&
 
     resize(prefs_.get<int>(TR_KEY_details_window_width), prefs_.get<int>(TR_KEY_details_window_height));
 
-    static std::array<tr_quark, 2> constexpr InitKeys = {
+    static std::array<tr_quark, 3> constexpr InitKeys = {
         TR_KEY_show_tracker_scrapes,
         TR_KEY_show_backup_trackers,
+        TR_KEY_show_extra_peer_details,
     };
 
     for (tr_quark const key : InitKeys) {
@@ -330,6 +339,10 @@ void DetailsDialog::refreshPref(tr_quark key)
         selection_model->setCurrentIndex(selection_model->currentIndex(), QItemSelectionModel::NoUpdate);
     } else if (key == TR_KEY_show_backup_trackers) {
         tracker_filter_->setShowBackupTrackers(prefs_.get<bool>(key));
+    } else if (key == TR_KEY_show_extra_peer_details) {
+        bool const show = prefs_.get<bool>(key);
+        ui_.peersView->setColumnHidden(COL_UP_REQS, !show);
+        ui_.peersView->setColumnHidden(COL_DOWN_REQS, !show);
     }
 }
 
@@ -1028,7 +1041,9 @@ void DetailsDialog::refreshUI()
             {
                 item = new PeerItem{ peer };
                 item->setTextAlignment(COL_UP, Qt::AlignRight | Qt::AlignVCenter);
+                item->setTextAlignment(COL_UP_REQS, Qt::AlignRight | Qt::AlignVCenter);
                 item->setTextAlignment(COL_DOWN, Qt::AlignRight | Qt::AlignVCenter);
+                item->setTextAlignment(COL_DOWN_REQS, Qt::AlignRight | Qt::AlignVCenter);
                 item->setTextAlignment(COL_PERCENT, Qt::AlignRight | Qt::AlignVCenter);
                 item->setIcon(COL_LOCK, peer.is_encrypted ? icon_encrypted_ : icon_unencrypted_);
                 item->setToolTip(COL_LOCK, peer.is_encrypted ? tr("Encrypted connection") : QString{});
@@ -1109,7 +1124,11 @@ void DetailsDialog::refreshUI()
             }
 
             item->setText(COL_UP, peer.rate_to_peer.is_zero() ? QString{} : peer.rate_to_peer.to_qstring());
+            item->setText(
+                COL_UP_REQS,
+                peer.active_reqs_to_client > 0 ? QString::number(peer.active_reqs_to_client) : QString{});
             item->setText(COL_DOWN, peer.rate_to_client.is_zero() ? QString{} : peer.rate_to_client.to_qstring());
+            item->setText(COL_DOWN_REQS, peer.active_reqs_to_peer > 0 ? QString::number(peer.active_reqs_to_peer) : QString{});
             item->setText(
                 COL_PERCENT,
                 peer.progress > 0 ? QStringLiteral("%1%").arg(static_cast<int>(peer.progress * 100.0)) : QString{});
@@ -1173,6 +1192,11 @@ void DetailsDialog::onShowTrackerScrapesToggled(bool val)
 void DetailsDialog::onShowBackupTrackersToggled(bool val)
 {
     prefs_.set(TR_KEY_show_backup_trackers, val);
+}
+
+void DetailsDialog::onShowExtraPeerDetailsToggled(bool val)
+{
+    prefs_.set(TR_KEY_show_extra_peer_details, val);
 }
 
 void DetailsDialog::onHonorsSessionLimitsToggled(bool val)
@@ -1426,15 +1450,21 @@ void DetailsDialog::initPeersTab()
 {
     auto const speed_width_str = Speed{ 1024U, Speed::Units::MByps }.to_qstring();
 
-    ui_.peersView->setHeaderLabels({ QString{}, tr("Up"), tr("Down"), tr("%"), tr("Status"), tr("Address"), tr("Client") });
+    ui_.peersView->setHeaderLabels(
+        { QString{}, tr("Up"), tr("Up Reqs"), tr("Down"), tr("Dn Reqs"), tr("%"), tr("Status"), tr("Address"), tr("Client") });
     ui_.peersView->sortByColumn(COL_ADDRESS, Qt::AscendingOrder);
 
     ui_.peersView->setColumnWidth(COL_LOCK, 20);
     ui_.peersView->setColumnWidth(COL_UP, measureViewItem(ui_.peersView, COL_UP, speed_width_str));
+    ui_.peersView->setColumnWidth(COL_UP_REQS, measureViewItem(ui_.peersView, COL_UP_REQS, QStringLiteral("888")));
     ui_.peersView->setColumnWidth(COL_DOWN, measureViewItem(ui_.peersView, COL_DOWN, speed_width_str));
+    ui_.peersView->setColumnWidth(COL_DOWN_REQS, measureViewItem(ui_.peersView, COL_DOWN_REQS, QStringLiteral("888")));
     ui_.peersView->setColumnWidth(COL_PERCENT, measureViewItem(ui_.peersView, COL_PERCENT, QStringLiteral("100%")));
     ui_.peersView->setColumnWidth(COL_STATUS, measureViewItem(ui_.peersView, COL_STATUS, QStringLiteral("ODUK?EXI")));
     ui_.peersView->setColumnWidth(COL_ADDRESS, measureViewItem(ui_.peersView, COL_ADDRESS, QStringLiteral("888.888.888.888")));
+
+    ui_.showExtraPeerDetailsCheck->setChecked(prefs_.get<bool>(TR_KEY_show_extra_peer_details));
+    connect(ui_.showExtraPeerDetailsCheck, &QAbstractButton::clicked, this, &DetailsDialog::onShowExtraPeerDetailsToggled);
 }
 
 // ---

--- a/qt/DetailsDialog.h
+++ b/qt/DetailsDialog.h
@@ -84,6 +84,9 @@ private slots:
     void onShowBackupTrackersToggled(bool val);
     void onTrackerListEdited(QString const& tracker_list);
 
+    // Peers tab
+    void onShowExtraPeerDetailsToggled(bool val);
+
     // Files tab
     void onFilePriorityChanged(file_indices_t const& file_indices, int priority);
     void onFileWantedChanged(file_indices_t const& file_indices, bool wanted);

--- a/qt/DetailsDialog.ui
+++ b/qt/DetailsDialog.ui
@@ -594,6 +594,13 @@
          </attribute>
         </widget>
        </item>
+       <item>
+        <widget class="QCheckBox" name="showExtraPeerDetailsCheck">
+         <property name="text">
+          <string>Show &amp;more details</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="trackersTab">

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -43,6 +43,8 @@ struct Peer {
     bool is_uploading_to = {};
     bool peer_is_choked = {};
     bool peer_is_interested = {};
+    size_t active_reqs_to_client = {};
+    size_t active_reqs_to_peer = {};
     QString address;
     QString client_name;
     QString flags;
@@ -55,6 +57,8 @@ struct Peer {
     using Field = tr::serializer::Field<MemberPtr>;
 
     static constexpr auto Fields = std::make_tuple(
+        Field<&Peer::active_reqs_to_client>{ TR_KEY_active_reqs_to_client },
+        Field<&Peer::active_reqs_to_peer>{ TR_KEY_active_reqs_to_peer },
         Field<&Peer::address>{ TR_KEY_address },
         Field<&Peer::client_is_choked>{ TR_KEY_client_is_choked },
         Field<&Peer::client_is_interested>{ TR_KEY_client_is_interested },


### PR DESCRIPTION
Expose these fields to RPC:

  - `tr_peer_stat::active_reqs_to_client`
  - `tr_peer_stat::active_reqs_to_peer`
    
Use them in the Qt client's Details dialog, matching the GTK client.

Notes: Improved `settings.json` compatibility between the GTK and Qt clients.