### PR TITLE
refactor: remove duplicate serializer code

### DIFF
--- a/libtransmission/converters.h
+++ b/libtransmission/converters.h
@@ -90,19 +90,10 @@ template<typename T>
 inline constexpr bool is_optional_v<std::optional<T>> = true;
 
 template<typename C>
-tr_variant from_push_back_range(C const& src);
+tr_variant from_range(C const& src);
 
 template<typename C>
-bool to_push_back_range(tr_variant const& src, C* ptgt);
-
-template<typename C>
-tr_variant from_insert_range(C const& src);
-
-template<typename C>
-bool to_insert_range(tr_variant const& src, C* ptgt);
-
-template<typename C>
-tr_variant from_array(C const& src);
+bool to_range(tr_variant const& src, C* ptgt);
 
 template<typename C>
 bool to_array(tr_variant const& src, C* ptgt);
@@ -205,12 +196,8 @@ template<typename T>
 {
     if constexpr (detail::HasConverter<T>) {
         return Converter<T>::to_variant(src);
-    } else if constexpr (detail::is_push_back_range_v<T>) {
-        return detail::from_push_back_range(src);
-    } else if constexpr (detail::is_insert_range_v<T>) {
-        return detail::from_insert_range(src);
-    } else if constexpr (detail::is_std_array_v<T>) {
-        return detail::from_array(src);
+    } else if constexpr (detail::is_push_back_range_v<T> || detail::is_insert_range_v<T> || detail::is_std_array_v<T>) {
+        return detail::from_range(src);
     } else if constexpr (detail::is_optional_v<T>) {
         return detail::from_optional(src);
     } else {
@@ -229,10 +216,8 @@ bool to_value(tr_variant const& src, T* const ptgt)
 
     if constexpr (detail::HasConverter<T>) {
         ok = Converter<T>::to_value(src, ptgt);
-    } else if constexpr (detail::is_push_back_range_v<T>) {
-        ok = detail::to_push_back_range(src, ptgt);
-    } else if constexpr (detail::is_insert_range_v<T>) {
-        ok = detail::to_insert_range(src, ptgt);
+    } else if constexpr (detail::is_push_back_range_v<T> || detail::is_insert_range_v<T>) {
+        ok = detail::to_range(src, ptgt);
     } else if constexpr (detail::is_std_array_v<T>) {
         ok = detail::to_array(src, ptgt);
     } else if constexpr (detail::is_optional_v<T>) {
@@ -342,14 +327,16 @@ TR_DECLARE_CONVERTER(tr_verify_added_mode)
 // ---
 
 // N.B. This second `detail` block contains the implementations of
-// to_push_back_range, from_push_back_range, etc., which were forward-
-// declared above. They must be defined after `to_variant`/`to_value`
-// because they call them for each element.
+// from_range, to_range, etc., which were forward-declared above. They must
+// be defined after `to_variant`/`to_value` because they call them for each
+// element.
 namespace detail
 {
 
+// Serialize any non-string iterable (push_back range, insert range, or
+// std::array) to a variant vector -- all three read identically.
 template<typename C>
-tr_variant from_push_back_range(C const& src)
+tr_variant from_range(C const& src)
 {
     auto ret = tr_variant::Vector{};
     ret.reserve(std::size(src));
@@ -359,8 +346,10 @@ tr_variant from_push_back_range(C const& src)
     return ret;
 }
 
+// Deserialize a variant vector into a growable container, appending via
+// `push_back` or `insert` as the container supports.
 template<typename C>
-bool to_push_back_range(tr_variant const& src, C* const ptgt)
+bool to_range(tr_variant const& src, C* const ptgt)
 {
     auto const* const vec = src.get_if<tr_variant::Vector>();
     if (vec == nullptr) {
@@ -375,55 +364,15 @@ bool to_push_back_range(tr_variant const& src, C* const ptgt)
         if (!to_value(elem, &value)) {
             return false;
         }
-        tmp.push_back(std::move(value));
-    }
-
-    *ptgt = std::move(tmp);
-    return true;
-}
-
-template<typename C>
-tr_variant from_insert_range(C const& src)
-{
-    auto ret = tr_variant::Vector{};
-    ret.reserve(std::size(src));
-    for (auto const& elem : src) {
-        ret.emplace_back(to_variant(elem));
-    }
-    return ret;
-}
-
-template<typename C>
-bool to_insert_range(tr_variant const& src, C* const ptgt)
-{
-    auto const* const vec = src.get_if<tr_variant::Vector>();
-    if (vec == nullptr) {
-        return false;
-    }
-
-    auto tmp = C{};
-
-    for (auto const& elem : *vec) {
-        typename C::value_type value{};
-        if (!to_value(elem, &value)) {
-            return false;
+        if constexpr (is_push_back_range_v<C>) {
+            tmp.push_back(std::move(value));
+        } else {
+            tmp.insert(std::move(value));
         }
-        tmp.insert(std::move(value));
     }
 
     *ptgt = std::move(tmp);
     return true;
-}
-
-template<typename C>
-tr_variant from_array(C const& src)
-{
-    auto ret = tr_variant::Vector{};
-    ret.reserve(std::size(src));
-    for (auto const& elem : src) {
-        ret.emplace_back(to_variant(elem));
-    }
-    return ret;
 }
 
 template<typename C>

--- a/libtransmission/serializer.h
+++ b/libtransmission/serializer.h
@@ -139,21 +139,6 @@ template<Serializable... S>
 }
 
 /**
- * Returns `true` iff any of the given Serializables has a field with `key`.
- * Example: has_key(TR_KEY_peer_port, session_settings, rpc_server_settings)
- */
-template<Serializable... S>
-[[nodiscard]] bool has_key(tr_quark key, S const&... /*objs*/)
-{
-    auto fields_contain = [key](auto const& fields) {
-        auto found = false;
-        std::apply([key, &found](auto const&... field) { ((found = found || field.key == key), ...); }, fields);
-        return found;
-    };
-    return (fields_contain(S::Fields) || ...);
-}
-
-/**
  * Compile-time check whether any of the given Serializable types has a
  * field with `key`. Takes the Serializables as template arguments so it
  * can be used in constant expressions. Example:
@@ -170,6 +155,17 @@ template<Serializable... S>
     return (fields_contain(S::Fields) || ...);
 }
 
+/**
+ * Returns `true` iff any of the given Serializables has a field with `key`.
+ * The objects are used only to deduce their types. Example:
+ * has_key(TR_KEY_peer_port, session_settings, rpc_server_settings)
+ */
+template<Serializable... S>
+[[nodiscard]] bool has_key(tr_quark key, S const&... /*objs*/)
+{
+    return has_key<S...>(key);
+}
+
 namespace detail
 {
 
@@ -184,13 +180,8 @@ template<Serializable S>
             return false;
         }
 
-        auto map = tr_variant::Map{ 1U };
-        field.save(&src, map);
-
-        if (auto const iter = map.find(key); iter != std::end(map)) {
-            result = iter->second.clone();
-        }
-
+        using FieldType = std::remove_cvref_t<decltype(field)>;
+        result = to_variant(src.*FieldType::MemberPointer);
         return true;
     };
 
@@ -251,6 +242,23 @@ template<typename ArgTuple, std::size_t... PairIndex>
         std::size_t{ 0 } + ... + std::tuple_size_v<std::remove_cvref_t<std::tuple_element_t<(2 * PairIndex) + 1, ArgTuple>>>);
 }
 
+// Resolve the pointer-to-member for the field in `S` whose key is `Key` and
+// whose value type is `T`. Fails to compile if no such field exists.
+template<typename T, tr_quark Key, Serializable S>
+[[nodiscard]] consteval auto member_pointer_by_key()
+{
+    using Fields = std::remove_cvref_t<decltype(S::Fields)>;
+    constexpr auto Count = std::tuple_size_v<Fields>;
+    constexpr auto Index = field_index<S, T, Key>(std::make_index_sequence<Count>{});
+
+    static_assert(Index < Count, "No field with matching tr_quark and value type in Serializable::Fields");
+
+    using FieldType = std::tuple_element_t<Index, Fields>;
+    static_assert(std::is_base_of_v<typename FieldType::owner_type, S>);
+
+    return FieldType::MemberPointer;
+}
+
 } // namespace detail
 
 /**
@@ -261,15 +269,14 @@ template<typename ArgTuple, std::size_t... PairIndex>
 template<Serializable S, Serializable... Ss>
 [[nodiscard]] std::optional<tr_variant> to_variant(tr_quark const key, S const& src, Ss const&... srcs)
 {
-    auto result = detail::to_variant_one(src, key);
-    if constexpr (sizeof...(Ss) != 0U) {
-        auto try_next = [&result, key](auto const& obj) {
-            if (!result) {
-                result = detail::to_variant_one(obj, key);
-            }
-        };
-        (try_next(srcs), ...);
-    }
+    auto result = std::optional<tr_variant>{};
+    auto try_next = [&result, key](auto const& obj) {
+        if (!result) {
+            result = detail::to_variant_one(obj, key);
+        }
+    };
+    try_next(src);
+    (try_next(srcs), ...);
     return result;
 }
 
@@ -286,31 +293,13 @@ template<typename T, Serializable S, Serializable... Ss>
 template<typename T, tr_quark Key, Serializable S>
 [[nodiscard]] constexpr T get(S const& src)
 {
-    using Fields = std::remove_cvref_t<decltype(S::Fields)>;
-    constexpr auto Count = std::tuple_size_v<Fields>;
-    constexpr auto Index = detail::field_index<S, T, Key>(std::make_index_sequence<Count>{});
-
-    static_assert(Index < Count, "No field with matching tr_quark and value type in Serializable::Fields");
-
-    using FieldType = std::tuple_element_t<Index, Fields>;
-    static_assert(std::is_base_of_v<typename FieldType::owner_type, S>);
-
-    return src.*(FieldType::MemberPointer);
+    return src.*(detail::member_pointer_by_key<T, Key, S>());
 }
 
 template<typename T, tr_quark Key, Serializable S>
 constexpr bool set(S& tgt, T val)
 {
-    using Fields = std::remove_cvref_t<decltype(S::Fields)>;
-    constexpr auto Count = std::tuple_size_v<Fields>;
-    constexpr auto Index = detail::field_index<S, T, Key>(std::make_index_sequence<Count>{});
-
-    static_assert(Index < Count, "No field with matching tr_quark and value type in Serializable::Fields");
-
-    using FieldType = std::tuple_element_t<Index, Fields>;
-    static_assert(std::is_base_of_v<typename FieldType::owner_type, S>);
-
-    auto& target = tgt.*(FieldType::MemberPointer);
+    auto& target = tgt.*(detail::member_pointer_by_key<T, Key, S>());
     if (target == val) {
         return false;
     }
@@ -413,6 +402,11 @@ auto load(tr_variant const& src, Args&&... args)
  *
  * Example: load(src, session_settings, alt_speed_settings, rpc_server_settings)
  */
+// Note: these two overloads look mergeable into one templated on the source
+// type, but the concrete `tr_variant::Map const&` / `tr_variant const&` first
+// parameter is what lets them win partial ordering against the (target, Fields)
+// pair worker `load(tr_variant::Map const&, Args&&...)` above. A templated
+// `Src const&` first parameter would tie and become ambiguous.
 template<Serializable S, Serializable... Ss>
 auto load(tr_variant::Map const& src, S& tgt, Ss&... tgts)
 {


### PR DESCRIPTION
serializer + converter are already feature-complete.

This is a cleanup PR to remove redundant code. No functional changes.

- fold `from_push_back_range()`, `from_insert_range()`, and `from_array()` into a single helper
- better `constexpr bool has_key()`
- avoid a deep Map copy in `to_variant_one()`
- extract-method the redundand preamble in the get-by-key / set-by-key

AI disclosure: I have reviewed and tested everything in this PR, which was written by Claude.