### PR TITLE
chore: remove Access-Control-Expose-Headers header

### DIFF
--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -584,9 +584,6 @@ void handle_request(struct evhttp_request* req, void* arg)
 
         evhttp_add_header(output_headers, std::data(TrRpcVersionHeader), std::data(TrRpcVersionSemver));
 
-        auto const expose_val = fmt::format("{:s}, {:s}", TrRpcSessionIdHeader, TrRpcVersionHeader);
-        evhttp_add_header(output_headers, "Access-Control-Expose-Headers", expose_val.c_str());
-
         auto const body = fmt::format(
             "<p>Your request had an invalid session_id header.</p>"
             "<p>To fix this, follow these steps:"


### PR DESCRIPTION
Clean up a leftover header from the CORS removal in 994e9a7f (#30).

This leftover header wasn't a security risk; no need to backport to 4.1.x. 

It's just not needed anymore, so remove it.
