### PR TITLE
refactor: change file-piece-map to use `std::span`

### DIFF
--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -702,10 +702,10 @@ bool FileList::Impl::onViewPathToggled(Gtk::TreeViewColumn* col, Gtk::TreeModel:
                 break;
             }
 
-            tr_torrentSetFilePriorities(tor, indexBuf.data(), indexBuf.size(), new_priority);
+            tr_torrentSetFilePriorities(tor, indexBuf, new_priority);
         } else {
             auto const enabled = iter->get_value(file_cols.enabled);
-            tr_torrentSetFileDLs(tor, indexBuf.data(), indexBuf.size(), enabled == static_cast<int>(false));
+            tr_torrentSetFileDLs(tor, indexBuf, enabled == static_cast<int>(false));
         }
 
         refresh();

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -23,24 +23,24 @@ tr_file_piece_map::tr_file_piece_map(tr_torrent_metainfo const& tm)
     reset(tm);
 }
 
-tr_file_piece_map::tr_file_piece_map(tr_block_info const& block_info, uint64_t const* const file_sizes, size_t const n_files)
+tr_file_piece_map::tr_file_piece_map(tr_block_info const& block_info, std::span<uint64_t const> const file_sizes)
 {
-    reset(block_info, file_sizes, n_files);
+    reset(block_info, file_sizes);
 }
 
-void tr_file_piece_map::reset(tr_block_info const& block_info, uint64_t const* const file_sizes, size_t const n_files)
+void tr_file_piece_map::reset(tr_block_info const& block_info, std::span<uint64_t const> const file_sizes)
 {
-    file_bytes_.resize(n_files);
+    file_bytes_.resize(file_sizes.size());
     file_bytes_.shrink_to_fit();
 
-    file_pieces_.resize(n_files);
+    file_pieces_.resize(file_sizes.size());
     file_pieces_.shrink_to_fit();
 
     auto edge_pieces = small::set<tr_piece_index_t, 1024U>{};
-    edge_pieces.reserve(n_files * 2U);
+    edge_pieces.reserve(file_sizes.size() * 2U);
 
     uint64_t offset = 0U;
-    for (tr_file_index_t i = 0U; i < n_files; ++i) {
+    for (tr_file_index_t i = 0U; i < file_sizes.size(); ++i) {
         auto const file_size = file_sizes[i];
 
         auto const begin_byte = offset;
@@ -79,7 +79,7 @@ void tr_file_piece_map::reset(tr_torrent_metainfo const& tm)
     for (tr_file_index_t i = 0U; i < n; ++i) {
         file_sizes[i] = tm.file_size(i);
     }
-    reset({ tm.total_size(), tm.piece_size() }, std::data(file_sizes), std::size(file_sizes));
+    reset({ tm.total_size(), tm.piece_size() }, file_sizes);
 }
 
 namespace
@@ -155,10 +155,10 @@ void tr_file_priorities::set(tr_file_index_t const file, tr_priority_t const new
     priorities_[file] = new_priority;
 }
 
-void tr_file_priorities::set(tr_file_index_t const* const files, size_t const n, tr_priority_t const new_priority)
+void tr_file_priorities::set(std::span<tr_file_index_t const> const files, tr_priority_t const new_priority)
 {
-    for (size_t i = 0U; i < n; ++i) {
-        set(files[i], new_priority);
+    for (auto const file : files) {
+        set(file, new_priority);
     }
 }
 
@@ -209,10 +209,10 @@ void tr_files_wanted::set(tr_file_index_t const file, bool const wanted)
     wanted_.set(file, wanted);
 }
 
-void tr_files_wanted::set(tr_file_index_t const* const files, size_t const n_files, bool const wanted)
+void tr_files_wanted::set(std::span<tr_file_index_t const> const files, bool const wanted)
 {
-    for (size_t idx = 0U; idx < n_files; ++idx) {
-        set(files[idx], wanted);
+    for (auto const file : files) {
+        set(file, wanted);
     }
 }
 

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -12,6 +12,7 @@
 #include <algorithm> // for std::binary_search()
 #include <cstdint> // for uint64_t
 #include <cstddef> // for size_t
+#include <span>
 #include <vector>
 
 #include "libtransmission/bitfield.h"
@@ -40,7 +41,7 @@ public:
 
     using file_offset_t = offset_t<tr_file_index_t>;
     explicit tr_file_piece_map(tr_torrent_metainfo const& tm);
-    tr_file_piece_map(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files);
+    tr_file_piece_map(tr_block_info const& block_info, std::span<uint64_t const> file_sizes);
 
     [[nodiscard]] TR_CONSTEXPR_VEC piece_span_t piece_span_for_file(tr_file_index_t const file) const noexcept
     {
@@ -71,7 +72,7 @@ private:
     using byte_span_t = index_span_t<uint64_t>;
 
     void reset(tr_torrent_metainfo const& tm);
-    void reset(tr_block_info const& block_info, uint64_t const* file_sizes, size_t n_files);
+    void reset(tr_block_info const& block_info, std::span<uint64_t const> file_sizes);
 
     std::vector<byte_span_t> file_bytes_;
     std::vector<piece_span_t> file_pieces_;
@@ -87,7 +88,7 @@ public:
     }
 
     void set(tr_file_index_t file, tr_priority_t priority);
-    void set(tr_file_index_t const* files, size_t n, tr_priority_t priority);
+    void set(std::span<tr_file_index_t const> files, tr_priority_t priority);
 
     [[nodiscard]] tr_priority_t file_priority(tr_file_index_t file) const;
     [[nodiscard]] tr_priority_t piece_priority(tr_piece_index_t piece) const;
@@ -103,7 +104,7 @@ public:
     explicit tr_files_wanted(tr_file_piece_map const* fpm);
 
     void set(tr_file_index_t file, bool wanted);
-    void set(tr_file_index_t const* files, size_t n, bool wanted);
+    void set(std::span<tr_file_index_t const> files, bool wanted);
 
     [[nodiscard]] constexpr bool file_wanted(tr_file_index_t file) const
     {

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -354,9 +354,8 @@ public:
             , swarm_{ swarm }
             , wishlist_{ *this }
             , signal_tags_{ {
-                  tor_.files_wanted_changed_.connect_scoped([this](tr_torrent*, tr_file_index_t const*, tr_file_index_t, bool) {
-                      wishlist_.on_files_wanted_changed();
-                  }),
+                  tor_.files_wanted_changed_.connect_scoped(
+                      [this](tr_torrent*, std::span<tr_file_index_t const>, bool) { wishlist_.on_files_wanted_changed(); }),
                   swarm_.peer_disconnect.connect_scoped(
                       [this](tr_torrent*, tr_bitfield const& have, tr_bitfield const& requests) {
                           wishlist_.on_peer_disconnect(have, requests);
@@ -375,10 +374,9 @@ public:
                       [this](tr_torrent*, tr_peer*, tr_block_index_t block) { wishlist_.on_got_reject(block); }),
                   tor_.piece_completed_.connect_scoped(
                       [this](tr_torrent*, tr_piece_index_t piece) { wishlist_.on_piece_completed(piece); }),
-                  tor_.priority_changed_.connect_scoped(
-                      [this](tr_torrent*, tr_file_index_t const*, tr_file_index_t, tr_priority_t) {
-                          wishlist_.on_priority_changed();
-                      }),
+                  tor_.priority_changed_.connect_scoped([this](tr_torrent*, std::span<tr_file_index_t const>, tr_priority_t) {
+                      wishlist_.on_priority_changed();
+                  }),
                   swarm_.sent_cancel.connect_scoped(
                       [this](tr_torrent*, tr_peer*, tr_block_index_t block) { wishlist_.on_sent_cancel(block); }),
                   swarm_.sent_request.connect_scoped(

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -184,8 +184,8 @@ tr_resume::fields_t load_dnd(tr_variant::Map const& map, tr_torrent* tor)
         }
     }
 
-    tor->init_files_wanted(std::data(unwanted), std::size(unwanted), false);
-    tor->init_files_wanted(std::data(wanted), std::size(wanted), true);
+    tor->init_files_wanted(unwanted, false);
+    tor->init_files_wanted(wanted, true);
 
     return tr_resume::Dnd;
 }

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1083,7 +1083,7 @@ namespace make_torrent_field_helpers
 {
     auto [indices, err, errmsg] = get_file_indices(tor, files_vec);
     if (err == JsonRpc::Error::SUCCESS) {
-        tor->set_file_priorities(std::data(indices), std::size(indices), priority);
+        tor->set_file_priorities(indices, priority);
     }
     return { err, std::move(errmsg) };
 }
@@ -1109,7 +1109,7 @@ namespace make_torrent_field_helpers
 {
     auto [indices, err, errmsg] = get_file_indices(tor, files_vec);
     if (err == JsonRpc::Error::SUCCESS) {
-        tor->set_files_wanted(std::data(indices), std::size(indices), wanted);
+        tor->set_files_wanted(indices, wanted);
     }
     return { err, std::move(errmsg) };
 }

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -57,15 +57,15 @@ bool tr_ctor::save(std::string_view filename, tr_error* error) const
 
 void tr_ctor::init_torrent_priorities(tr_torrent& tor) const
 {
-    tor.set_file_priorities(std::data(low_), std::size(low_), TR_PRI_LOW);
-    tor.set_file_priorities(std::data(normal_), std::size(normal_), TR_PRI_NORMAL);
-    tor.set_file_priorities(std::data(high_), std::size(high_), TR_PRI_HIGH);
+    tor.set_file_priorities(low_, TR_PRI_LOW);
+    tor.set_file_priorities(normal_, TR_PRI_NORMAL);
+    tor.set_file_priorities(high_, TR_PRI_HIGH);
 }
 
 void tr_ctor::init_torrent_wanted(tr_torrent& tor) const
 {
-    tor.init_files_wanted(std::data(unwanted_), std::size(unwanted_), false);
-    tor.init_files_wanted(std::data(wanted_), std::size(wanted_), true);
+    tor.init_files_wanted(unwanted_, false);
+    tor.init_files_wanted(wanted_, true);
 }
 
 // --- PUBLIC C API

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1749,11 +1749,11 @@ void tr_torrent::recheck_completeness()
 
 // --- File DND
 
-void tr_torrentSetFileDLs(tr_torrent* tor, tr_file_index_t const* files, tr_file_index_t n_files, bool wanted)
+void tr_torrentSetFileDLs(tr_torrent* const tor, std::span<tr_file_index_t const> const files, bool const wanted)
 {
     tr_return_if_fail(tr_isTorrent(tor));
 
-    tor->set_files_wanted(files, n_files, wanted);
+    tor->set_files_wanted(files, wanted);
 }
 
 // ---
@@ -1851,13 +1851,13 @@ tr_block_span_t tr_torrent::block_span_for_file(tr_file_index_t const file) cons
 
 // ---
 
-void tr_torrent::set_file_priorities(tr_file_index_t const* files, tr_file_index_t file_count, tr_priority_t priority)
+void tr_torrent::set_file_priorities(std::span<tr_file_index_t const> const files, tr_priority_t priority)
 {
-    if (std::ranges::any_of(files, files + file_count, [this, priority](tr_file_index_t file) {
+    if (std::ranges::any_of(files, [this, priority](tr_file_index_t file) {
             return priority != file_priorities_.file_priority(file);
         })) {
-        file_priorities_.set(files, file_count, priority);
-        priority_changed_(this, files, file_count, priority);
+        file_priorities_.set(files, priority);
+        priority_changed_(this, files, priority);
         set_dirty();
         mark_changed();
     }
@@ -2323,14 +2323,13 @@ void tr_torrentRenamePath(
 // ---
 
 void tr_torrentSetFilePriorities(
-    tr_torrent* tor,
-    tr_file_index_t const* files,
-    tr_file_index_t file_count,
-    tr_priority_t priority)
+    tr_torrent* const tor,
+    std::span<tr_file_index_t const> const files,
+    tr_priority_t const priority)
 {
     tr_return_if_fail(tr_isTorrent(tor));
 
-    tor->set_file_priorities(files, file_count, priority);
+    tor->set_file_priorities(files, priority);
 }
 
 bool tr_torrentHasMetadata(tr_torrent const* tor)

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -408,14 +408,14 @@ struct tr_torrent {
         return files_wanted_.file_wanted(file);
     }
 
-    void init_files_wanted(tr_file_index_t const* files, size_t n_files, bool wanted)
+    void init_files_wanted(std::span<tr_file_index_t const> files, bool wanted)
     {
-        set_files_wanted(files, n_files, wanted, /*is_bootstrapping*/ true);
+        set_files_wanted(files, wanted, /*is_bootstrapping*/ true);
     }
 
-    void set_files_wanted(tr_file_index_t const* files, size_t n_files, bool wanted)
+    void set_files_wanted(std::span<tr_file_index_t const> files, bool wanted)
     {
-        set_files_wanted(files, n_files, wanted, /*is_bootstrapping*/ false);
+        set_files_wanted(files, wanted, /*is_bootstrapping*/ false);
     }
 
     /// PRIORITIES
@@ -425,13 +425,13 @@ struct tr_torrent {
         return file_priorities_.piece_priority(piece);
     }
 
-    void set_file_priorities(tr_file_index_t const* files, tr_file_index_t file_count, tr_priority_t priority);
+    void set_file_priorities(std::span<tr_file_index_t const> files, tr_priority_t priority);
 
     void set_file_priority(tr_file_index_t file, tr_priority_t priority)
     {
         if (priority != file_priorities_.file_priority(file)) {
             file_priorities_.set(file, priority);
-            priority_changed_(this, &file, 1U, priority);
+            priority_changed_(this, std::span{ &file, 1U }, priority);
             set_dirty();
             mark_changed();
         }
@@ -995,8 +995,8 @@ struct tr_torrent {
     sigslot::signal<tr_torrent*> started_;
     sigslot::signal<tr_torrent*> stopped_;
     sigslot::signal<tr_torrent*> swarm_is_all_upload_only_;
-    sigslot::signal<tr_torrent*, tr_file_index_t const*, tr_file_index_t, bool> files_wanted_changed_;
-    sigslot::signal<tr_torrent*, tr_file_index_t const*, tr_file_index_t, tr_priority_t> priority_changed_;
+    sigslot::signal<tr_torrent*, std::span<tr_file_index_t const>, bool> files_wanted_changed_;
+    sigslot::signal<tr_torrent*, std::span<tr_file_index_t const>, tr_priority_t> priority_changed_;
     sigslot::signal<tr_torrent*, bool> sequential_download_changed_;
     sigslot::signal<tr_torrent*, tr_piece_index_t> sequential_download_from_piece_changed_;
 
@@ -1203,13 +1203,13 @@ private:
         needs_completeness_check_ = true;
     }
 
-    void set_files_wanted(tr_file_index_t const* files, size_t n_files, bool wanted, bool is_bootstrapping)
+    void set_files_wanted(std::span<tr_file_index_t const> files, bool wanted, bool is_bootstrapping)
     {
         auto const lock = unique_lock();
 
-        files_wanted_.set(files, n_files, wanted);
+        files_wanted_.set(files, wanted);
         completion_.invalidate_size_when_done();
-        files_wanted_changed_(this, files, n_files, wanted);
+        files_wanted_changed_(this, files, wanted);
 
         if (!is_bootstrapping) {
             set_dirty();

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -16,6 +16,7 @@
 #include <ctime>
 #include <functional>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -731,14 +732,10 @@ void tr_torrentSetPeerLimit(tr_torrent* tor, uint16_t max_connected_peers);
  *
  * @param priority must be one of TR_PRI_NORMAL, _HIGH, or _LOW
  */
-void tr_torrentSetFilePriorities(
-    tr_torrent* torrent,
-    tr_file_index_t const* files,
-    tr_file_index_t file_count,
-    tr_priority_t priority);
+void tr_torrentSetFilePriorities(tr_torrent* torrent, std::span<tr_file_index_t const> files, tr_priority_t priority);
 
 /** @brief Set a batch of files to be downloaded or not. */
-void tr_torrentSetFileDLs(tr_torrent* torrent, tr_file_index_t const* files, tr_file_index_t n_files, bool wanted);
+void tr_torrentSetFileDLs(tr_torrent* tor, std::span<tr_file_index_t const>, bool wanted);
 
 /**
  * Returns a permanently interned string of the torrent's download directory.

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -1509,11 +1509,10 @@ static tr_torrent_rename_done_func makeRenameDoneCallback(NSDictionary* contextI
 - (void)setFileCheckState:(NSControlStateValue)state forIndexes:(NSIndexSet*)indexSet
 {
     NSUInteger count = indexSet.count;
-    tr_file_index_t* files = static_cast<tr_file_index_t*>(malloc(count * sizeof(tr_file_index_t)));
-    [indexSet getIndexes:files maxCount:count inIndexRange:nil];
+    auto files = std::vector<tr_file_index_t>(count);
+    [indexSet getIndexes:files.data() maxCount:files.size() inIndexRange:nil];
 
-    tr_torrentSetFileDLs(self.fHandle, files, count, state != NSControlStateValueOff);
-    free(files);
+    tr_torrentSetFileDLs(self.fHandle, files, state != NSControlStateValueOff);
 
     [self update];
     [NSNotificationCenter.defaultCenter postNotificationName:@"TorrentFileCheckChange" object:self];
@@ -1528,7 +1527,7 @@ static tr_torrent_rename_done_func makeRenameDoneCallback(NSDictionary* contextI
         files[i] = index;
     }
 
-    tr_torrentSetFilePriorities(self.fHandle, std::data(files), std::size(files), priority);
+    tr_torrentSetFilePriorities(self.fHandle, files, priority);
 }
 
 - (BOOL)hasFilePriority:(tr_priority_t)priority forIndexes:(NSIndexSet*)indexSet

--- a/tests/libtransmission/file-piece-map-test.cc
+++ b/tests/libtransmission/file-piece-map-test.cc
@@ -66,7 +66,7 @@ protected:
 
 TEST_F(FilePieceMapTest, fileOffset)
 {
-    auto const fpm = tr_file_piece_map{ block_info_, std::data(FileSizes), std::size(FileSizes) };
+    auto const fpm = tr_file_piece_map{ block_info_, FileSizes };
 
     // first byte of the first file
     auto file_offset = fpm.file_offset(0U);
@@ -119,7 +119,7 @@ TEST_F(FilePieceMapTest, pieceSpan)
     });
     EXPECT_EQ(std::size(FileSizes), std::size(ExpectedPieceSpans));
 
-    auto const fpm = tr_file_piece_map{ block_info_, std::data(FileSizes), std::size(FileSizes) };
+    auto const fpm = tr_file_piece_map{ block_info_, FileSizes };
     auto const n_files = fpm.file_count();
     EXPECT_EQ(std::size(FileSizes), n_files);
     uint64_t offset = 0U;
@@ -134,7 +134,7 @@ TEST_F(FilePieceMapTest, pieceSpan)
 
 TEST_F(FilePieceMapTest, priorities)
 {
-    auto const fpm = tr_file_piece_map{ block_info_, std::data(FileSizes), std::size(FileSizes) };
+    auto const fpm = tr_file_piece_map{ block_info_, FileSizes };
     auto file_priorities = tr_file_priorities(&fpm);
     tr_file_index_t const n_files = std::size(FileSizes);
 
@@ -271,13 +271,13 @@ TEST_F(FilePieceMapTest, priorities)
     auto file_indices = std::vector<tr_file_index_t>(n_files);
     std::iota(std::begin(file_indices), std::end(file_indices), 0U);
     pri = TR_PRI_HIGH;
-    file_priorities.set(std::data(file_indices), std::size(file_indices), pri);
+    file_priorities.set(file_indices, pri);
     std::ranges::fill(expected_file_priorities, pri);
     std::ranges::fill(expected_piece_priorities, pri);
     mark_file_endpoints_as_high_priority();
     compare_to_expected();
     pri = TR_PRI_LOW;
-    file_priorities.set(std::data(file_indices), std::size(file_indices), pri);
+    file_priorities.set(file_indices, pri);
     std::ranges::fill(expected_file_priorities, pri);
     std::ranges::fill(expected_piece_priorities, pri);
     mark_file_endpoints_as_high_priority();
@@ -286,7 +286,7 @@ TEST_F(FilePieceMapTest, priorities)
 
 TEST_F(FilePieceMapTest, wanted)
 {
-    auto const fpm = tr_file_piece_map{ block_info_, std::data(FileSizes), std::size(FileSizes) };
+    auto const fpm = tr_file_piece_map{ block_info_, FileSizes };
     auto files_wanted = tr_files_wanted(&fpm);
     tr_file_index_t const n_files = std::size(FileSizes);
 
@@ -390,11 +390,11 @@ TEST_F(FilePieceMapTest, wanted)
     // test the batch API
     auto file_indices = std::vector<tr_file_index_t>(n_files);
     std::iota(std::begin(file_indices), std::end(file_indices), 0);
-    files_wanted.set(std::data(file_indices), std::size(file_indices), true);
+    files_wanted.set(file_indices, true);
     expected_files_wanted.set_has_all();
     expected_pieces_wanted.set_has_all();
     compare_to_expected();
-    files_wanted.set(std::data(file_indices), std::size(file_indices), false);
+    files_wanted.set(file_indices, false);
     expected_files_wanted.set_has_none();
     expected_pieces_wanted.set_has_none();
     compare_to_expected();

--- a/tests/libtransmission/torrents-test.cc
+++ b/tests/libtransmission/torrents-test.cc
@@ -144,7 +144,7 @@ TEST_F(TorrentsTest, invalidArgsAreLogged)
     tr_torrentVerify(nullptr);
     ++expected_log_size;
 
-    tr_torrentSetFileDLs(nullptr, nullptr, 0, false);
+    tr_torrentSetFileDLs(nullptr, {}, false);
     ++expected_log_size;
 
     EXPECT_EQ(TR_PRI_NORMAL, tr_torrentGetPriority(nullptr));
@@ -174,7 +174,7 @@ TEST_F(TorrentsTest, invalidArgsAreLogged)
     tr_torrentRenamePath(nullptr, ""sv, ""sv, {});
     ++expected_log_size;
 
-    tr_torrentSetFilePriorities(nullptr, nullptr, 0, TR_PRI_NORMAL);
+    tr_torrentSetFilePriorities(nullptr, {}, TR_PRI_NORMAL);
     ++expected_log_size;
 
     EXPECT_FALSE(tr_torrentHasMetadata(nullptr));


### PR DESCRIPTION
Fixes `cppcoreguidelines-pro-bounds-pointer-arithmetic` clang-tidy warnings in file piece map code.

There should be no change in behaviour.

Notes: Moved from C++17 to C++20.