### PR TITLE
feat: add reverify-on-download-complete feature to RPC and Qt app

### DIFF
--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -631,6 +631,7 @@ Response parameters: `path`, `name`, and `id`, holding the torrent ID integer
 | `speed_limit_up_enabled` | boolean | true means enabled
 | `start_added_torrents` | boolean | true means added torrents will be started right away
 | `tcp_enabled` | boolean | **DEPRECATED** Use `preferred_transports` instead
+| `torrent_complete_verify_enabled` | boolean | true means torrents are re-verified once they finish downloading
 | `trash_original_torrent_files` | boolean | true means the .torrent file of added torrents will be deleted
 | `units` | object | see below
 | `utp_enabled` | boolean | **DEPRECATED** Use `preferred_transports` instead
@@ -1131,4 +1132,6 @@ Transmission 4.2.0 (`rpc_version_semver` 6.1.0, `rpc_version`: ?)
 | `torrent_get` | **DEPRECATED** `webseeds`. Use `webseeds_ex` instead.
 | `session_get` | new arg `recent_download_paths`
 | `session_get` | new arg `recent_relocate_paths`
+| `session_get` | new arg `torrent_complete_verify_enabled`
+| `session_set` | new arg `torrent_complete_verify_enabled`
 | `session_get` | **DEPRECATED** `cache_size_mib`. The memory cache is being removed, making this setting moot. The setting will still be gettable and settable via RPC `session_get` and `session_set` until Transmission 5.0.0 to avoid client breakage, but it will be otherwise unused in libtransmission. Clients should stop using this key.

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -440,6 +440,7 @@ DownloadingPage::DownloadingPage(
     init_chooser_button("incomplete_dir_chooser", TR_KEY_incomplete_dir);
     init_check_button("download_done_script_check", TR_KEY_script_torrent_done_enabled);
     init_chooser_button("download_done_script_chooser", TR_KEY_script_torrent_done_filename);
+    init_check_button("download_done_verify_check", TR_KEY_torrent_complete_verify_enabled);
 
     on_core_prefs_changed(TR_KEY_download_dir);
 }

--- a/gtk/ui/gtk3/PrefsDialog.ui
+++ b/gtk/ui/gtk3/PrefsDialog.ui
@@ -679,7 +679,7 @@
                         </child>
                         <child>
                           <object class="GtkCheckButton" id="download_done_script_check">
-                            <property name="label" translatable="yes">Call scrip_t when done downloading:</property>
+                            <property name="label" translatable="yes">Call scrip_t when download completes:</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">False</property>
@@ -717,6 +717,22 @@
                           <packing>
                             <property name="left-attach">1</property>
                             <property name="top-attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkCheckButton" id="download_done_verify_check">
+                            <property name="label" translatable="yes">Verify data when download completes</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="valign">center</property>
+                            <property name="hexpand">True</property>
+                            <property name="draw-indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">3</property>
+                            <property name="width">2</property>
                           </packing>
                         </child>
                       </object>

--- a/gtk/ui/gtk4/PrefsDialog.ui
+++ b/gtk/ui/gtk4/PrefsDialog.ui
@@ -486,7 +486,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="download_done_script_check">
-                                <property name="label" translatable="yes">Call scrip_t when done downloading:</property>
+                                <property name="label" translatable="yes">Call scrip_t when download completes:</property>
                                 <property name="focusable">1</property>
                                 <property name="valign">center</property>
                                 <property name="use-underline">1</property>
@@ -514,6 +514,19 @@
                                 <layout>
                                   <property name="column">1</property>
                                   <property name="row">2</property>
+                                </layout>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="download_done_verify_check">
+                                <property name="label" translatable="yes">Verify data when download completes</property>
+                                <property name="focusable">1</property>
+                                <property name="valign">center</property>
+                                <property name="hexpand">1</property>
+                                <layout>
+                                  <property name="column">0</property>
+                                  <property name="row">3</property>
+                                  <property name="column-span">2</property>
                                 </layout>
                               </object>
                             </child>

--- a/libtransmission-app/prefs.h
+++ b/libtransmission-app/prefs.h
@@ -195,6 +195,7 @@ struct SessionPrefs {
     bool script_torrent_done_enabled_ = {};
     bool script_torrent_done_seeding_enabled_ = {};
     bool start_ = {};
+    bool torrent_complete_verify_enabled_ = {};
     bool trash_original_ = {};
     bool uspeed_enabled_ = {};
     bool utp_enabled_ = {};
@@ -251,6 +252,7 @@ struct SessionPrefs {
         Field<&SessionPrefs::script_torrent_done_seeding_filename_>{ TR_KEY_script_torrent_done_seeding_filename },
         Field<&SessionPrefs::socket_diffserv_>{ TR_KEY_peer_socket_diffserv },
         Field<&SessionPrefs::start_>{ TR_KEY_start_added_torrents },
+        Field<&SessionPrefs::torrent_complete_verify_enabled_>{ TR_KEY_torrent_complete_verify_enabled },
         Field<&SessionPrefs::trash_original_>{ TR_KEY_trash_original_torrent_files },
         Field<&SessionPrefs::upload_slots_per_torrent_>{ TR_KEY_upload_slots_per_torrent },
         Field<&SessionPrefs::uspeed_>{ TR_KEY_speed_limit_up },

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1885,7 +1885,7 @@ using SessionAccessors = std::pair<SessionGetter, SessionSetter>;
 
 [[nodiscard]] auto& session_accessors()
 {
-    static auto map = small::max_size_map<tr_quark, SessionAccessors, 64U>{};
+    static auto map = small::map<tr_quark, SessionAccessors, 64U>{};
 
     if (!std::empty(map)) {
         return map;
@@ -2357,6 +2357,15 @@ using SessionAccessors = std::pair<SessionGetter, SessionSetter>;
         [](tr_session& tgt, tr_variant const& src, ErrorInfo& /*err*/) {
             if (auto const val = src.value_if<bool>()) {
                 tr_sessionSetUTPEnabled(&tgt, *val);
+            }
+        });
+
+    map.try_emplace(
+        TR_KEY_torrent_complete_verify_enabled,
+        [](tr_session const& src) -> tr_variant { return src.shouldFullyVerifyCompleteTorrents(); },
+        [](tr_session& tgt, tr_variant const& src, ErrorInfo& /*err*/) {
+            if (auto const val = src.value_if<bool>()) {
+                tr_sessionSetCompleteVerifyEnabled(&tgt, *val);
             }
         });
 

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -513,6 +513,7 @@ void PrefsDialog::initDownloadingTab()
     initWidget(ui_.doneDownloadingScriptCheck, TR_KEY_script_torrent_done_enabled);
     initWidget(ui_.doneDownloadingScriptButton, TR_KEY_script_torrent_done_filename);
     initWidget(ui_.doneDownloadingScriptEdit, TR_KEY_script_torrent_done_filename);
+    initWidget(ui_.downloadDoneVerifyCheck, TR_KEY_torrent_complete_verify_enabled);
 
     auto* cr = new ColumnResizer{ this };
     cr->addLayout(ui_.addingSectionLayout);

--- a/qt/PrefsDialog.ui
+++ b/qt/PrefsDialog.ui
@@ -407,7 +407,7 @@
           <item row="2" column="0">
            <widget class="QCheckBox" name="doneDownloadingScriptCheck">
             <property name="text">
-             <string>Call scrip&amp;t when downloading is completed:</string>
+             <string>Call scrip&amp;t when download completes:</string>
             </property>
             <property name="checked">
              <bool>true</bool>
@@ -424,6 +424,13 @@
             </property>
             <widget class="PathButton" name="doneDownloadingScriptButton"/>
             <widget class="QLineEdit" name="doneDownloadingScriptEdit"/>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="2">
+           <widget class="QCheckBox" name="downloadDoneVerifyCheck">
+            <property name="text">
+             <string>Verify data when download completes</string>
+            </property>
            </widget>
           </item>
          </layout>

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -168,6 +168,7 @@ void Session::updatePref(tr_quark key)
         case TR_KEY_speed_limit_up:
         case TR_KEY_speed_limit_up_enabled:
         case TR_KEY_utp_enabled:
+        case TR_KEY_torrent_complete_verify_enabled:
             sessionSet(key, prefs_.get<tr_variant>(key));
             break;
 

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -642,6 +642,7 @@ TEST_F(RpcTest, sessionGet)
         TR_KEY_speed_limit_up_enabled,
         TR_KEY_start_added_torrents,
         TR_KEY_tcp_enabled,
+        TR_KEY_torrent_complete_verify_enabled,
         TR_KEY_trash_original_torrent_files,
         TR_KEY_units,
         TR_KEY_utp_enabled,

--- a/tests/qt/CMakeLists.txt
+++ b/tests/qt/CMakeLists.txt
@@ -25,10 +25,11 @@ endfunction()
 
 add_trqt_test(options-dialog-test.cc)
 add_trqt_test(prefs-test.cc)
+add_trqt_test(prefs-dialog-test.cc)
 add_trqt_test(session-test.cc)
 
-# session-test and options-dialog-test drive a real loopback HTTP server (evhttp)
-# instead of a fake QNAM
+# session-test, options-dialog-test and prefs-dialog-test drive a real loopback
+# HTTP server (evhttp) instead of a fake QNAM
 target_link_libraries(qt-test-session
     PRIVATE
         libevent::core
@@ -37,11 +38,16 @@ target_link_libraries(qt-test-options-dialog
     PRIVATE
         libevent::core
         libevent::extra)
+target_link_libraries(qt-test-prefs-dialog
+    PRIVATE
+        libevent::core
+        libevent::extra)
 
 add_custom_target(qt-tests
     DEPENDS
         qt-test-options-dialog
         qt-test-prefs
+        qt-test-prefs-dialog
         qt-test-session)
 
 set_property(

--- a/tests/qt/options-dialog-test.cc
+++ b/tests/qt/options-dialog-test.cc
@@ -115,6 +115,11 @@ class OptionsDialogTest
     }
 
 private slots:
+    static void initTestCase()
+    {
+        TR_QT_SKIP_UNLESS_SIGNALS_WORK();
+    }
+
     // A remote session can't browse the server's filesystem, so the dialog
     // offers an editable combo box seeded with the server's recent paths.
     void remote_session_uses_editable_combo()

--- a/tests/qt/prefs-dialog-test.cc
+++ b/tests/qt/prefs-dialog-test.cc
@@ -90,6 +90,11 @@ class PrefsDialogTest
     Q_OBJECT
 
 private slots:
+    static void initTestCase()
+    {
+        TR_QT_SKIP_UNLESS_SIGNALS_WORK();
+    }
+
     // Toggling the "verify data when download completes" checkbox must flow
     // through PrefsDialog::set() into Prefs, which emits changed(tr_quark). This
     // is the wiring the GUI relies on to persist the preference.

--- a/tests/qt/prefs-dialog-test.cc
+++ b/tests/qt/prefs-dialog-test.cc
@@ -1,0 +1,145 @@
+// This file Copyright © Mnemosaic LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosaic LLC.
+// License text can be found in the licenses/ folder.
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QDir>
+#include <QElapsedTimer>
+#include <QSignalSpy>
+#include <QString>
+#include <QTest>
+
+#include <libtransmission/transmission.h>
+#include <libtransmission/quark.h>
+#include <libtransmission/variant.h>
+
+#include "FreeSpaceLabel.h"
+#include "Prefs.h"
+#include "PrefsDialog.h"
+#include "Session.h"
+#include "qt-test-fixtures.h"
+#include "rpc-test-fixtures.h"
+
+// QSignalSpy needs tr_quark registered as a metatype to capture the argument of
+// Prefs::changed(tr_quark).
+Q_DECLARE_METATYPE(tr_quark)
+
+namespace
+{
+// Point prefs at an in-process session. Such a session reports
+// isLocalFilesystem(), which is what makes the dialog show the path button.
+void setLocalPrefs(Prefs& prefs, QString const& dl_dir)
+{
+    prefs.set(TR_KEY_remote_session_enabled, false);
+    prefs.set(TR_KEY_download_dir, dl_dir);
+}
+
+// Keep an in-process session off the network so the test stays fast and
+// deterministic (mirrors the libtransmission session fixture defaults).
+void writeQuietSettings(QString const& config_dir)
+{
+    auto settings = tr::Settings{};
+    settings.insert_or_assign(TR_KEY_dht_enabled, false);
+    settings.insert_or_assign(TR_KEY_lpd_enabled, false);
+    settings.insert_or_assign(TR_KEY_pex_enabled, false);
+    settings.insert_or_assign(TR_KEY_port_forwarding_enabled, false);
+    settings.insert_or_assign(TR_KEY_utp_enabled, false);
+
+    auto const filename = QDir{ config_dir }.filePath(QStringLiteral("settings.json")).toStdString();
+    tr::settings::save(filename, settings);
+}
+
+// Pump the Qt event loop until `pred` is true or we time out. Returning control
+// to the loop lets RpcClient deliver its queued-connection continuations.
+template<typename Predicate>
+[[nodiscard]] bool waitUntil(Predicate const& pred, int const timeout_ms = 10000)
+{
+    auto timer = QElapsedTimer{};
+    timer.start();
+    while (!pred()) {
+        if (timer.elapsed() > timeout_ms) {
+            return false;
+        }
+        QTest::qWait(20);
+    }
+    return true;
+}
+
+// Building the dialog kicks off FreeSpaceLabel's async free-space request, which
+// runs on a tr::app::RpcQueue. That queue keeps a reference to itself until it
+// finishes, so it must run to completion before teardown or the never-finished
+// queue leaks under LSan. A successful reply replaces the label's "Calculating…"
+// placeholder, proving the queue reached its final step and released itself.
+[[nodiscard]] bool drainFreeSpace(PrefsDialog& dialog)
+{
+    auto* const label = dialog.findChild<FreeSpaceLabel*>();
+    if (label == nullptr) {
+        return false;
+    }
+
+    auto const placeholder = label->text();
+    return waitUntil([label, placeholder]() { return label->text() != placeholder; });
+}
+
+class PrefsDialogTest
+    : public QObject
+    , SandboxedTest
+{
+    Q_OBJECT
+
+private slots:
+    // Toggling the "verify data when download completes" checkbox must flow
+    // through PrefsDialog::set() into Prefs, which emits changed(tr_quark). This
+    // is the wiring the GUI relies on to persist the preference.
+    void toggling_verify_check_emits_prefs_changed()
+    {
+        auto const dl_dir = QDir{ sandboxDir() }.filePath(QStringLiteral("downloads"));
+        QVERIFY(QDir{}.mkpath(dl_dir));
+
+        auto prefs = Prefs{};
+        writeQuietSettings(sandboxDir());
+        setLocalPrefs(prefs, dl_dir);
+
+        auto rpc = RpcClient{};
+        auto session = Session{ sandboxDir(), prefs, rpc };
+        session.restart();
+        QVERIFY(session.isLocalFilesystem());
+
+        auto dialog = PrefsDialog{ session, prefs };
+        QVERIFY(drainFreeSpace(dialog));
+
+        auto* const check = dialog.findChild<QCheckBox*>(QStringLiteral("downloadDoneVerifyCheck"));
+        QVERIFY(check != nullptr);
+        if (check == nullptr) {
+            return;
+        }
+
+        // Spy after construction: the initial setChecked() runs under a
+        // QSignalBlocker, so only a genuine user toggle reaches Prefs.
+        auto const spy = QSignalSpy{ &prefs, qOverload<tr_quark>(&Prefs::changed) };
+
+        auto const was_checked = check->isChecked();
+        check->click();
+        QCOMPARE(check->isChecked(), !was_checked);
+
+        // exactly one changed(key) for the verify-on-completion preference
+        auto constexpr Key = TR_KEY_torrent_complete_verify_enabled;
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.first().at(0).value<tr_quark>(), Key);
+        QCOMPARE(prefs.get<bool>(Key), !was_checked);
+    }
+};
+} // namespace
+
+int main(int argc, char** argv)
+{
+    qRegisterMetaType<tr_quark>("tr_quark");
+    auto const app = QApplication{ argc, argv };
+
+    auto test = PrefsDialogTest{};
+    return QTest::qExec(&test, argc, argv);
+}
+
+#include "prefs-dialog-test.moc"

--- a/tests/qt/prefs-test.cc
+++ b/tests/qt/prefs-test.cc
@@ -40,6 +40,11 @@ class PrefsTest : public QObject
     }
 
 private slots:
+    static void initTestCase()
+    {
+        TR_QT_SKIP_UNLESS_SIGNALS_WORK();
+    }
+
     // QString round-trips exercise the Qt-only Converter in VariantHelpers.
     void handles_qstring()
     {

--- a/tests/qt/qt-test-fixtures.h
+++ b/tests/qt/qt-test-fixtures.h
@@ -7,8 +7,10 @@
 
 #include <type_traits>
 
+#include <QObject>
 #include <QTemporaryDir>
 #include <QTest>
+#include <QTimer>
 
 #include <fmt/format.h>
 
@@ -45,6 +47,34 @@ void trcompare(T const& actual, U const& expected, bool const negate)
 
 #define TRCOMPARE_EQ(actual, expected) trcompare((actual), (expected), false)
 #define TRCOMPARE_NE(actual, expected) trcompare((actual), (expected), true)
+
+// Probes whether this build's Qt can resolve a pointer-to-member signal at
+// runtime. Some prebuilt Qt packages (seen on the netbsd/freebsd CI runners,
+// where a modern Qt is compiled by a compiler too old for it) miscompile the
+// `connect()` machinery, so *every* pointer-to-member connection silently fails
+// with "signal not found" and never delivers. A failed connect returns an
+// invalid QMetaObject::Connection, which we detect here without needing an event
+// loop, moc, or a QApplication. Keying test execution on this capability -- vs a
+// hardcoded platform or compiler-version list -- lets the Qt runtime tests
+// re-enable themselves automatically once the environment can run them.
+[[nodiscard]] inline bool qtPointerConnectWorks()
+{
+    auto timer = QTimer{};
+    auto receiver = QObject{};
+    auto const connection = QObject::connect(&timer, &QTimer::timeout, &receiver, &QObject::deleteLater);
+    return static_cast<bool>(connection);
+}
+
+// Skip the entire test (call from initTestCase) when this build's Qt can't
+// deliver pointer-to-member signals; see qtPointerConnectWorks().
+#define TR_QT_SKIP_UNLESS_SIGNALS_WORK() \
+    do { \
+        if (!qtPointerConnectWorks()) { \
+            QSKIP( \
+                "Qt pointer-to-member connect is non-functional in this build's Qt " \
+                "(likely prebuilt with a compiler too old for it); skipping Qt runtime tests."); \
+        } \
+    } while (false)
 
 class BasicTest
 {

--- a/tests/qt/session-test.cc
+++ b/tests/qt/session-test.cc
@@ -80,6 +80,11 @@ class SessionTest
     Q_OBJECT
 
 private slots:
+    static void initTestCase()
+    {
+        TR_QT_SKIP_UNLESS_SIGNALS_WORK();
+    }
+
     static void download_dir_change_posts_session_set_data()
     {
         QTest::addColumn<Style>("initial_style");

--- a/web/src/prefs-dialog.js
+++ b/web/src/prefs-dialog.js
@@ -320,6 +320,14 @@ export class PrefsDialog extends EventTarget {
     PrefsDialog._enableIfChecked(input, cal.check);
     const download_queue_input = input;
 
+    cal = PrefsDialog._createCheckAndLabel(
+      'download-done-verify-div',
+      'Verify data when download completes',
+    );
+    cal.check.dataset.key = 'torrent_complete_verify_enabled';
+    root.append(cal.root);
+    const download_done_verify_check = cal.check;
+
     label = document.createElement('div');
     label.textContent = 'Seeding';
     label.classList.add('section-label');
@@ -373,6 +381,7 @@ export class PrefsDialog extends EventTarget {
     return {
       autostart_check,
       download_dir,
+      download_done_verify_check,
       download_queue_check,
       download_queue_input,
       incomplete_dir_check,


### PR DESCRIPTION
Part of  #82, specifically the subtask of getting the GTK and Qt apps' use of settings keys aligned with each other so that they can both use `tr::app::Prefs`.

The GTK and macOS apps already support reverify-on-download-complete. This PR adds support for it in RPC and adds it to the Qt and web UIs.

Notes: The "Re-verify data when download completes" feature is now supported on all desktop clients.

AI disclosure: I have written or reviewed all changes in this PR. Production C++ code written by me.  Tests and JS code written by Claude and reviewed by me.