### PR TITLE
ci: remove dead code in GitHub Actions yml

### DIFF
--- a/.github/actions/detect-platform/action.yml
+++ b/.github/actions/detect-platform/action.yml
@@ -4,15 +4,6 @@ outputs:
   os-family:
     description: 'OS family (linux, macos, windows, unknown)'
     value: ${{ steps.detect.outputs.os-family }}
-  distro:
-    description: 'Linux distribution (ubuntu, debian, fedora, unknown)'
-    value: ${{ steps.detect.outputs.distro }}
-  distro-version:
-    description: 'Linux distribution version (e.g., 22.04)'
-    value: ${{ steps.detect.outputs.distro-version }}
-  pkg-family:
-    description: 'Package manager family (apt, dnf, brew, unknown)'
-    value: ${{ steps.detect.outputs.pkg-family }}
 runs:
   using: composite
   steps:

--- a/.github/actions/detect-platform/detect-platform.sh
+++ b/.github/actions/detect-platform/detect-platform.sh
@@ -46,8 +46,5 @@ echo "DISTRO_VERSION=$DISTRO_VERSION" >> "$GITHUB_ENV"
 echo "PKG_FAMILY=$PKG_FAMILY" >> "$GITHUB_ENV"
 
 echo "os-family=$OS_FAMILY" >> "$GITHUB_OUTPUT"
-echo "distro=$DISTRO" >> "$GITHUB_OUTPUT"
-echo "distro-version=$DISTRO_VERSION" >> "$GITHUB_OUTPUT"
-echo "pkg-family=$PKG_FAMILY" >> "$GITHUB_OUTPUT"
 
 echo "Final detected platform: OS_FAMILY=$OS_FAMILY DISTRO=$DISTRO DISTRO_VERSION=$DISTRO_VERSION PKG_FAMILY=$PKG_FAMILY"

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -9,10 +9,6 @@ inputs:
     description: 'Install clang-tidy-22'
     required: false
     default: 'false'
-  enable-debugging:
-    description: 'Install debugging tools (gdb, lldb, etc.)'
-    required: false
-    default: 'false'
   enable-gtk:
     description: 'Install GTK dependencies (gtk3 or gtk4)'
     required: false
@@ -316,14 +312,5 @@ runs:
         if [[ "${{ inputs.enable-clang-tidy }}" == "true" ]]; then
           echo "Static Analysis:"
           clang-tidy-22 --version 2>/dev/null | head -1 || clang-tidy --version 2>/dev/null | head -1 || echo "clang-tidy: not found"
-          echo ""
-        fi
-
-        if [[ "${{ inputs.enable-debugging }}" == "true" ]]; then
-          echo "Debugging Tools:"
-          gdb --version 2>/dev/null | head -1 || echo "gdb: not found"
-          if [[ "$OS_FAMILY" == "macos" ]]; then
-            lldb --version 2>/dev/null | head -1 || echo "lldb: not found"
-          fi
           echo ""
         fi

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -1,10 +1,6 @@
 name: Run tests
 description: Run ctest with crash-friendly settings and optional fallbacks
 inputs:
-  setup-env:
-    description: "Call set-test-env before running tests"
-    required: false
-    default: "true"
   build-dir:
     description: "CTest build directory"
     required: false
@@ -13,16 +9,8 @@ inputs:
     description: "CTest build configuration"
     required: false
     default: ""
-  parallel:
-    description: "Number of parallel jobs (auto if empty)"
-    required: false
-    default: ""
   timeout:
     description: "CTest timeout in seconds"
-    required: false
-    default: ""
-  extra-ctest-args:
-    description: "Additional ctest arguments"
     required: false
     default: ""
   enable-sanitizers:
@@ -33,48 +21,19 @@ inputs:
     description: "Explicitly enable ASan options"
     required: false
     default: ""
-  enable-ubsan:
-    description: "Explicitly enable UBSan options"
-    required: false
-    default: ""
-  enable-lsan:
-    description: "Explicitly enable LSan options"
-    required: false
-    default: ""
   extra-asan-options:
     description: "Additional ASan options to append"
     required: false
     default: ""
-  extra-ubsan-options:
-    description: "Additional UBSan options to append"
-    required: false
-    default: ""
-  extra-lsan-options:
-    description: "Additional LSan options to append"
-    required: false
-    default: ""
-  use-catchsegv:
-    description: "Use catchsegv on Linux if available"
-    required: false
-    default: "true"
-  enable-macos-crash-reports:
-    description: "Attempt to collect macOS crash reports on failure"
-    required: false
-    default: "true"
 runs:
   using: composite
   steps:
     - name: Set test environment
-      if: ${{ inputs.setup-env == 'true' }}
       uses: ./.github/actions/set-test-env
       with:
         enable-sanitizers: ${{ inputs.enable-sanitizers }}
         enable-asan: ${{ inputs.enable-asan }}
-        enable-ubsan: ${{ inputs.enable-ubsan }}
-        enable-lsan: ${{ inputs.enable-lsan }}
         extra-asan-options: ${{ inputs.extra-asan-options }}
-        extra-ubsan-options: ${{ inputs.extra-ubsan-options }}
-        extra-lsan-options: ${{ inputs.extra-lsan-options }}
     - name: Detect platform
       id: platform
       uses: ./.github/actions/detect-platform
@@ -87,23 +46,17 @@ runs:
 
         build_dir="${{ inputs.build-dir }}"
         build_config="${{ inputs.build-config }}"
-        parallel="${{ inputs.parallel }}"
         timeout="${{ inputs.timeout }}"
-        extra_args="${{ inputs.extra-ctest-args }}"
         enable_sanitizers="${{ inputs.enable-sanitizers }}"
-        use_catchsegv="${{ inputs.use-catchsegv }}"
-        enable_macos_crash_reports="${{ inputs.enable-macos-crash-reports }}"
 
-        if [[ -z "$parallel" ]]; then
-          if command -v nproc >/dev/null 2>&1; then
-            parallel=$(nproc)
-          elif command -v sysctl >/dev/null 2>&1; then
-            parallel=$(sysctl -n hw.logicalcpu)
-          elif [[ -n "${NUMBER_OF_PROCESSORS:-}" ]]; then
-            parallel="$NUMBER_OF_PROCESSORS"
-          else
-            parallel=1
-          fi
+        if command -v nproc >/dev/null 2>&1; then
+          parallel=$(nproc)
+        elif command -v sysctl >/dev/null 2>&1; then
+          parallel=$(sysctl -n hw.logicalcpu)
+        elif [[ -n "${NUMBER_OF_PROCESSORS:-}" ]]; then
+          parallel="$NUMBER_OF_PROCESSORS"
+        else
+          parallel=1
         fi
 
         args=("--test-dir" "$build_dir" "-j" "$parallel" "--output-on-failure")
@@ -113,18 +66,15 @@ runs:
         if [[ -n "$timeout" ]]; then
           args+=("--timeout" "$timeout")
         fi
-        if [[ -n "$extra_args" ]]; then
-          args+=($extra_args)
-        fi
 
         crash_marker=""
-        if [[ "${OS_FAMILY:-}" == "macos" && "$enable_macos_crash_reports" == "true" ]]; then
+        if [[ "${OS_FAMILY:-}" == "macos" ]]; then
           crash_marker="$RUNNER_TEMP/ctest-crash-marker"
           touch "$crash_marker"
         fi
 
         run_ctest() {
-          if [[ "${OS_FAMILY:-}" == "linux" && "$enable_sanitizers" != "true" && "$use_catchsegv" == "true" ]] && command -v catchsegv >/dev/null 2>&1; then
+          if [[ "${OS_FAMILY:-}" == "linux" && "$enable_sanitizers" != "true" ]] && command -v catchsegv >/dev/null 2>&1; then
             catchsegv ctest "${args[@]}"
           else
             ctest "${args[@]}"
@@ -136,7 +86,7 @@ runs:
         status=$?
         set -e
 
-        if [[ $status -ne 0 && "${OS_FAMILY:-}" == "macos" && "$enable_macos_crash_reports" == "true" ]]; then
+        if [[ $status -ne 0 && "${OS_FAMILY:-}" == "macos" ]]; then
           echo "::group::macOS crash reports"
           reports_found=0
           for report_dir in "$HOME/Library/Logs/DiagnosticReports" "/Library/Logs/DiagnosticReports"; do

--- a/.github/actions/set-test-env/action.yml
+++ b/.github/actions/set-test-env/action.yml
@@ -9,24 +9,8 @@ inputs:
     description: "Explicitly enable ASan options"
     required: false
     default: ""
-  enable-ubsan:
-    description: "Explicitly enable UBSan options"
-    required: false
-    default: ""
-  enable-lsan:
-    description: "Explicitly enable LSan options"
-    required: false
-    default: ""
   extra-asan-options:
     description: "Additional ASan options to append"
-    required: false
-    default: ""
-  extra-ubsan-options:
-    description: "Additional UBSan options to append"
-    required: false
-    default: ""
-  extra-lsan-options:
-    description: "Additional LSan options to append"
     required: false
     default: ""
 runs:
@@ -47,10 +31,12 @@ runs:
 
         enable_sanitizers="${{ inputs.enable-sanitizers }}"
         enable_asan="${{ inputs.enable-asan }}"
-        enable_ubsan="${{ inputs.enable-ubsan }}"
-        enable_lsan="${{ inputs.enable-lsan }}"
+        enable_ubsan=""
+        enable_lsan=""
 
-        if [[ -z "$enable_asan" && -z "$enable_ubsan" && -z "$enable_lsan" ]]; then
+        # enable-asan may be set alone (e.g. MSVC's address-only ASan);
+        # otherwise ASan/UBSan/LSan all track enable-sanitizers.
+        if [[ -z "$enable_asan" ]]; then
           enable_asan="$enable_sanitizers"
           enable_ubsan="$enable_sanitizers"
           enable_lsan="$enable_sanitizers"
@@ -88,16 +74,10 @@ runs:
 
         if [[ "$enable_ubsan" == "true" ]]; then
           ubsan_opts="halt_on_error=1:print_stacktrace=1:report_error_type=1:symbolize=1"
-          if [[ -n "${{ inputs.extra-ubsan-options }}" ]]; then
-            ubsan_opts+="${ubsan_opts:+:}${{ inputs.extra-ubsan-options }}"
-          fi
           echo "UBSAN_OPTIONS=$ubsan_opts" >> "$GITHUB_ENV"
         fi
 
         if [[ "$enable_lsan" == "true" ]]; then
           lsan_opts="verbosity=0:log_threads=0:print_suppressions=1"
-          if [[ -n "${{ inputs.extra-lsan-options }}" ]]; then
-            lsan_opts+="${lsan_opts:+:}${{ inputs.extra-lsan-options }}"
-          fi
           echo "LSAN_OPTIONS=$lsan_opts" >> "$GITHUB_ENV"
         fi

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -144,7 +144,6 @@ jobs:
         uses: ./.github/actions/install-deps
         with:
           compiler: clang
-          enable-debugging: true
           enable-qt: qt6
           use-sudo: true
       - name: Configure

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -726,8 +726,6 @@ jobs:
         run: cmake --build obj --config RelWithDebInfo
       - name: Test
         if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
-        env:
-          TMPDIR: /private/tmp
         uses: ./.github/actions/run-tests
         with:
           build-dir: obj
@@ -1203,8 +1201,6 @@ jobs:
         run: cmake --build obj --config RelWithDebInfo
       - name: Test
         if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
-        env:
-          TMPDIR: /private/tmp
         uses: ./.github/actions/run-tests
         with:
           build-dir: obj

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1213,7 +1213,7 @@ jobs:
         run: cmake --install obj --config RelWithDebInfo --strip
       - uses: actions/upload-artifact@v6
         with:
-          name: binaries-${{ github.job }}-${{ matrix.enable-utp && 'with' || 'without' }}-utp
+          name: binaries-${{ github.job }}-without-utp
           path: pfx/**/*
 
   android:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1516,8 +1516,6 @@ jobs:
         uses: ./.github/actions/install-deps
         with:
           compiler: clang # Workaround https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109717
-          enable-gtk: false
-          enable-qt: false
           use-sudo: true
           enable-mold: true
       - name: Install Crypto Library


### PR DESCRIPTION
CI yml simplification, part 1 of 4. This one removes dead code.

- remove unused inputs from `run-tests`
- remove redundant install-deps in the crypto job
- remove unused outputs from `detect-platform`
- remove unused matrix option in `utp-disabled`
- fix copy-paste error that used macOS `TMPDIR=/private/tmp`  on Linux

AI disclosure: I have reviewed all changes in this PR. This dead code was found by Claude with a `/simplify` prompt.