### PR TITLE
fix: serialize `tr_preferred_transport` to string keys

### DIFF
--- a/libtransmission/converters.cc
+++ b/libtransmission/converters.cc
@@ -385,7 +385,7 @@ bool to_preferred_transport(tr_variant const& src, small::max_size_vector<tr_pre
 tr_variant from_preferred_transport(small::max_size_vector<tr_preferred_transport, PreferredTransportCount> const& val)
 {
     static auto constexpr SaveSingle = [](tr_preferred_transport const ele) -> tr_variant {
-        return static_cast<int64_t>(ele);
+        return from_enum_or_integral_with_lookup(PreferredTransportKeys, ele);
     };
 
     auto ret = tr_variant::Vector{};

--- a/tests/libtransmission/settings-test.cc
+++ b/tests/libtransmission/settings-test.cc
@@ -506,10 +506,7 @@ TEST_F(SettingsTest, canLoadPreferredTransport)
 TEST_F(SettingsTest, canSavePreferredTransport)
 {
     static auto constexpr Key = TR_KEY_preferred_transports;
-    static auto constexpr ExpectedValue = std::array<int64_t, PreferredTransportCount>{
-        static_cast<int64_t>(tr_preferred_transport::TCP),
-        static_cast<int64_t>(tr_preferred_transport::UTP),
-    };
+    static auto constexpr ExpectedValue = std::array<std::string_view, PreferredTransportCount>{ "tcp"sv, "utp"sv };
     auto const setting_value = small::max_size_vector<tr_preferred_transport, PreferredTransportCount>{
         tr_preferred_transport::TCP,
         tr_preferred_transport::UTP,
@@ -527,8 +524,7 @@ TEST_F(SettingsTest, canSavePreferredTransport)
     for (size_t i = 0, n = std::size(*l); i < n; ++i) {
         auto const expected = ExpectedValue[i];
         auto const& actual = (*l)[i];
-        ASSERT_TRUE(actual.holds_alternative<int64_t>());
-        EXPECT_EQ(expected, actual.value_if<int64_t>());
+        EXPECT_EQ(expected, actual.value_if<std::string_view>());
     }
 }
 


### PR DESCRIPTION
Cherry-pick upstream PR 8880.