### PR TITLE
fix a couple of new clang-tidy warnings

### DIFF
--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -735,7 +735,7 @@ void tr_torrentSetPeerLimit(tr_torrent* tor, uint16_t max_connected_peers);
 void tr_torrentSetFilePriorities(tr_torrent* torrent, std::span<tr_file_index_t const> files, tr_priority_t priority);
 
 /** @brief Set a batch of files to be downloaded or not. */
-void tr_torrentSetFileDLs(tr_torrent* tor, std::span<tr_file_index_t const>, bool wanted);
+void tr_torrentSetFileDLs(tr_torrent* tor, std::span<tr_file_index_t const> files, bool wanted);
 
 /**
  * Returns a permanently interned string of the torrent's download directory.

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -39,7 +39,7 @@
 #if defined(_WIN32) && !defined(WITH_OPENSSL)
 #error Windows builds require the OpenSSL crypto backend (WITH_CRYPTO=openssl): \
     tracker TLS certs are verified against the Windows system certificate store, \
-    which is injected into OpenSSL's trust store by ssl_context_func() below.
+    which is injected into the OpenSSL trust store by ssl_context_func() below.
 #endif
 
 #if defined(_WIN32) && defined(WITH_OPENSSL)


### PR DESCRIPTION
Fix a couple of new clang-tidy warnings:

```
/tmp/foo/transmission-scratch/libtransmission/web.cc:42:35: warning: missing terminating ' character
   42 |     which is injected into OpenSSL's trust store by ssl_context_func() below.
      |                                   ^
[94/101] Building CXX object libtransmission/CMakeFiles/transmission.dir/webseed.cc.o
[95/101] Building CXX object libtransmission/CMakeFiles/transmission.dir/torrent.cc.o
/tmp/foo/transmission-scratch/libtransmission/../libtransmission/transmission.h:738:76: warning: all parameters should be named in a function [readability-named-parameter]
  738 | void tr_torrentSetFileDLs(tr_torrent* tor, std::span<tr_file_index_t const>, bool wanted);
      |                                                                            ^
      |                                                                             /*files*/
```

Also, it looks there might be a CI issue with clang-tidy-diff.py letting these new regressions get through somehow. I think part 4 (not pushed yet) of the [CI cleanup series](https://github.com/transmissiontorrent/transmission/pull/101) will fix this.