### PR TITLE
perf: simplify tr_arc4

### DIFF
--- a/libtransmission/peer-mse.cc
+++ b/libtransmission/peer-mse.cc
@@ -118,7 +118,7 @@ void Filter::decrypt_init(bool is_incoming, DH const& dh, tr_sha1_digest_t const
     auto const key = is_incoming ? "keyA"sv : "keyB"sv;
     auto const buf = tr_sha1::digest(key, dh.secret(), info_hash);
     dec_active_ = true;
-    dec_key_.init(std::data(buf), std::size(buf));
+    dec_key_.init(buf);
     dec_key_.discard(1024);
 }
 
@@ -127,7 +127,7 @@ void Filter::encrypt_init(bool is_incoming, DH const& dh, tr_sha1_digest_t const
     auto const key = is_incoming ? "keyB"sv : "keyA"sv;
     auto const buf = tr_sha1::digest(key, dh.secret(), info_hash);
     enc_active_ = true;
-    enc_key_.init(std::data(buf), std::size(buf));
+    enc_key_.init(buf);
     enc_key_.discard(1024);
 }
 

--- a/libtransmission/peer-mse.h
+++ b/libtransmission/peer-mse.h
@@ -12,7 +12,7 @@
 #include <algorithm> // for std::copy_n()
 #include <array>
 #include <cstddef> // size_t, std::byte
-#include <cstdint> // uint8_t
+#include <span>
 
 #include "libtransmission/tr-arc4.h"
 #include "libtransmission/types.h" // tr_sha1_digest_t
@@ -110,7 +110,7 @@ private:
         if (buf_in == nullptr || buf_out == nullptr) {
             skip(buf_len, active, arc4);
         } else if (active) {
-            arc4.process(reinterpret_cast<uint8_t const*>(buf_in), buf_len, reinterpret_cast<uint8_t*>(buf_out));
+            arc4.process(std::as_bytes(std::span{ buf_in, buf_len }), std::as_writable_bytes(std::span{ buf_out, buf_len }));
         } else if (buf_in != buf_out) {
             std::copy_n(buf_in, buf_len, buf_out);
         }

--- a/libtransmission/tr-arc4.h
+++ b/libtransmission/tr-arc4.h
@@ -5,8 +5,11 @@
 #pragma once
 
 #include <array>
-#include <cstddef> // size_t
+#include <cstddef> // size_t, std::byte
 #include <cstdint> // uint8_t
+#include <numeric> // std::iota
+#include <span>
+#include <utility> // std::swap
 
 /**
  * This is a tiny and reusable implementation of alleged RC4 cipher.
@@ -26,55 +29,48 @@
 class tr_arc4
 {
 public:
-    constexpr tr_arc4() = default;
-
-    constexpr tr_arc4(void const* key, size_t key_length)
+    constexpr void init(std::span<std::byte const> key)
     {
-        init(key, key_length);
-    }
-
-    constexpr void init(void const* key, size_t key_length)
-    {
-        for (size_t i = 0; i < 256; ++i) {
-            s_[i] = static_cast<uint8_t>(i);
-        }
+        std::iota(std::begin(s_), std::end(s_), uint8_t{ 0 });
 
         for (size_t i = 0, j = 0; i < 256; ++i) {
-            j = static_cast<uint8_t>(j + s_[i] + static_cast<uint8_t const*>(key)[i % key_length]);
-            arc4_swap(i, j);
+            j = static_cast<uint8_t>(j + s_[i] + std::to_integer<uint8_t>(key[i % std::size(key)]));
+            std::swap(s_[i], s_[j]);
         }
     }
 
-    constexpr void process(uint8_t const* const src, size_t n_bytes, uint8_t* const tgt)
+    // tgt must hold at least std::size(src) bytes; src and tgt may be equal
+    constexpr void process(std::span<std::byte const> src, std::span<std::byte> tgt)
     {
-        for (size_t i = 0; i != n_bytes; ++i) {
-            tgt[i] = src[i] ^ arc4_next();
+        auto i = i_;
+        auto j = j_;
+
+        for (size_t k = 0, n = std::size(src); k < n; ++k) {
+            tgt[k] = src[k] ^ std::byte{ next(i, j) };
         }
+
+        i_ = i;
+        j_ = j;
     }
 
     constexpr void discard(size_t length)
     {
         while (length-- > 0) {
-            arc4_next();
+            next(i_, j_);
         }
     }
 
 private:
-    constexpr void arc4_swap(size_t i, size_t j)
+    // state is passed by reference so that process() can keep it
+    // in locals across its hot loop instead of touching members
+    constexpr uint8_t next(uint8_t& i, uint8_t& j)
     {
-        auto const tmp = s_[i];
-        s_[i] = s_[j];
-        s_[j] = tmp;
-    }
+        i += 1;
+        j += s_[i];
 
-    constexpr uint8_t arc4_next()
-    {
-        i_ += 1;
-        j_ += s_[i_];
+        std::swap(s_[i], s_[j]);
 
-        arc4_swap(i_, j_);
-
-        return s_[static_cast<uint8_t>(s_[i_] + s_[j_])];
+        return s_[static_cast<uint8_t>(s_[i] + s_[j])];
     }
 
     std::array<uint8_t, 256> s_ = {};

--- a/libtransmission/tr-arc4.h
+++ b/libtransmission/tr-arc4.h
@@ -42,6 +42,10 @@ public:
     // tgt must hold at least std::size(src) bytes; src and tgt may be equal
     constexpr void process(std::span<std::byte const> src, std::span<std::byte> tgt)
     {
+        // See https://github.com/transmissiontorrent/transmission/pull/109
+        // tldr: the compiler thinks the in-loop assignment call could
+        // overwrite `i_` or `j_`, so it reloads them each time we loop.
+        // Hosting them into locals avoids that work.
         auto i = i_;
         auto j = j_;
 


### PR DESCRIPTION
Minor optimizations to the `tr_arc4` header:

- Use `std::span` instead of pointer-and-length
- Use `std::swap` and `std::itoa` instead of bespoke code
- Remove an unused constructor
- Hoist `i_` and `j_ ` into locals across the loop in `process()`, giving about 5% throughput gain in `-O2` on all encrypted peer traffic. *eta:* more info @ https://github.com/transmissiontorrent/transmission/pull/109#discussion_r3566502647 

Notes: Improved libtransmission code to use less CPU.

AI disclosure: I have reviewed and tested all changes in this PR.