### PR TITLE
chore: add `new` label to new PRs

### DIFF
--- a/.github/workflows/pr-new-label-expiry.yml
+++ b/.github/workflows/pr-new-label-expiry.yml
@@ -1,12 +1,11 @@
 name: Expire the "new" label on pull requests
 
 # Removes the `new` label once min(2 weekdays, 3 calendar days) have elapsed
-# since a PR was opened. Runs on a schedule and can be triggered manually.
+# since a PR was opened. Runs hourly on a schedule.
 
 on:
   schedule:
     - cron: '0 * * * *' # hourly
-  workflow_dispatch:
 
 permissions:
   pull-requests: write

--- a/.github/workflows/pr-new-label-expiry.yml
+++ b/.github/workflows/pr-new-label-expiry.yml
@@ -1,0 +1,71 @@
+name: Expire the "new" label on pull requests
+
+# Removes the `new` label once min(2 weekdays, 3 calendar days) have elapsed
+# since a PR was opened. Runs on a schedule and can be triggered manually.
+
+on:
+  schedule:
+    - cron: '0 * * * *' # hourly
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+env:
+  LABEL: new
+
+jobs:
+  expire-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const label = process.env.LABEL;
+            const { owner, repo } = context.repo;
+            const now = new Date();
+
+            const DAY_MS = 24 * 60 * 60 * 1000;
+
+            // created + n weekdays (skipping Sat/Sun), preserving time-of-day.
+            const addWeekdays = (start, n) => {
+              const d = new Date(start);
+              while (n > 0) {
+                d.setUTCDate(d.getUTCDate() + 1);
+                const day = d.getUTCDay();
+                if (day !== 0 && day !== 6) n--;
+              }
+              return d;
+            };
+
+            // All open PRs currently carrying the label (PRs are issues here).
+            const items = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              labels: label,
+              per_page: 100,
+            });
+
+            for (const item of items) {
+              if (!item.pull_request) continue; // skip plain issues
+
+              const created = new Date(item.created_at);
+              const byWeekdays = addWeekdays(created, 2);
+              const byCalendar = new Date(created.getTime() + 3 * DAY_MS);
+              const expiry = byWeekdays < byCalendar ? byWeekdays : byCalendar;
+
+              if (now < expiry) continue;
+
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: item.number,
+                  name: label,
+                });
+                core.info(`Removed "${label}" from #${item.number}`);
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+            }

--- a/.github/workflows/pr-new-label-expiry.yml
+++ b/.github/workflows/pr-new-label-expiry.yml
@@ -17,7 +17,7 @@ jobs:
   expire-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             const label = process.env.LABEL;

--- a/.github/workflows/pr-new-label.yml
+++ b/.github/workflows/pr-new-label.yml
@@ -23,7 +23,7 @@ jobs:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             const label = process.env.LABEL;
@@ -56,7 +56,7 @@ jobs:
       github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             const label = process.env.LABEL;

--- a/.github/workflows/pr-new-label.yml
+++ b/.github/workflows/pr-new-label.yml
@@ -14,7 +14,6 @@ on:
 
 permissions:
   pull-requests: write
-  issues: write
 
 env:
   LABEL: new

--- a/.github/workflows/pr-new-label.yml
+++ b/.github/workflows/pr-new-label.yml
@@ -1,0 +1,75 @@
+name: Label new pull requests
+
+# Adds a `new` label when a PR is opened, and removes it once the PR is approved.
+# The label is also removed on a timer by pr-new-label-expiry.yml.
+
+on:
+  # `pull_request_target` (rather than `pull_request`) so the GITHUB_TOKEN has
+  # write access even for PRs opened from forks. This workflow only calls the
+  # labels API and never checks out or runs PR-supplied code, so it is safe.
+  pull_request_target:
+    types: [opened]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+env:
+  LABEL: new
+
+jobs:
+  add-label:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const label = process.env.LABEL;
+            const { owner, repo } = context.repo;
+
+            // Create the label on first use so the repo does not need manual setup.
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: label });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name: label,
+                color: 'ff6700',
+                description: 'Newly opened, not yet reviewed',
+              });
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: context.payload.pull_request.number,
+              labels: [label],
+            });
+
+  remove-on-approval:
+    if: >-
+      github.event_name == 'pull_request_review' &&
+      github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const label = process.env.LABEL;
+            const { owner, repo } = context.repo;
+            try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: context.payload.pull_request.number,
+                name: label,
+              });
+            } catch (error) {
+              // 404 just means the label was already gone; anything else is real.
+              if (error.status !== 404) throw error;
+            }


### PR DESCRIPTION
As discussed in maintainer chat.

This is an experimental workflow for the team to try and see if it works.

OT1H we're a very small team and each of us has our code areas of focus, so requiring code review & approval for every change could be difficult.

OT2H it's not good to just land code without a chance for review.

So the idea is to add a `new` label for maintainer-submitted PRs. They shouldn't be merged until the label is removed. This happens automatically after any of:

- another maintainer approves the PR
- three calendar days have passed
- two weekdays have passed

