### PR TITLE
refactor: change crypto utils to use `std::span`

### DIFF
--- a/libtransmission/crypto-utils-ccrypto.cc
+++ b/libtransmission/crypto-utils-ccrypto.cc
@@ -154,13 +154,11 @@ tr_sha256_digest_t tr_sha256::finish()
 
 // ---
 
-bool tr_rand_buffer_crypto(void* buffer, size_t length)
+bool tr_rand_buffer_crypto(std::span<std::byte> const buffer)
 {
-    if (length == 0) {
+    if (buffer.empty()) {
         return true;
     }
 
-    TR_ASSERT(buffer != nullptr);
-
-    return check_result(CCRandomGenerateBytes(buffer, length));
+    return check_result(CCRandomGenerateBytes(buffer.data(), buffer.size()));
 }

--- a/libtransmission/crypto-utils-mbedtls.cc
+++ b/libtransmission/crypto-utils-mbedtls.cc
@@ -65,7 +65,7 @@ bool check_mbedtls_result(int result, int expected_result, char const* file, int
 int my_rand(void* /*context*/, unsigned char* buffer, size_t buffer_size)
 {
     // since we're initializing tr_rand_buffer()'s rng, we can't use tr_rand_buffer() here
-    tr_rand_buffer_std(buffer, buffer_size);
+    tr_rand_buffer_std(std::as_writable_bytes(std::span{ buffer, buffer_size }));
     return 0;
 }
 
@@ -191,26 +191,23 @@ tr_sha256_digest_t tr_sha256::finish()
 
 // ---
 
-bool tr_rand_buffer_crypto(void* buffer, size_t length)
+bool tr_rand_buffer_crypto(std::span<std::byte> buffer)
 {
-    if (length == 0) {
+    if (buffer.empty()) {
         return true;
     }
 
-    TR_ASSERT(buffer != nullptr);
-
-    auto constexpr ChunkSize = size_t{ MBEDTLS_CTR_DRBG_MAX_REQUEST };
+    static auto constexpr ChunkSize = size_t{ MBEDTLS_CTR_DRBG_MAX_REQUEST };
     static_assert(ChunkSize > 0U);
 
     auto const lock = std::scoped_lock{ rng_mutex_ };
 
-    for (auto offset = size_t{ 0 }; offset < length; offset += ChunkSize) {
-        if (!check_result(mbedtls_ctr_drbg_random(
-                get_rng(),
-                static_cast<unsigned char*>(buffer) + offset,
-                std::min(ChunkSize, length - offset)))) {
+    while (!buffer.empty()) {
+        auto const chunk_size = std::min(ChunkSize, buffer.size());
+        if (!check_result(mbedtls_ctr_drbg_random(get_rng(), reinterpret_cast<unsigned char*>(buffer.data()), chunk_size))) {
             return false;
         }
+        buffer = buffer.subspan(chunk_size);
     }
 
     return true;

--- a/libtransmission/crypto-utils-openssl.cc
+++ b/libtransmission/crypto-utils-openssl.cc
@@ -158,13 +158,11 @@ tr_sha256_digest_t tr_sha256::finish()
 
 // --- rand
 
-bool tr_rand_buffer_crypto(void* buffer, size_t length)
+bool tr_rand_buffer_crypto(std::span<std::byte> const buffer)
 {
-    if (length == 0) {
+    if (buffer.empty()) {
         return true;
     }
 
-    TR_ASSERT(buffer != nullptr);
-
-    return check_result(RAND_bytes(static_cast<unsigned char*>(buffer), (int)length));
+    return check_result(RAND_bytes(reinterpret_cast<unsigned char*>(buffer.data()), static_cast<int>(buffer.size())));
 }

--- a/libtransmission/crypto-utils-wolfssl.cc
+++ b/libtransmission/crypto-utils-wolfssl.cc
@@ -142,14 +142,12 @@ tr_sha256_digest_t tr_sha256::finish()
 
 // ---
 
-bool tr_rand_buffer_crypto(void* buffer, size_t length)
+bool tr_rand_buffer_crypto(std::span<std::byte> const buffer)
 {
-    if (length == 0) {
+    if (buffer.empty()) {
         return true;
     }
 
-    TR_ASSERT(buffer != nullptr);
-
     auto const lock = std::scoped_lock{ rng_mutex_ };
-    return check_result(wc_RNG_GenerateBlock(get_rng(), static_cast<byte*>(buffer), length));
+    return check_result(wc_RNG_GenerateBlock(get_rng(), reinterpret_cast<byte*>(buffer.data()), buffer.size()));
 }

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -203,21 +203,23 @@ uint32_t tr_crc32c(void const* data, size_t count)
 }
 
 // fallback implementation in case the system crypto library's RNG fails
-void tr_rand_buffer_std(void* buffer, size_t length)
+void tr_rand_buffer_std(std::span<std::byte> buffer)
 {
     static thread_local auto gen = std::mt19937{ std::random_device{}() };
     static thread_local auto dist = std::uniform_int_distribution<unsigned long long>{};
 
-    for (auto *walk = static_cast<uint8_t*>(buffer), *end = walk + length; walk < end;) {
-        auto const tmp = dist(gen);
-        auto const step = std::min(sizeof(tmp), static_cast<size_t>(end - walk));
-        walk = std::copy_n(reinterpret_cast<uint8_t const*>(&tmp), step, walk);
+    while (!buffer.empty()) {
+        auto const value = dist(gen);
+        auto const bytes = std::as_bytes(std::span{ &value, 1U });
+        auto const step = std::min(bytes.size(), buffer.size());
+        std::ranges::copy(bytes.first(step), buffer.begin());
+        buffer = buffer.subspan(step);
     }
 }
 
-void tr_rand_buffer(void* buffer, size_t length)
+void tr_rand_buffer(std::span<std::byte> const buffer)
 {
-    if (!tr_rand_buffer_crypto(buffer, length)) {
-        tr_rand_buffer_std(buffer, length);
+    if (!tr_rand_buffer_crypto(buffer)) {
+        tr_rand_buffer_std(buffer);
     }
 }

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -11,6 +11,7 @@
 #include <limits>
 #include <optional>
 #include <random> // for std::uniform_int_distribution<T>
+#include <span>
 #include <string>
 #include <string_view>
 
@@ -100,12 +101,24 @@ private:
 /**
  * @brief Fill a buffer with random bytes.
  */
-void tr_rand_buffer(void* buffer, size_t length);
+void tr_rand_buffer(std::span<std::byte> buffer);
+
+inline void tr_rand_buffer(void* const buffer, size_t length)
+{
+    tr_rand_buffer({ static_cast<std::byte*>(buffer), length });
+}
+
+template<typename R>
+    requires(!requires(R& range) { std::span<std::byte>{ range }; })
+void tr_rand_buffer(R& range)
+{
+    tr_rand_buffer(std::as_writable_bytes(std::span<typename R::value_type>{ range }));
+}
 
 // Client code should use `tr_rand_buffer()`.
 // These helpers are only exposed here to permit open-box tests.
-bool tr_rand_buffer_crypto(void* buffer, size_t length);
-void tr_rand_buffer_std(void* buffer, size_t length);
+bool tr_rand_buffer_crypto(std::span<std::byte> buffer);
+void tr_rand_buffer_std(std::span<std::byte> buffer);
 
 template<typename T>
 T tr_rand_obj()
@@ -184,7 +197,7 @@ public:
         }
 
         if (pos_ == 0U) {
-            tr_rand_buffer(std::data(buf_), std::size(buf_) * sizeof(T));
+            tr_rand_buffer(buf_);
         }
 
         return buf_[pos_++];

--- a/tests/libtransmission/crypto-test.cc
+++ b/tests/libtransmission/crypto-test.cc
@@ -238,13 +238,13 @@ TEST_P(CryptoRandBufferTest, randBuf)
     static auto constexpr Iterations = 1000U;
 
     auto const width = GetParam();
-    auto const empty = std::vector<uint8_t>(width, 0);
+    auto const empty = std::vector<std::byte>(width, std::byte{});
 
     auto buf = empty;
 
     for (size_t i = 0; i < Iterations; ++i) {
         auto tmp = buf;
-        tr_rand_buffer(std::data(tmp), std::size(tmp));
+        tr_rand_buffer(tmp);
         EXPECT_NE(tmp, empty);
         EXPECT_NE(tmp, buf);
         buf = tmp;
@@ -252,7 +252,7 @@ TEST_P(CryptoRandBufferTest, randBuf)
 
     for (size_t i = 0; i < Iterations; ++i) {
         auto tmp = buf;
-        EXPECT_TRUE(tr_rand_buffer_crypto(std::data(tmp), std::size(tmp)));
+        EXPECT_TRUE(tr_rand_buffer_crypto(tmp));
         EXPECT_NE(tmp, empty);
         EXPECT_NE(tmp, buf);
         buf = tmp;
@@ -260,7 +260,7 @@ TEST_P(CryptoRandBufferTest, randBuf)
 
     for (size_t i = 0; i < Iterations; ++i) {
         auto tmp = buf;
-        tr_rand_buffer_std(std::data(tmp), std::size(tmp));
+        tr_rand_buffer_std(tmp);
         EXPECT_NE(tmp, empty);
         EXPECT_NE(tmp, buf);
         buf = tmp;


### PR DESCRIPTION
Fixes `cppcoreguidelines-pro-bounds-pointer-arithmetic` clang-tidy warnings in `crypto-utils*` code.

I haven't made up my mind whether to enable `cppcoreguidelines-pro-bounds-pointer-arithmetic` globally yet. My opinion on pointer arithmetic is a bit similar to `goto`: Most of the time they are fragile, hard-to-maintain code, but sometimes they are the only tool that does the job well.

There should be no change in behaviour.

Notes: Moved from C++17 to C++20.