### PR TITLE
refactor: convert `tr_pex` methods to use `std::span`

### DIFF
--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -360,7 +360,7 @@ void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::
             } else if (pathIs("tracker id"sv)) {
                 response_.tracker_id = value;
             } else if (pathIs("peers"sv)) {
-                response_.pex = tr_pex::from_compact_ipv4(std::data(value), std::size(value), nullptr, 0);
+                response_.pex = tr_pex::from_compact_ipv4(value, {});
             } else if (pathIs("peers6"sv)) {
                 response_.pex6 = tr_pex::from_compact_ipv6(std::data(value), std::size(value), nullptr, 0);
             } else if (pathIs("peers"sv, ArrayKey, "ip"sv)) {

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -362,7 +362,7 @@ void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::
             } else if (pathIs("peers"sv)) {
                 response_.pex = tr_pex::from_compact_ipv4(value, {});
             } else if (pathIs("peers6"sv)) {
-                response_.pex6 = tr_pex::from_compact_ipv6(std::data(value), std::size(value), nullptr, 0);
+                response_.pex6 = tr_pex::from_compact_ipv6(value, {});
             } else if (pathIs("peers"sv, ArrayKey, "ip"sv)) {
                 if (auto const addr = tr_address::from_string(value); addr) {
                     pex_.socket_address.address_ = *addr;

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -280,7 +280,7 @@ struct tau_announce_request {
                 response.pex = tr_pex::from_compact_ipv4(buf, {});
                 break;
             case TR_AF_INET6:
-                response.pex6 = tr_pex::from_compact_ipv6(std::data(buf), std::size(buf), nullptr, 0);
+                response.pex6 = tr_pex::from_compact_ipv6(buf, {});
                 break;
             default:
                 break;

--- a/libtransmission/announcer-udp.cc
+++ b/libtransmission/announcer-udp.cc
@@ -277,7 +277,7 @@ struct tau_announce_request {
 
             switch (ip_protocol_resp) {
             case TR_AF_INET:
-                response.pex = tr_pex::from_compact_ipv4(std::data(buf), std::size(buf), nullptr, 0);
+                response.pex = tr_pex::from_compact_ipv4(buf, {});
                 break;
             case TR_AF_INET6:
                 response.pex6 = tr_pex::from_compact_ipv6(std::data(buf), std::size(buf), nullptr, 0);

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1329,21 +1329,16 @@ std::vector<tr_pex> tr_pex::from_compact_ipv4(std::span<std::byte const> const c
     return pex;
 }
 
-// TODO(C++20): convert to std::span
-std::vector<tr_pex> tr_pex::from_compact_ipv6(
-    void const* compact,
-    size_t compact_len,
-    uint8_t const* added_f,
-    size_t added_f_len)
+std::vector<tr_pex> tr_pex::from_compact_ipv6(std::span<std::byte const> const compact, std::span<uint8_t const> const added_f)
 {
-    size_t const n = compact_len / tr_socket_address::CompactSockAddrBytes[TR_AF_INET6];
-    auto const* walk = static_cast<std::byte const*>(compact);
+    size_t const n = compact.size() / tr_socket_address::CompactSockAddrBytes[TR_AF_INET6];
+    auto const* walk = compact.data();
     auto pex = std::vector<tr_pex>(n);
 
     for (size_t i = 0; i < n; ++i) {
         std::tie(pex[i].socket_address, walk) = tr_socket_address::from_compact_ipv6(walk);
 
-        if (added_f != nullptr && n == added_f_len) {
+        if (n == added_f.size()) {
             pex[i].flags = added_f[i];
         }
     }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1312,21 +1312,16 @@ size_t tr_peerMgrAddPex(tr_torrent* tor, tr_peer_from from, tr_pex const* pex, s
     return n_used;
 }
 
-// TODO(C++20): convert to std::span
-std::vector<tr_pex> tr_pex::from_compact_ipv4(
-    void const* compact,
-    size_t compact_len,
-    uint8_t const* added_f,
-    size_t added_f_len)
+std::vector<tr_pex> tr_pex::from_compact_ipv4(std::span<std::byte const> const compact, std::span<uint8_t const> const added_f)
 {
-    size_t const n = compact_len / tr_socket_address::CompactSockAddrBytes[TR_AF_INET];
-    auto const* walk = static_cast<std::byte const*>(compact);
+    size_t const n = compact.size() / tr_socket_address::CompactSockAddrBytes[TR_AF_INET];
+    auto const* walk = compact.data();
     auto pex = std::vector<tr_pex>(n);
 
     for (size_t i = 0; i < n; ++i) {
         std::tie(pex[i].socket_address, walk) = tr_socket_address::from_compact_ipv4(walk);
 
-        if (added_f != nullptr && n == added_f_len) {
+        if (n == added_f.size()) {
             pex[i].flags = added_f[i];
         }
     }

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -553,7 +553,7 @@ struct tr_pex {
     tr_pex() = default;
 
     explicit tr_pex(tr_socket_address socket_address_in, uint8_t flags_in = {})
-        : socket_address{ socket_address_in }
+        : socket_address{ std::move(socket_address_in) }
         , flags{ flags_in }
     {
     }
@@ -591,10 +591,21 @@ struct tr_pex {
     }
 
     [[nodiscard]] static std::vector<tr_pex> from_compact_ipv6(
-        void const* compact,
-        size_t compact_len,
-        uint8_t const* added_f,
-        size_t added_f_len);
+        std::span<std::byte const> compact,
+        std::span<uint8_t const> added_f);
+
+    template<typename Compact, typename AddedF = std::span<uint8_t const>>
+        requires(!requires(Compact const& compact, AddedF const& added_f) {
+            std::span<std::byte const>{ compact };
+            std::span<uint8_t const>{ added_f };
+        })
+    [[nodiscard]] static std::vector<tr_pex> from_compact_ipv6(Compact const& compact, AddedF const& added_f)
+    {
+        auto const added_f_span = std::span{ added_f };
+        return from_compact_ipv6(
+            std::as_bytes(std::span<typename Compact::value_type const>{ compact }),
+            std::span{ reinterpret_cast<uint8_t const*>(added_f_span.data()), added_f_span.size_bytes() });
+    }
 
     [[nodiscard]] std::string display_name() const
     {

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -574,10 +574,21 @@ struct tr_pex {
     }
 
     [[nodiscard]] static std::vector<tr_pex> from_compact_ipv4(
-        void const* compact,
-        size_t compact_len,
-        uint8_t const* added_f,
-        size_t added_f_len);
+        std::span<std::byte const> compact,
+        std::span<uint8_t const> added_f);
+
+    template<typename Compact, typename AddedF = std::span<uint8_t const>>
+        requires(!requires(Compact const& compact, AddedF const& added_f) {
+            std::span<std::byte const>{ compact };
+            std::span<uint8_t const>{ added_f };
+        })
+    [[nodiscard]] static std::vector<tr_pex> from_compact_ipv4(Compact const& compact, AddedF const& added_f)
+    {
+        auto const added_f_span = std::span{ added_f };
+        return from_compact_ipv4(
+            std::as_bytes(std::span<typename Compact::value_type const>{ compact }),
+            std::span{ reinterpret_cast<uint8_t const*>(added_f_span.data()), added_f_span.size_bytes() });
+    }
 
     [[nodiscard]] static std::vector<tr_pex> from_compact_ipv6(
         void const* compact,

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -14,6 +14,7 @@
 #include <ctime>
 #include <limits>
 #include <optional>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -564,10 +565,10 @@ struct tr_pex {
     }
 
     template<typename OutputIt>
-    static OutputIt to_compact(OutputIt out, tr_pex const* pex, size_t n_pex)
+    static OutputIt to_compact(OutputIt out, std::span<tr_pex const> const pex)
     {
-        for (size_t i = 0; i < n_pex; ++i) {
-            out = pex[i].to_compact(out);
+        for (auto const& p : pex) {
+            out = p.to_compact(out);
         }
         return out;
     }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -962,11 +962,8 @@ void tr_peerMsgsImpl::parse_ut_pex(MessageReader& payload)
     }
 
     if (auto const added = map->value_if<std::string_view>(TR_KEY_added6)) {
-        auto const added_f_sv = map->value_if<std::string_view>(TR_KEY_added6_f);
-        auto const* const added_f = added_f_sv ? reinterpret_cast<uint8_t const*>(std::data(*added_f_sv)) : nullptr;
-        auto const added_f_len = added_f_sv ? std::size(*added_f_sv) : 0U;
-
-        auto pex = tr_pex::from_compact_ipv6(std::data(*added), std::size(*added), added_f, added_f_len);
+        auto const added_f = map->value_if<std::string_view>(TR_KEY_added6_f);
+        auto pex = tr_pex::from_compact_ipv6(*added, added_f.value_or(""sv));
         pex.resize(std::min(MaxPexPeerCount, std::size(pex)));
         tr_peerMgrAddPex(&tor_, TR_PEER_FROM_PEX, std::data(pex), std::size(pex));
     }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1030,7 +1030,7 @@ void tr_peerMsgsImpl::send_ut_pex()
             // "added"
             tmpbuf.clear();
             tmpbuf.reserve(std::size(added) * tr_socket_address::CompactSockAddrBytes[i]);
-            tr_pex::to_compact(std::back_inserter(tmpbuf), std::data(added), std::size(added));
+            tr_pex::to_compact(std::back_inserter(tmpbuf), added);
             TR_ASSERT(std::size(tmpbuf) == std::size(added) * tr_socket_address::CompactSockAddrBytes[i]);
             map.try_emplace(AddedMap[i], std::string_view{ reinterpret_cast<char*>(std::data(tmpbuf)), std::size(tmpbuf) });
 
@@ -1051,7 +1051,7 @@ void tr_peerMsgsImpl::send_ut_pex()
             // "dropped"
             tmpbuf.clear();
             tmpbuf.reserve(std::size(dropped) * tr_socket_address::CompactSockAddrBytes[i]);
-            tr_pex::to_compact(std::back_inserter(tmpbuf), std::data(dropped), std::size(dropped));
+            tr_pex::to_compact(std::back_inserter(tmpbuf), dropped);
             TR_ASSERT(std::size(tmpbuf) == std::size(dropped) * tr_socket_address::CompactSockAddrBytes[i]);
             map.try_emplace(DroppedMap[i], std::string_view{ reinterpret_cast<char*>(std::data(tmpbuf)), std::size(tmpbuf) });
         }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -955,11 +955,8 @@ void tr_peerMsgsImpl::parse_ut_pex(MessageReader& payload)
     logtrace(this, "got ut pex");
 
     if (auto const added = map->value_if<std::string_view>(TR_KEY_added)) {
-        auto const added_f_sv = map->value_if<std::string_view>(TR_KEY_added_f);
-        auto const* const added_f = added_f_sv ? reinterpret_cast<uint8_t const*>(std::data(*added_f_sv)) : nullptr;
-        auto const added_f_len = added_f_sv ? std::size(*added_f_sv) : 0U;
-
-        auto pex = tr_pex::from_compact_ipv4(std::data(*added), std::size(*added), added_f, added_f_len);
+        auto const added_f = map->value_if<std::string_view>(TR_KEY_added_f);
+        auto pex = tr_pex::from_compact_ipv4(*added, added_f.value_or(""sv));
         pex.resize(std::min(MaxPexPeerCount, std::size(pex)));
         tr_peerMgrAddPex(&tor_, TR_PEER_FROM_PEX, std::data(pex), std::size(pex));
     }

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -382,7 +382,8 @@ private:
                 tr_pex::from_compact_ipv4(std::span{ static_cast<std::byte const*>(data), data_len }, {}));
             self->mediator_.add_pex(hash, std::data(pex), std::size(pex));
         } else if (event == DHT_EVENT_VALUES6) {
-            auto const pex = remove_bad_pex(tr_pex::from_compact_ipv6(data, data_len, nullptr, 0));
+            auto const pex = remove_bad_pex(
+                tr_pex::from_compact_ipv6(std::span{ static_cast<std::byte const*>(data), data_len }, {}));
             self->mediator_.add_pex(hash, std::data(pex), std::size(pex));
         }
     }

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -378,7 +378,8 @@ private:
         std::copy_n(reinterpret_cast<std::byte const*>(info_hash), std::size(hash), std::data(hash));
 
         if (event == DHT_EVENT_VALUES) {
-            auto const pex = remove_bad_pex(tr_pex::from_compact_ipv4(data, data_len, nullptr, 0));
+            auto const pex = remove_bad_pex(
+                tr_pex::from_compact_ipv4(std::span{ static_cast<std::byte const*>(data), data_len }, {}));
             self->mediator_.add_pex(hash, std::data(pex), std::size(pex));
         } else if (event == DHT_EVENT_VALUES6) {
             auto const pex = remove_bad_pex(tr_pex::from_compact_ipv6(data, data_len, nullptr, 0));

--- a/tests/libtransmission/net-test.cc
+++ b/tests/libtransmission/net-test.cc
@@ -101,7 +101,7 @@ TEST_F(NetTest, compact4)
     /// compact <--> tr_pex
 
     // extract them into a tr_pex struct...
-    auto const pex = tr_pex::from_compact_ipv4(std::data(buf), out - std::data(buf), nullptr, 0U);
+    auto const pex = tr_pex::from_compact_ipv4(std::span{ buf }.first(out - std::data(buf)), {});
     ASSERT_EQ(1U, std::size(pex));
     EXPECT_EQ(addr, pex.front().socket_address.address());
     EXPECT_EQ(port, pex.front().socket_address.port());
@@ -112,6 +112,39 @@ TEST_F(NetTest, compact4)
     out = tr_pex::to_compact(out, pex);
     EXPECT_EQ(std::size(Compact4), static_cast<size_t>(out - std::data(buf)));
     EXPECT_TRUE(std::equal(std::begin(Compact4), std::end(Compact4), std::data(buf)));
+}
+
+TEST_F(NetTest, compact4TemplatedOverload)
+{
+    static auto constexpr ExpectedReadable = std::to_array<std::string_view>({ "10.10.10.5"sv, "127.0.0.1"sv });
+    static auto constexpr ExpectedPort = std::to_array({ tr_port::from_host(128), tr_port::from_host(6881) });
+    static auto constexpr Compact4 = std::to_array<uint8_t>({
+        0x0A,
+        0x0A,
+        0x0A,
+        0x05,
+        0x00,
+        0x80,
+        0x7F,
+        0x00,
+        0x00,
+        0x01,
+        0x1A,
+        0xE1,
+    });
+    static auto constexpr AddedF = std::to_array<uint8_t>({ 0x01, 0x80 });
+
+    auto const compact4 = std::string_view{ reinterpret_cast<char const*>(std::data(Compact4)), std::size(Compact4) };
+    auto const added_f = std::string_view{ reinterpret_cast<char const*>(std::data(AddedF)), std::size(AddedF) };
+    auto const pex = tr_pex::from_compact_ipv4(compact4, added_f);
+
+    ASSERT_EQ(std::size(ExpectedReadable), std::size(pex));
+
+    for (size_t i = 0; i < std::size(pex); ++i) {
+        EXPECT_EQ(ExpectedReadable[i], pex[i].socket_address.address().display_name());
+        EXPECT_EQ(ExpectedPort[i], pex[i].socket_address.port());
+        EXPECT_EQ(AddedF[i], pex[i].flags);
+    }
 }
 
 TEST_F(NetTest, compact6)

--- a/tests/libtransmission/net-test.cc
+++ b/tests/libtransmission/net-test.cc
@@ -109,7 +109,7 @@ TEST_F(NetTest, compact4)
     // ...serialize that back again too
     buf.fill(std::byte{});
     out = std::data(buf);
-    out = tr_pex::to_compact(out, std::data(pex), std::size(pex));
+    out = tr_pex::to_compact(out, pex);
     EXPECT_EQ(std::size(Compact4), static_cast<size_t>(out - std::data(buf)));
     EXPECT_TRUE(std::equal(std::begin(Compact4), std::end(Compact4), std::data(buf)));
 }
@@ -177,7 +177,7 @@ TEST_F(NetTest, compact6)
     // ...serialize that back again too
     std::ranges::fill(compact6, std::byte{});
     out = std::data(compact6);
-    out = tr_pex::to_compact(out, std::data(pex), std::size(pex));
+    out = tr_pex::to_compact(out, pex);
     EXPECT_EQ(std::data(compact6) + std::size(compact6), out);
     EXPECT_EQ(Compact6, compact6);
 }

--- a/tests/libtransmission/net-test.cc
+++ b/tests/libtransmission/net-test.cc
@@ -202,7 +202,7 @@ TEST_F(NetTest, compact6)
     /// compact <--> tr_pex
 
     // extract them into a tr_pex struct...
-    auto const pex = tr_pex::from_compact_ipv6(std::data(compact6), std::size(compact6), nullptr, 0U);
+    auto const pex = tr_pex::from_compact_ipv6(compact6, {});
     ASSERT_EQ(1U, std::size(pex));
     EXPECT_EQ(addr, pex.front().socket_address.address());
     EXPECT_EQ(port, pex.front().socket_address.port());
@@ -213,6 +213,32 @@ TEST_F(NetTest, compact6)
     out = tr_pex::to_compact(out, pex);
     EXPECT_EQ(std::data(compact6) + std::size(compact6), out);
     EXPECT_EQ(Compact6, compact6);
+}
+
+TEST_F(NetTest, compact6TemplatedOverload)
+{
+    static auto constexpr ExpectedReadable = std::to_array<std::string_view>({
+        "1002:1035:4527:3546:7854:1237:3247:3217"sv,
+        "2001:db8:1234:5678:9abc:def0:1111:2222"sv,
+    });
+    static auto constexpr ExpectedPort = std::to_array({ tr_port::from_host(6881), tr_port::from_host(128) });
+    static auto constexpr Compact6 = std::to_array<uint8_t>({
+        0x10, 0x02, 0x10, 0x35, 0x45, 0x27, 0x35, 0x46, 0x78, 0x54, 0x12, 0x37, 0x32, 0x47, 0x32, 0x17, 0x1A, 0xE1,
+        0x20, 0x01, 0x0D, 0xB8, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x11, 0x11, 0x22, 0x22, 0x00, 0x80,
+    });
+    static auto constexpr AddedF = std::to_array<uint8_t>({ 0xA5, 0x5A });
+
+    auto const compact6 = std::string_view{ reinterpret_cast<char const*>(std::data(Compact6)), std::size(Compact6) };
+    auto const added_f = std::string_view{ reinterpret_cast<char const*>(std::data(AddedF)), std::size(AddedF) };
+    auto const pex = tr_pex::from_compact_ipv6(compact6, added_f);
+
+    ASSERT_EQ(std::size(ExpectedReadable), std::size(pex));
+
+    for (size_t i = 0; i < std::size(pex); ++i) {
+        EXPECT_EQ(ExpectedReadable[i], pex[i].socket_address.address().display_name());
+        EXPECT_EQ(ExpectedPort[i], pex[i].socket_address.port());
+        EXPECT_EQ(AddedF[i], pex[i].flags);
+    }
 }
 
 TEST_F(NetTest, isGlobalUnicastAddress)


### PR DESCRIPTION
Notes: Moved from C++17 to C++20.

P.S. I'm noticing that migrating to `std::span` generally needs more function overloads if we want to keep the call sites succinct, and I'm a bit torn about this. OT1H this complicates our classes. But OTOH, this seems to be the general direction C++ is headed, because this is also what the STL does in newer C++ versions.