### PR TITLE
docs: sync settings docs with libtransmission defaults

### DIFF
--- a/docs/Editing-Configuration-Files.md
+++ b/docs/Editing-Configuration-Files.md
@@ -60,11 +60,11 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
  * **speed_limit_down_enabled:** Boolean (default = false)
  * **speed_limit_up:** Number (kB/s, default = 100)
  * **speed_limit_up_enabled:** Boolean (default = false)
- * **upload_slots_per_torrent:** Number (default = 14)
+ * **upload_slots_per_torrent:** Number (default = 8)
 
 #### [Blocklists](./Blocklists.md)
 
- * **blocklist_url:** String (default = https://www.example.com/blocklist)
+ * **blocklist_url:** String (default = http://www.example.com/blocklist)
  * **blocklist_enabled:** Boolean (default = false)
 
 #### [Files and Locations](./Configuration-Files.md)
@@ -73,6 +73,8 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
  * **incomplete_dir:** String (default = [default locations](Configuration-Files.md#Locations)) Directory to keep files in until torrent is complete.
  * **incomplete_dir_enabled:** Boolean (default = false) When enabled, new torrents will download the files to `incomplete_dir`. When complete, the files will be moved to `download_dir`.
  * **preallocation:** Number (0 = Off, 1 = Fast, 2 = Full (slower but reduces disk fragmentation), default = 1)
+ * **recent_download_paths:** String[] (default = [`download_dir`]) List of recently-used download directories, most recent first, offered by the GUI clients' destination folder pickers. Transmission keeps up to 6 entries.
+ * **recent_relocate_paths:** String[] (default = [`download_dir`]) Same as `recent_download_paths`, but for the dialogs that move a torrent's local data to a new location.
  * **rename_partial_files:** Boolean (default = true) Postfix partially downloaded files with ".part".
  * **start_added_torrents:** Boolean (default = true) Start torrents as soon as they are added.
  * **trash_can_enabled:** Boolean (default = true) Whether to move the torrents to the system's trashcan or unlink them right away upon deletion from Transmission.
@@ -86,13 +88,13 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
    _Note: transmission-daemon only._
 
 #### Misc
- * **cache_size_mib:** Number (default = 4), in MiB, to allocate for Transmission's memory cache. The cache is used to help batch disk IO together, so increasing the cache size can be used to reduce the number of disk reads and writes. The value is the total available to the Transmission instance. Set it to the smallest value tolerable by the random access performance of your storage medium to minimize data loss in case Transmission quit unexpectedly. Setting this to 0 bypasses the cache, which may be useful if your filesystem already has a cache layer that aggregates transactions. Pieces are guaranteed to be written to filesystem if sequential download is enabled. Otherwise, data might still be in cache only.
+ * **cache_size_mib:** Number (default = 4) **DEPRECATED** and has no effect: Transmission's memory cache has been removed. The key is kept only for backwards compatibility and will be removed in the future.
  * **default_trackers:** String (default = "") A list of double-newline separated tracker announce URLs. These are used for all torrents in addition to the per torrent trackers specified in the torrent file. If a tracker is only meant to be a backup, it should be separated from its main tracker by a single newline character. If a tracker should be used additionally to another tracker it should be separated by two newlines. (e.g. "udp://tracker.example.invalid:1337/announce\n\nudp://tracker.another-example.invalid:6969/announce\nhttps://backup-tracker.another-example.invalid:443/announce\n\nudp://tracker.yet-another-example.invalid:1337/announce", in this case tracker.example.invalid, tracker.another-example.invalid and tracker.yet-another-example.invalid would be used as trackers and backup-tracker.another-example.invalid as backup in case tracker.another-example.invalid is unreachable.
  * **dht_enabled:** Boolean (default = true) Enable [Distributed Hash Table (DHT)](https://wiki.theory.org/BitTorrentSpecification#Distributed_Hash_Table).
  * **encryption:** String ("allowed" = Prefer unencrypted connections, "preferred" = Prefer encrypted connections, "required" = Require encrypted connections; default = "preferred") [Encryption](https://wiki.vuze.com/w/Message_Stream_Encryption) preference. Encryption may help get around some ISP filtering, but at the cost of slightly higher CPU use.
- * **ip_endpoints_ipv4** String[] (default = ["https://ipv4.transmissiontorrent.com/"]) A list of IP query endpoints to be tried in order, and the first valid result will be cached as the client's global IPv4 address. Specifying an empty array disables IP query for IPv4, but Transmission might not be able to announce your IPv4 address via legacy BEP-7 `&ipv4=` query parameter.
- * **ip_endpoints_ipv6** String[] (default = ["https://ipv6.transmissiontorrent.com/"]) Same as `ip_endpoints_ipv4`, but for IPv6.
- * **lpd_enabled:** Boolean (default = false) Enable [Local Peer Discovery (LPD)](https://en.wikipedia.org/wiki/Local_Peer_Discovery).
+ * **ip_endpoints_ipv4** String[] (default = ["https://ipv4.transmissiontorrent.com"]) A list of IP query endpoints to be tried in order, and the first valid result will be cached as the client's global IPv4 address. Specifying an empty array disables IP query for IPv4, but Transmission might not be able to announce your IPv4 address via legacy BEP-7 `&ipv4=` query parameter.
+ * **ip_endpoints_ipv6** String[] (default = ["https://ipv6.transmissiontorrent.com"]) Same as `ip_endpoints_ipv4`, but for IPv6.
+ * **lpd_enabled:** Boolean (default = true) Enable [Local Peer Discovery (LPD)](https://en.wikipedia.org/wiki/Local_Peer_Discovery).
  * **message_level:** Number (0 = None, 1 = Critical, 2 = Error, 3 = Warn, 4 = Info, 5 = Debug, 6 = Trace; default = 4) Set verbosity of Transmission's log messages.
  * **pex_enabled:** Boolean (default = true) Enable [Peer Exchange (PEX)](https://en.wikipedia.org/wiki/Peer_exchange).
  * **pidfile:** String Path to file in which daemon PID will be stored (_transmission-daemon only_)
@@ -119,14 +121,14 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
  * **peer_congestion_algorithm:** String. This is documented on https://www.pps.jussieu.fr/~jch/software/bittorrent/tcp-congestion-control.html.
  * **peer_limit_global:** Number (default = 200)
  * **peer_limit_per_torrent:** Number (default = 50)
- * **peer_socket_diffserv:** String (default = "le") Set the [DiffServ](https://en.wikipedia.org/wiki/Differentiated_services) parameter for outgoing packets. Allowed values are lowercase DSCP names. See the `tr_diffserv_t` class from `libtransmission/types.h` for the exact list of possible values.
+ * **peer_socket_diffserv:** String (default = "le") Set the [DiffServ](https://en.wikipedia.org/wiki/Differentiated_services) parameter for outgoing packets. Allowed values are lowercase DSCP names. See `DiffServKeys` in `libtransmission/converters.cc` for the exact list of possible values.
  * **reqq:** Number (default = 2000) The number of outstanding block requests a peer is allowed to queue in the client. The higher this number, the higher the max possible upload speed towards each peer.
  * **sequential_download** Boolean (default = false) Enable sequential download by default when adding torrents.
 
 #### Peer Port
  * **peer_port:** Number (default = 51413)
  * **peer_port_random_high:** Number (default = 65535)
- * **peer_port_random_low:** Number (default = 1024)
+ * **peer_port_random_low:** Number (default = 49152)
  * **peer_port_random_on_start:** Boolean (default = false)
  * **port_forwarding_enabled:** Boolean (default = true) Enable [UPnP](https://en.wikipedia.org/wiki/Universal_Plug_and_Play) or [NAT-PMP](https://en.wikipedia.org/wiki/NAT_Port_Mapping_Protocol).
 
@@ -151,7 +153,7 @@ Here is a sample of the three basic types: respectively Boolean, Number and Stri
  * **rpc_socket_mode:** String UNIX filesystem mode for the RPC UNIX socket (default: 0750; used when `rpc_bind_address` is a UNIX socket)
  * **rpc_url:** String (default = /transmission/. Added in v2.2)
  * **rpc_username:** String
- * **rpc_whitelist:** String (Comma-delimited list of IP addresses. Wildcards allowed using '\*'. Example: "127.0.0.\*,192.168.\*.\*", Default:  "127.0.0.1")
+ * **rpc_whitelist:** String (Comma-delimited list of IP addresses. Wildcards allowed using '\*'. Example: "127.0.0.\*,192.168.\*.\*", Default:  "127.0.0.1,::1")
  * **rpc_whitelist_enabled:** Boolean (default = true)
 
 #### Scheduling


### PR DESCRIPTION
Update `Editing-Configuration-Files.md` where it had drifted from production values over the years.

- `blocklist_url` default is http://, not https://
- `cache_size_mib` is now a deprecated no-op (the write cache is gone), so stop describing cache-tuning behavior
- `ip_endpoints_ipv4` and `ip_endpoints_ipv6` defaults have no trailing slash
- `lpd_enabled` defaults to true, not false
- `peer_port_random_low` defaults to 49152, not 1024
- `peer_socket_diffserv`: the DSCP name list lives in DiffServKeys in converters.cc, not in types.h
- `recent_download_paths` and `recent_relocate_paths` were missing
- `rpc_whitelist` defaults to "127.0.0.1,::1", not "127.0.0.1"
- `upload_slots_per_torrent` defaults to 8, not 14
