### PR TITLE
ci: handle dpkg configuration-ordering failures issues more gracefully

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -144,7 +144,7 @@ runs:
             BASE_PACKAGES+=(mold)
           fi
 
-          $SUDO_CMD apt-get install -y --no-install-recommends "${BASE_PACKAGES[@]}"
+          SUDO_CMD="$SUDO_CMD" bash "$GITHUB_ACTION_PATH/apt-install.sh" "${BASE_PACKAGES[@]}"
 
           # Setup UTF-8 locale for Qt builds
           if [[ "${{ inputs.enable-qt }}" != "false" ]]; then
@@ -179,9 +179,9 @@ runs:
             SUDO_CMD="sudo"
           fi
           if [ '${{ inputs.enable-gtk }}' = 'gtk3' ]; then
-            $SUDO_CMD apt-get install -y --no-install-recommends libgtkmm-3.0-dev
+            SUDO_CMD="$SUDO_CMD" bash "$GITHUB_ACTION_PATH/apt-install.sh" libgtkmm-3.0-dev
           elif [ '${{ inputs.enable-gtk }}' = 'gtk4' ]; then
-            $SUDO_CMD apt-get install -y --no-install-recommends libgtkmm-4.0-dev
+            SUDO_CMD="$SUDO_CMD" bash "$GITHUB_ACTION_PATH/apt-install.sh" libgtkmm-4.0-dev
           fi
         else
           echo "Unsupported package family: $PKG_FAMILY"
@@ -204,9 +204,9 @@ runs:
             SUDO_CMD="sudo"
           fi
           if [[ "${{ inputs.enable-qt }}" == "qt5" ]]; then
-            $SUDO_CMD apt-get install -y --no-install-recommends libxcb-cursor0 qtbase5-dev libqt5svg5-dev qttools5-dev
+            SUDO_CMD="$SUDO_CMD" bash "$GITHUB_ACTION_PATH/apt-install.sh" libxcb-cursor0 qtbase5-dev libqt5svg5-dev qttools5-dev
           elif [[ "${{ inputs.enable-qt }}" == "qt6" ]]; then
-            $SUDO_CMD apt-get install -y --no-install-recommends qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-svg-dev
+            SUDO_CMD="$SUDO_CMD" bash "$GITHUB_ACTION_PATH/apt-install.sh" qt6-base-dev qt6-tools-dev qt6-l10n-tools qt6-svg-dev
           fi
         else
           echo "Unsupported package family: $PKG_FAMILY"

--- a/.github/actions/install-deps/apt-install.sh
+++ b/.github/actions/install-deps/apt-install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# `apt-get install` wrapper that tolerates dpkg configuration-ordering failures.
+# When a single transaction unpacks a large dependency graph, dpkg can try to
+# configure a package before its freshly-unpacked dependencies, aborting the run
+# even though nothing is actually broken. On failure, complete the deferred
+# configuration and retry once.
+#
+# Pass the sudo prefix (if any) via the SUDO_CMD environment variable.
+#
+set -euo pipefail
+
+: "${SUDO_CMD:=}"
+
+if $SUDO_CMD apt-get install -y --no-install-recommends "$@"; then
+  exit 0
+fi
+
+echo "::warning title=apt-get retry::install failed; completing deferred dpkg configuration and retrying"
+$SUDO_CMD dpkg --configure -a || true
+$SUDO_CMD apt-get install -f -y
+$SUDO_CMD apt-get install -y --no-install-recommends "$@"


### PR DESCRIPTION
This is to resolve a CI issue seen today in Debian unstable:

```
Preparing to unpack .../5-libtss2-tcti-cmd0t64_4.1.3-6_amd64.deb ...
Unpacking libtss2-tcti-cmd0t64:amd64 (4.1.3-6) ...
dpkg: dependency problems prevent configuration of libtss2-tcti-cmd0t64:amd64:
 libtss2-tcti-cmd0t64:amd64 depends on tpm-udev (>= 4.1.3-6); however:
  Package tpm-udev is not configured yet.
 libtss2-tcti-cmd0t64:amd64 depends on libtss2-mu-4.0.1-0t64 (>= 3.0.1); however:
  Package libtss2-mu-4.0.1-0t64:amd64 is not configured yet.

dpkg: error processing package libtss2-tcti-cmd0t64:amd64 (--configure):
 dependency problems - leaving unconfigured
Errors were encountered while processing:
 libtss2-tcti-cmd0t64:amd64
```