### PR TITLE
refactor: convert peer mgr API to take `std::span` parameters

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1293,18 +1293,17 @@ void tr_peerMgrAddIncoming(tr_peerMgr* manager, std::shared_ptr<tr_peer_socket> 
     }
 }
 
-// TODO(C++20): convert to std::span
-size_t tr_peerMgrAddPex(tr_torrent* tor, tr_peer_from from, tr_pex const* pex, size_t n_pex)
+size_t tr_peerMgrAddPex(tr_torrent* tor, tr_peer_from from, std::span<tr_pex const> const pex)
 {
     size_t n_used = 0;
     tr_swarm* s = tor->swarm;
     auto const lock = s->manager->unique_lock();
 
-    for (tr_pex const* const end = pex + n_pex; pex != end; ++pex) {
-        if (tr_isPex(pex) && /* safeguard against corrupt data */
-            !s->manager->blocklists_.contains(pex->socket_address.address()) && pex->is_valid_for_peers(from) &&
+    for (auto const& p : pex) {
+        if (p.is_valid() && // safeguard against corrupt data
+            !s->manager->blocklists_.contains(p.socket_address.address()) && p.is_valid_for_peers(from) &&
             from != TR_PEER_FROM_INCOMING) {
-            s->ensure_info_exists(pex->socket_address, pex->flags, from);
+            s->ensure_info_exists(p.socket_address, p.flags, from);
             ++n_used;
         }
     }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1484,16 +1484,15 @@ int8_t tr_peerMgrPieceAvailability(tr_torrent const* tor, tr_piece_index_t piece
     return static_cast<int8_t>(std::ranges::count_if(peers, [piece](auto const& peer) { return peer->has_piece(piece); }));
 }
 
-void tr_peerMgrTorrentAvailability(tr_torrent const* tor, int8_t* tab, unsigned int n_tabs)
+void tr_peerMgrTorrentAvailability(tr_torrent const* tor, std::span<int8_t> const tab)
 {
     TR_ASSERT(tr_isTorrent(tor));
-    TR_ASSERT(tab != nullptr);
-    TR_ASSERT(n_tabs > 0);
+    TR_ASSERT(!tab.empty());
 
-    std::fill_n(tab, n_tabs, int8_t{});
+    std::ranges::fill(tab, int8_t{});
 
-    auto const interval = static_cast<double>(tor->piece_count()) / static_cast<double>(n_tabs);
-    for (unsigned int i = 0; i < n_tabs; ++i) {
+    auto const interval = static_cast<double>(tor->piece_count()) / static_cast<double>(tab.size());
+    for (size_t i = 0; i < tab.size(); ++i) {
         auto const piece = static_cast<tr_piece_index_t>(static_cast<double>(i) * interval);
         tab[i] = tr_peerMgrPieceAvailability(tor, piece);
     }

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -614,11 +614,6 @@ struct tr_pex {
     uint8_t flags = 0;
 };
 
-constexpr bool tr_isPex(tr_pex const* pex)
-{
-    return pex != nullptr && pex->socket_address.is_valid();
-}
-
 [[nodiscard]] tr_peerMgr* tr_peerMgrNew(tr_session* session);
 
 void tr_peerMgrFree(tr_peerMgr* manager);
@@ -627,7 +622,7 @@ void tr_peerMgrFree(tr_peerMgr* manager);
 
 void tr_peerMgrAddIncoming(tr_peerMgr* manager, std::shared_ptr<tr_peer_socket> socket);
 
-size_t tr_peerMgrAddPex(tr_torrent* tor, tr_peer_from from, tr_pex const* pex, size_t n_pex);
+size_t tr_peerMgrAddPex(tr_torrent* tor, tr_peer_from from, std::span<tr_pex const> pex);
 
 enum : uint8_t { TR_PEERS_CONNECTED, TR_PEERS_INTERESTING };
 

--- a/libtransmission/peer-mgr.h
+++ b/libtransmission/peer-mgr.h
@@ -637,7 +637,7 @@ void tr_peerMgrAddTorrent(tr_peerMgr* manager, struct tr_torrent* tor);
 // return the number of connected peers that have `piece`, or -1 if we already have it
 [[nodiscard]] int8_t tr_peerMgrPieceAvailability(tr_torrent const* tor, tr_piece_index_t piece);
 
-void tr_peerMgrTorrentAvailability(tr_torrent const* tor, int8_t* tab, unsigned int n_tabs);
+void tr_peerMgrTorrentAvailability(tr_torrent const* tor, std::span<int8_t> tab);
 
 [[nodiscard]] uint64_t tr_peerMgrGetDesiredAvailable(tr_torrent const* tor);
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -961,7 +961,7 @@ void tr_peerMsgsImpl::parse_ut_pex(MessageReader& payload)
 
         auto pex = tr_pex::from_compact_ipv4(std::data(*added), std::size(*added), added_f, added_f_len);
         pex.resize(std::min(MaxPexPeerCount, std::size(pex)));
-        tr_peerMgrAddPex(&tor_, TR_PEER_FROM_PEX, std::data(pex), std::size(pex));
+        tr_peerMgrAddPex(&tor_, TR_PEER_FROM_PEX, pex);
     }
 
     if (auto const added = map->value_if<std::string_view>(TR_KEY_added6)) {
@@ -971,7 +971,7 @@ void tr_peerMsgsImpl::parse_ut_pex(MessageReader& payload)
 
         auto pex = tr_pex::from_compact_ipv6(std::data(*added), std::size(*added), added_f, added_f_len);
         pex.resize(std::min(MaxPexPeerCount, std::size(pex)));
-        tr_peerMgrAddPex(&tor_, TR_PEER_FROM_PEX, std::data(pex), std::size(pex));
+        tr_peerMgrAddPex(&tor_, TR_PEER_FROM_PEX, pex);
     }
 }
 
@@ -1269,7 +1269,7 @@ void tr_peerMsgsImpl::parse_ltep_handshake(MessageReader& payload)
             auto pex = tr_pex{ peer_info->listen_socket_address(), peer_info->pex_flags() };
             auto const* const bytes = reinterpret_cast<std::byte const*>(std::data(*addr_compact));
             pex.socket_address.address_ = tr_address::from_compact_ipv4(bytes).first;
-            tr_peerMgrAddPex(&tor_, TR_PEER_FROM_LTEP, &pex, 1);
+            tr_peerMgrAddPex(&tor_, TR_PEER_FROM_LTEP, { &pex, 1 });
         }
 
         if (auto const addr_compact = map->value_if<std::string_view>(TR_KEY_ipv6);
@@ -1277,7 +1277,7 @@ void tr_peerMsgsImpl::parse_ltep_handshake(MessageReader& payload)
             auto pex = tr_pex{ peer_info->listen_socket_address(), peer_info->pex_flags() };
             auto const* const bytes = reinterpret_cast<std::byte const*>(std::data(*addr_compact));
             pex.socket_address.address_ = tr_address::from_compact_ipv6(bytes).first;
-            tr_peerMgrAddPex(&tor_, TR_PEER_FROM_LTEP, &pex, 1);
+            tr_peerMgrAddPex(&tor_, TR_PEER_FROM_LTEP, { &pex, 1 });
         }
     }
 

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -67,7 +67,7 @@ size_t add_peers(tr_torrent* tor, tr_variant::Vector const& l)
             pex.emplace_back(std::move(*p));
         }
     }
-    return tr_peerMgrAddPex(tor, TR_PEER_FROM_RESUME, std::data(pex), std::size(pex));
+    return tr_peerMgrAddPex(tor, TR_PEER_FROM_RESUME, pex);
 }
 
 auto load_peers(tr_variant::Map const& map, tr_torrent* tor)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -213,10 +213,10 @@ tr_sha1_digest_t tr_session::DhtMediator::torrent_info_hash(tr_torrent_id_t id) 
     return {};
 }
 
-void tr_session::DhtMediator::add_pex(tr_sha1_digest_t const& info_hash, tr_pex const* pex, size_t n_pex)
+void tr_session::DhtMediator::add_pex(tr_sha1_digest_t const& info_hash, std::span<tr_pex const> const pex)
 {
     if (auto* const tor = session_.torrents().get(info_hash); tor != nullptr) {
-        tr_peerMgrAddPex(tor, TR_PEER_FROM_DHT, pex, n_pex);
+        tr_peerMgrAddPex(tor, TR_PEER_FROM_DHT, pex);
     }
 }
 
@@ -245,7 +245,7 @@ bool tr_session::LpdMediator::onPeerFound(std::string_view info_hash_str, tr_add
     // we found a suitable peer, add it to the torrent
     auto const socket_address = tr_socket_address{ address, port };
     auto const pex = tr_pex{ socket_address };
-    tr_peerMgrAddPex(tor, TR_PEER_FROM_LPD, &pex, 1U);
+    tr_peerMgrAddPex(tor, TR_PEER_FROM_LPD, { &pex, 1U });
     tr_logAddDebugTor(tor, fmt::format("Found a local peer from LPD ({:s})", socket_address.display_name()));
     return true;
 }

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -181,7 +181,7 @@ private:
             return session_.timerMaker();
         }
 
-        void add_pex(tr_sha1_digest_t const& info_hash, tr_pex const* pex, size_t n_pex) override;
+        void add_pex(tr_sha1_digest_t const& info_hash, std::span<tr_pex const> pex) override;
 
     private:
         tr_session& session_;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1932,7 +1932,7 @@ void tr_torrent::on_tracker_response(tr_tracker_event const* event)
     switch (event->type) {
     case tr_tracker_event::Type::Peers:
         tr_logAddTraceTor(this, fmt::format("Got {} peers from tracker", std::size(event->pex)));
-        tr_peerMgrAddPex(this, TR_PEER_FROM_TRACKER, std::data(event->pex), std::size(event->pex));
+        tr_peerMgrAddPex(this, TR_PEER_FROM_TRACKER, event->pex);
         break;
 
     case tr_tracker_event::Type::Counts:

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1422,12 +1422,12 @@ std::vector<tr_peer_stat> tr_torrentPeers(tr_torrent const* tor)
     return tr_peerMgrPeerStats(tor);
 }
 
-void tr_torrentAvailability(tr_torrent const* tor, int8_t* tab, int size)
+void tr_torrentAvailability(tr_torrent const* tor, std::span<int8_t> const tab)
 {
     tr_return_if_fail(tr_isTorrent(tor));
 
-    if (tab != nullptr && size > 0) {
-        tr_peerMgrTorrentAvailability(tor, tab, size);
+    if (!tab.empty()) {
+        tr_peerMgrTorrentAvailability(tor, tab);
     }
 }
 

--- a/libtransmission/tr-dht.cc
+++ b/libtransmission/tr-dht.cc
@@ -379,10 +379,10 @@ private:
 
         if (event == DHT_EVENT_VALUES) {
             auto const pex = remove_bad_pex(tr_pex::from_compact_ipv4(data, data_len, nullptr, 0));
-            self->mediator_.add_pex(hash, std::data(pex), std::size(pex));
+            self->mediator_.add_pex(hash, pex);
         } else if (event == DHT_EVENT_VALUES6) {
             auto const pex = remove_bad_pex(tr_pex::from_compact_ipv6(data, data_len, nullptr, 0));
-            self->mediator_.add_pex(hash, std::data(pex), std::size(pex));
+            self->mediator_.add_pex(hash, pex);
         }
     }
 

--- a/libtransmission/tr-dht.h
+++ b/libtransmission/tr-dht.h
@@ -11,6 +11,7 @@
 #include <cstddef> // size_t
 #include <ctime>
 #include <memory>
+#include <span>
 #include <string_view>
 #include <vector>
 
@@ -98,7 +99,7 @@ public:
             return api_;
         }
 
-        virtual void add_pex(tr_sha1_digest_t const&, tr_pex const* pex, size_t n_pex) = 0;
+        virtual void add_pex(tr_sha1_digest_t const&, std::span<tr_pex const> pex) = 0;
 
     private:
         API api_;

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -880,7 +880,7 @@ struct tr_torrent_view tr_torrentView(tr_torrent const* tor);
  * to either -1 if we have the piece, otherwise it is set to the number
  * of connected peers who have the piece.
  */
-void tr_torrentAvailability(tr_torrent const* torrent, int8_t* tab, int size);
+void tr_torrentAvailability(tr_torrent const* torrent, std::span<int8_t> tab);
 
 void tr_torrentAmountFinished(tr_torrent const* torrent, float* tab, int n_tabs);
 

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -220,7 +220,7 @@ static tr_torrent_rename_done_func makeRenameDoneCallback(NSDictionary* contextI
 
 - (void)getAvailability:(int8_t*)tab size:(int)size
 {
-    tr_torrentAvailability(self.fHandle, tab, size);
+    tr_torrentAvailability(self.fHandle, { tab, static_cast<size_t>(size) });
 }
 
 - (void)getAmountFinished:(float*)tab size:(int)size

--- a/tests/libtransmission/dht-test.cc
+++ b/tests/libtransmission/dht-test.cc
@@ -354,7 +354,7 @@ protected:
             return mock_dht_;
         }
 
-        void add_pex(tr_sha1_digest_t const& /*info_hash*/, tr_pex const* /*pex*/, size_t /*n_pex*/) override
+        void add_pex(tr_sha1_digest_t const& /*info_hash*/, std::span<tr_pex const> /*pex*/) override
         {
         }
 

--- a/tests/libtransmission/torrents-test.cc
+++ b/tests/libtransmission/torrents-test.cc
@@ -129,7 +129,7 @@ TEST_F(TorrentsTest, invalidArgsAreLogged)
     EXPECT_TRUE(std::empty(tr_torrentPeers(nullptr)));
     ++expected_log_size;
 
-    tr_torrentAvailability(nullptr, nullptr, 0);
+    tr_torrentAvailability(nullptr, {});
     ++expected_log_size;
 
     tr_torrentAmountFinished(nullptr, nullptr, 0);


### PR DESCRIPTION
Notes: Moved from C++17 to C++20.

There should be no change in behaviour.