### PR TITLE
ci: use sccache on linux and macos

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -207,12 +207,18 @@ jobs:
         uses: ./.github/actions/install-deps
         with:
           compiler: clang
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ${{ github.job }}
       - name: Configure
         run: |
           cmake \
             -S . \
             -B obj \
             -G Ninja \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_CXX_FLAGS='-gdwarf-4 -fno-omit-frame-pointer -fsanitize=address,undefined' \
             -DCMAKE_C_FLAGS='-gdwarf-4 -fno-omit-frame-pointer -fsanitize=address,undefined' \
@@ -613,12 +619,18 @@ jobs:
           compiler: clang
           enable-gtk: ${{ needs.what-to-make.outputs.make-gtk == 'true' && 'gtk4' || 'false' }}
           enable-qt: ${{ needs.what-to-make.outputs.make-qt == 'true' && 'qt6' || 'false' }}
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ${{ github.job }}-${{ matrix.os }}
       - name: Configure
         run: |
           cmake \
             -S . \
             -B obj \
             -G Ninja \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_INSTALL_PREFIX=pfx \
             -DCMAKE_PREFIX_PATH=`brew --prefix`/opt/qt \
@@ -910,12 +922,18 @@ jobs:
           name: source-tarball
       - name: Extract Source
         run: mkdir src && tar xf transmission*.tar.* -C src --strip-components 1
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ${{ github.job }}-${{ matrix.os }}
       - name: Configure
         run: |
           cmake \
             -S src \
             -B obj \
             -G Ninja \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_CXX_FLAGS='--system-header-prefix=fmt/' `# Needed to supress system header warnings in macos-26` \
             -DCMAKE_C_FLAGS='--system-header-prefix=fmt/' `# Needed to supress system header warnings in macos26` \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -51,7 +51,6 @@ jobs:
         with:
           fetch-depth: 0
           path: src
-          submodules: recursive
       - name: Check for diffs
         id: check-diffs
         run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -143,12 +143,18 @@ jobs:
           compiler: clang
           enable-qt: qt6
           use-sudo: true
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ${{ github.job }}
       - name: Configure
         run: |
           cmake \
             -S . \
             -B obj \
             -G Ninja \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_CXX_COMPILER='clang++' \
             -DCMAKE_CXX_FLAGS='-gdwarf-4 -fno-omit-frame-pointer -fsanitize=address,leak,undefined' \
@@ -1171,12 +1177,18 @@ jobs:
           name: source-tarball
       - name: Extract Source
         run: mkdir src && tar xf transmission*.tar.* -C src --strip-components 1
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ${{ github.job }}
       - name: Configure
         run: |
           cmake \
             -S src \
             -B obj \
             -G Ninja \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_CXX_COMPILER='clang++' \
             -DCMAKE_C_COMPILER='clang' \
@@ -1287,12 +1299,18 @@ jobs:
           enable-qt: ${{ needs.what-to-make.outputs.make-qt == 'true' && 'qt6' || 'false' }}
           use-sudo: true
           enable-mold: true
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ${{ github.job }}
       - name: Configure
         run: |
           cmake \
             -S . \
             -B obj \
             -G Ninja \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_STANDARD=23 \
             -DCMAKE_CXX_COMPILER='clang++' \
             -DCMAKE_C_COMPILER='clang' \
@@ -1360,12 +1378,18 @@ jobs:
           name: source-tarball
       - name: Extract Source
         run: mkdir src && tar xf transmission*.tar.* -C src --strip-components 1
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ${{ github.job }}
       - name: Configure
         run: |
           cmake \
             -S src \
             -B obj \
             -G Ninja \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER='clang++' \
             -DCMAKE_C_COMPILER='clang' \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -1535,12 +1559,18 @@ jobs:
           name: source-tarball
       - name: Extract Source
         run: mkdir src && tar xf transmission*.tar.* -C src --strip-components 1
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ${{ github.job }}-${{ matrix.crypto.cmake }}
       - name: Configure
         run: |
           cmake \
             -S src \
             -B obj \
             -G Ninja \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_CXX_COMPILER='clang++' \
             -DCMAKE_C_COMPILER='clang' \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -386,7 +386,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          submodules: recursive
+          submodules: false
+      - name: Check out submodules (shallow)
+        if: matrix.enabled == 'true'
+        run: git submodule update --init --recursive --depth 1
       - name: Get Dependencies
         if: matrix.enabled == 'true'
         uses: ./.github/actions/install-deps
@@ -478,7 +481,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          submodules: recursive
+          submodules: false
+      - name: Check out submodules (shallow)
+        if: matrix.enabled == 'true'
+        shell: bash
+        run: git submodule update --init --recursive --depth 1
       - name: Prepare Build Deps
         if: matrix.enabled == 'true'
         uses: ./.github/actions/prepare-deps-win32

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -99,8 +99,6 @@ jobs:
           cat /etc/os-release
       - name: Get Source
         uses: actions/checkout@v6
-        with:
-          submodules: recursive
       - name: Check for style diffs
         id: check-for-diffs
         working-directory: .

--- a/cmake/TrMacros.cmake
+++ b/cmake/TrMacros.cmake
@@ -256,6 +256,8 @@ macro(tr_add_external_auto_library ID PACKAGENAME)
                 "-DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}"
                 "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
                 "-DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}"
+                "-DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}"
+                "-DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}"
                 "-DCMAKE_AR=${CMAKE_AR}"
                 "-DCMAKE_NM=${CMAKE_NM}"
                 "-DCMAKE_RANLIB=${CMAKE_RANLIB}"


### PR DESCRIPTION
CI yml simplification, part 2 in a [series](https://github.com/transmissiontorrent/transmission/pull/101) of 4. This piece:

- Use sccache to persist unchanged build info between PRs.
- Use shallow checkouts of submodules when we don't need their commit history
 
AI disclosure: I have reviewed all changes in this PR. These refactors were suggested by Claude during a /simplify prompt.

