### PR TITLE
fix: clang-tidy header warnings

### DIFF
--- a/libtransmission-app/rpc-queue.h
+++ b/libtransmission-app/rpc-queue.h
@@ -155,20 +155,21 @@ private:
     static QueuedFunction normalize_func(Func&& func)
     {
         using F = std::remove_cvref_t<Func>;
-        return [func = make_copyable(std::forward<Func>(func))](RpcResponse const& prev, Continue done) mutable {
-            if constexpr (std::invocable<F, RpcResponse const&, Continue>) {
-                std::invoke(func, prev, std::move(done));
-            } else if constexpr (std::invocable<F, Continue>) {
-                std::invoke(func, std::move(done));
-            } else if constexpr (std::invocable<F, RpcResponse const&>) {
-                std::invoke(func, prev);
-                done(make_ok_response());
-            } else {
-                static_assert(std::invocable<F>, "step must take (prev, done), (done), (prev), or ()");
-                std::invoke(func);
-                done(make_ok_response());
-            }
-        };
+        return
+            [func = make_copyable(std::forward<Func>(func))]([[maybe_unused]] RpcResponse const& prev, Continue done) mutable {
+                if constexpr (std::invocable<F, RpcResponse const&, Continue>) {
+                    std::invoke(func, prev, std::move(done));
+                } else if constexpr (std::invocable<F, Continue>) {
+                    std::invoke(func, std::move(done));
+                } else if constexpr (std::invocable<F, RpcResponse const&>) {
+                    std::invoke(func, prev);
+                    done(make_ok_response());
+                } else {
+                    static_assert(std::invocable<F>, "step must take (prev, done), (done), (prev), or ()");
+                    std::invoke(func);
+                    done(make_ok_response());
+                }
+            };
     }
 
     // Adapts an error handler that takes either the failing response or nothing.
@@ -176,7 +177,7 @@ private:
     static ErrorHandlerFunction normalize_error_handler(Func&& func)
     {
         using F = std::remove_cvref_t<Func>;
-        return [func = make_copyable(std::forward<Func>(func))](RpcResponse const& r) mutable {
+        return [func = make_copyable(std::forward<Func>(func))]([[maybe_unused]] RpcResponse const& r) mutable {
             if constexpr (std::invocable<F, RpcResponse const&>) {
                 std::invoke(func, r);
             } else {

--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -375,7 +375,7 @@ void tr_bitfield::set_span(size_t begin, size_t end, bool value)
     }
 }
 
-tr_bitfield& tr_bitfield::operator|=(tr_bitfield const& that) noexcept
+tr_bitfield& tr_bitfield::operator|=(tr_bitfield const& that)
 {
     if (has_all() || that.has_none()) {
         return *this;
@@ -396,7 +396,7 @@ tr_bitfield& tr_bitfield::operator|=(tr_bitfield const& that) noexcept
     return *this;
 }
 
-tr_bitfield& tr_bitfield::operator&=(tr_bitfield const& that) noexcept
+tr_bitfield& tr_bitfield::operator&=(tr_bitfield const& that)
 {
     if (has_none() || that.has_all()) {
         return *this;

--- a/libtransmission/bitfield.h
+++ b/libtransmission/bitfield.h
@@ -119,8 +119,8 @@ public:
         return static_cast<float>(count()) / static_cast<float>(size());
     }
 
-    tr_bitfield& operator|=(tr_bitfield const& that) noexcept;
-    tr_bitfield& operator&=(tr_bitfield const& that) noexcept;
+    tr_bitfield& operator|=(tr_bitfield const& that);
+    tr_bitfield& operator&=(tr_bitfield const& that);
     [[nodiscard]] bool intersects(tr_bitfield const& that) const noexcept;
 
 private:

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -130,27 +130,6 @@ bool is_valid_path(std::string_view path)
     return path_to_fixed_native_path(path);
 }
 
-std::string native_path_to_path(std::wstring_view wide_path)
-{
-    if (std::empty(wide_path)) {
-        return {};
-    }
-
-    if (tr_strv_starts_with(wide_path, NativeUncPathPrefix)) {
-        wide_path.remove_prefix(std::size(NativeUncPathPrefix));
-        auto path = tr_win32_native_to_utf8(wide_path);
-        path.insert(0, R"(\\)"sv);
-        return path;
-    }
-
-    if (tr_strv_starts_with(wide_path, NativeLocalPathPrefix)) {
-        wide_path.remove_prefix(std::size(NativeLocalPathPrefix));
-        return tr_win32_native_to_utf8(wide_path);
-    }
-
-    return tr_win32_native_to_utf8(wide_path);
-}
-
 [[nodiscard]] tr_sys_file_t open_file(
     std::string_view const path,
     DWORD const access,

--- a/libtransmission/ip-cache.cc
+++ b/libtransmission/ip-cache.cc
@@ -221,7 +221,7 @@ void tr_ip_cache::update_global_addr(tr_address_type const type) noexcept
     }
 
     auto const ix_service = ix_service_[type];
-    if (ix_service == 0U && !set_is_updating(type, ip_endpoints)) {
+    if (ix_service == 0U && !set_is_updating(type, { ip_endpoints.begin(), ip_endpoints.end() })) {
         return;
     }
     TR_ASSERT(ix_service < std::size(current_ip_endpoints_[type]));
@@ -365,13 +365,13 @@ void tr_ip_cache::unset_addr(tr_address_type type) noexcept
     unset_global_addr(type);
 }
 
-bool tr_ip_cache::set_is_updating(tr_address_type type, std::span<std::string const> ip_endpoints) noexcept
+bool tr_ip_cache::set_is_updating(tr_address_type type, std::vector<std::string> ip_endpoints) noexcept
 {
     if (is_updating_[type] != is_updating_t::No) {
         return false;
     }
     is_updating_[type] = is_updating_t::Yes;
-    current_ip_endpoints_[type].assign(ip_endpoints.begin(), ip_endpoints.end());
+    current_ip_endpoints_[type] = std::move(ip_endpoints);
     return true;
 }
 

--- a/libtransmission/ip-cache.cc
+++ b/libtransmission/ip-cache.cc
@@ -202,7 +202,7 @@ bool tr_ip_cache::set_global_addr(tr_address const& addr_new) noexcept
     return false;
 }
 
-void tr_ip_cache::update_addr(tr_address_type type) noexcept
+void tr_ip_cache::update_addr(tr_address_type type)
 {
     update_source_addr(type);
     if (source_addr(type)) {
@@ -210,7 +210,7 @@ void tr_ip_cache::update_addr(tr_address_type type) noexcept
     }
 }
 
-void tr_ip_cache::update_global_addr(tr_address_type const type) noexcept
+void tr_ip_cache::update_global_addr(tr_address_type const type)
 {
     TR_ASSERT(type < NUM_TR_AF_INET_TYPES);
     TR_ASSERT(has_ip_protocol_[type]);
@@ -291,7 +291,7 @@ void tr_ip_cache::update_source_addr(tr_address_type type) noexcept
     unset_is_updating(type);
 }
 
-void tr_ip_cache::on_response_ip_query(tr_address_type const type, tr_web::FetchResponse const& response) noexcept
+void tr_ip_cache::on_response_ip_query(tr_address_type const type, tr_web::FetchResponse const& response)
 {
     auto& ix_service = ix_service_[type];
     auto const& ip_endpoints = current_ip_endpoints_[type];

--- a/libtransmission/ip-cache.h
+++ b/libtransmission/ip-cache.h
@@ -122,7 +122,7 @@ private:
         upkeep_timers_[type]->stop();
     }
 
-    [[nodiscard]] bool set_is_updating(tr_address_type type, std::span<std::string const> ip_endpoints = {}) noexcept;
+    [[nodiscard]] bool set_is_updating(tr_address_type type, std::vector<std::string> ip_endpoints = {}) noexcept;
     void unset_is_updating(tr_address_type type) noexcept;
 
     Mediator& mediator_;

--- a/libtransmission/ip-cache.h
+++ b/libtransmission/ip-cache.h
@@ -90,12 +90,12 @@ public:
 
     bool set_global_addr(tr_address const& addr_new) noexcept;
 
-    void update_addr(tr_address_type type) noexcept;
-    void update_global_addr(tr_address_type type) noexcept;
+    void update_addr(tr_address_type type);
+    void update_global_addr(tr_address_type type);
     void update_source_addr(tr_address_type type) noexcept;
 
     // Only use as a callback for web_->fetch()
-    void on_response_ip_query(tr_address_type type, tr_web::FetchResponse const& response) noexcept;
+    void on_response_ip_query(tr_address_type type, tr_web::FetchResponse const& response);
 
     [[nodiscard]] constexpr auto has_ip_protocol(tr_address_type type) const noexcept
     {

--- a/libtransmission/ip-cache.h
+++ b/libtransmission/ip-cache.h
@@ -55,7 +55,7 @@ public:
             return {};
         }
 
-        [[nodiscard]] virtual std::span<std::string const> settings_ip_endpoint(tr_address_type /*type*/)
+        [[nodiscard]] virtual std::span<std::string const> settings_ip_endpoint(tr_address_type /*type*/) noexcept
         {
             return {};
         }

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -455,7 +455,7 @@ public:
         return tor->unique_lock();
     }
 
-    tr_swarm(tr_peerMgr* manager_in, tr_torrent* tor_in) noexcept
+    tr_swarm(tr_peerMgr* manager_in, tr_torrent* tor_in)
         : manager{ manager_in }
         , tor{ tor_in }
         , tags_{ {

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -971,8 +971,9 @@ void tr_rpc_server::load(Settings&& settings)
     }
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape): stop_server can throw on OOM, but a
-// destructor must not propagate; terminating is the correct behavior here.
+// stop_server can throw on OOM, but a destructor must not propagate;
+// terminating is the correct behavior here.
+// NOLINTNEXTLINE(bugprone-exception-escape)
 tr_rpc_server::~tr_rpc_server()
 {
     stop_server(this);

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -877,7 +877,7 @@ void tr_rpc_server::set_username(std::string username) noexcept
     tr_logAddDebug(fmt::format("setting our username to '{:s}'", settings_.username));
 }
 
-void tr_rpc_server::set_password(std::string_view password) noexcept
+void tr_rpc_server::set_password(std::string_view password)
 {
     auto const is_salted = tr_ssha1_test(password);
     settings_.salted_password = is_salted ? password : tr_ssha1(password);

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -971,6 +971,8 @@ void tr_rpc_server::load(Settings&& settings)
     }
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape): stop_server can throw on OOM, but a
+// destructor must not propagate; terminating is the correct behavior here.
 tr_rpc_server::~tr_rpc_server()
 {
     stop_server(this);

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -871,10 +871,10 @@ void tr_rpc_server::set_whitelist(std::string_view whitelist)
 
 // --- PASSWORD
 
-void tr_rpc_server::set_username(std::string_view username)
+void tr_rpc_server::set_username(std::string username) noexcept
 {
-    settings_.username = username;
-    tr_logAddDebug(fmt::format("setting our username to '{:s}'", username));
+    settings_.username = std::move(username);
+    tr_logAddDebug(fmt::format("setting our username to '{:s}'", settings_.username));
 }
 
 void tr_rpc_server::set_password(std::string_view password) noexcept

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -101,7 +101,7 @@ public:
         return settings_.salted_password;
     }
 
-    void set_password(std::string_view password) noexcept;
+    void set_password(std::string_view password);
 
     [[nodiscard]] constexpr auto is_anti_brute_force_enabled() const noexcept
     {

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -87,7 +87,7 @@ public:
         return settings_.username;
     }
 
-    void set_username(std::string_view username);
+    void set_username(std::string username) noexcept;
 
     [[nodiscard]] constexpr auto is_password_enabled() const noexcept
     {

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1737,7 +1737,7 @@ void tr_sessionSetRPCUsername(tr_session* session, std::string_view const userna
 {
     TR_ASSERT(session != nullptr);
 
-    session->rpc_server_->set_username(username);
+    session->rpc_server_->set_username(std::string{ username });
 }
 
 std::string tr_sessionGetRPCUsername(tr_session const* session)

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -332,7 +332,7 @@ private:
             }
         }
 
-        [[nodiscard]] std::span<std::string const> settings_ip_endpoint(tr_address_type type) override
+        [[nodiscard]] std::span<std::string const> settings_ip_endpoint(tr_address_type type) noexcept override
         {
             switch (type) {
             case TR_AF_INET:

--- a/libtransmission/string-utils.cc
+++ b/libtransmission/string-utils.cc
@@ -11,6 +11,7 @@
 #include <ranges>
 #include <string>
 #include <string_view>
+#include <utility> // std::cmp_equal
 
 #ifdef _WIN32
 #include <windows.h>
@@ -113,7 +114,7 @@ std::string tr_win32_native_to_utf8(std::wstring_view in)
         static_cast<int>(std::size(out)),
         nullptr,
         nullptr);
-    TR_ASSERT(len == std::size(out));
+    TR_ASSERT(std::cmp_equal(len, std::size(out)));
     return out;
 }
 
@@ -128,7 +129,7 @@ std::wstring tr_win32_utf8_to_native(std::string_view in)
         static_cast<int>(std::size(in)),
         std::data(out),
         static_cast<int>(std::size(out)));
-    TR_ASSERT(len == std::size(out));
+    TR_ASSERT(std::cmp_equal(len, std::size(out)));
     return out;
 }
 

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -301,7 +301,7 @@ void tr_torrent::set_metadata_piece(int64_t const piece, void const* const data,
 
 // ---
 
-[[nodiscard]] std::optional<int64_t> tr_metadata_download::get_next_metadata_request(time_t const now) noexcept
+[[nodiscard]] std::optional<int64_t> tr_metadata_download::get_next_metadata_request(time_t const now)
 {
     auto& needed = pieces_needed_;
     if (std::empty(needed) || needed.front().requested_at + MinRepeatIntervalSecs >= now) {
@@ -316,9 +316,9 @@ void tr_torrent::set_metadata_piece(int64_t const piece, void const* const data,
     return req.piece;
 }
 
-[[nodiscard]] std::optional<int64_t> tr_torrent::get_next_metadata_request(time_t const now) noexcept
+[[nodiscard]] std::optional<int64_t> tr_torrent::get_next_metadata_request(time_t const now)
 {
-    if (auto& m = metadata_download_; m) {
+    if (auto& m = metadata_download_) {
         return m->get_next_metadata_request(now);
     }
 

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -48,7 +48,7 @@ template<typename T>
 }
 } // namespace
 
-void tr_metadata_download::create_all_needed(int64_t n_pieces) noexcept
+void tr_metadata_download::create_all_needed(int64_t const n_pieces)
 {
     pieces_needed_.clear();
     pieces_needed_.resize(n_pieces);

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -66,7 +66,7 @@ private:
             MetadataPieceSize;
     }
 
-    void create_all_needed(int64_t n_pieces) noexcept;
+    void create_all_needed(int64_t n_pieces);
 
     std::vector<char> metadata_;
     std::deque<metadata_node> pieces_needed_;

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -39,7 +39,7 @@ public:
 
     bool set_metadata_piece(int64_t piece, void const* data, size_t len);
 
-    [[nodiscard]] std::optional<int64_t> get_next_metadata_request(time_t now) noexcept;
+    [[nodiscard]] std::optional<int64_t> get_next_metadata_request(time_t now);
 
     [[nodiscard]] double get_metadata_percent() const noexcept;
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -634,7 +634,7 @@ struct tr_torrent {
 
     void set_metadata_piece(int64_t piece, void const* data, size_t len);
 
-    [[nodiscard]] std::optional<int64_t> get_next_metadata_request(time_t now) noexcept;
+    [[nodiscard]] std::optional<int64_t> get_next_metadata_request(time_t now);
 
     [[nodiscard]] double get_metadata_percent() const noexcept;
 

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -149,7 +149,7 @@ private:
         return depth < MaxDepth ? prealloc_guess_[depth] : 0;
     }
 
-    tr_variant* push_stack() noexcept
+    tr_variant* push_stack()
     {
         return std::size(stack_) < MaxDepth ? stack_.emplace(get_leaf()) : nullptr;
     }

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -283,9 +283,9 @@ public:
         Task& operator=(Task&&) = delete;
         Task& operator=(Task const&) = delete;
 
-        // NOLINTNEXTLINE(bugprone-exception-escape): easy_dispose can throw on OOM
-        // while pooling the handle, but a destructor must not propagate; terminating
-        // is the correct behavior here.
+        // easy_dispose can throw on OOM while pooling the handle, but a
+        // destructor must not propagate; terminating is the correct behavior here.
+        // NOLINTNEXTLINE(bugprone-exception-escape)
         ~Task()
         {
             easy_dispose(easy_);

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -283,6 +283,9 @@ public:
         Task& operator=(Task&&) = delete;
         Task& operator=(Task const&) = delete;
 
+        // NOLINTNEXTLINE(bugprone-exception-escape): easy_dispose can throw on OOM
+        // while pooling the handle, but a destructor must not propagate; terminating
+        // is the correct behavior here.
         ~Task()
         {
             easy_dispose(easy_);

--- a/qt/AddData.cc
+++ b/qt/AddData.cc
@@ -58,9 +58,10 @@ AddData::Type AddData::set(QString const& key)
             this->filename = file.fileName();
             this->type = FILENAME;
 
-            file.open(QIODevice::ReadOnly);
-            this->metainfo = file.readAll();
-            file.close();
+            if (file.open(QIODevice::ReadOnly)) {
+                this->metainfo = file.readAll();
+                file.close();
+            }
         }
     } else if (auto const raw = QByteArray::fromBase64(key.toUtf8()); !raw.isEmpty()) {
         this->metainfo.append(raw);

--- a/qt/ComInteropHelper.cc
+++ b/qt/ComInteropHelper.cc
@@ -43,6 +43,8 @@ QVariant ComInteropHelper::addMetainfo(QString const& metainfo) const
 void ComInteropHelper::initialize()
 {
     qAxOutProcServer = true;
+    // GetModuleFileNameW is a Win32 API that writes the module path into the raw buffer.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
     ::GetModuleFileNameW(nullptr, qAxModuleFilename, MAX_PATH);
 
     ::CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
@@ -52,5 +54,8 @@ void ComInteropHelper::initialize()
 void ComInteropHelper::registerObject(QObject* parent)
 {
     QAxFactory::startServer();
+    // The new object is owned by its QObject parent (Qt parent-child ownership),
+    // which the analyzer can't see, so it is not actually leaked.
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     QAxFactory::registerActiveObject(new InteropObject{ parent });
 }

--- a/qt/ComInteropHelper.cc
+++ b/qt/ComInteropHelper.cc
@@ -55,7 +55,7 @@ void ComInteropHelper::registerObject(QObject* parent)
 {
     QAxFactory::startServer();
     // The new object is owned by its QObject parent (Qt parent-child ownership),
-    // which the analyzer can't see, so it is not actually leaked.
-    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
+    // which the analyzer can't see, so it is not actually leaked. The analyzer
+    // anchors the leak to the closing brace, so the suppression must live there.
     QAxFactory::registerActiveObject(new InteropObject{ parent });
-}
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -378,6 +378,7 @@ void Session::torrentRenamePath(torrent_ids_t const& torrent_ids, QString const&
                 QObject::connect(d, &QMessageBox::rejected, d, &QMessageBox::deleteLater);
                 d->show();
             })
+        // NOLINTNEXTLINE(bugprone-exception-escape)
         .add([this, torrent_ids](RpcResponse const& /*r*/) { refreshTorrents(torrent_ids, TorrentProperties::Rename); })
         .run();
 }
@@ -588,6 +589,7 @@ void Session::sendTorrentRequest(tr_quark const method, torrent_ids_t const& tor
         .add([this, method, params = makeParams(TR_KEY_ids, torrent_ids)](RpcClient::ResponseFunc done) mutable {
             exec(method, std::move(params), std::move(done));
         })
+        // NOLINTNEXTLINE(bugprone-exception-escape)
         .add([this, torrent_ids]() { refreshTorrents(torrent_ids, TorrentProperties::MainStats); })
         .run();
 }

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -52,7 +52,7 @@ constexpr struct {
 } TorrentIdLessThan;
 
 template<typename Iter>
-auto getIds(Iter it, Iter end)
+auto getIds(Iter it, Iter const& end)
 {
     torrent_ids_t ids;
 

--- a/tests/libtransmission/ip-cache-test.cc
+++ b/tests/libtransmission/ip-cache-test.cc
@@ -231,7 +231,7 @@ TEST_F(IPCacheTest, onResponseIPQuery)
             options.done_func(response);
         }
 
-        [[nodiscard]] std::span<std::string const> settings_ip_endpoint(tr_address_type /*type*/) override
+        [[nodiscard]] std::span<std::string const> settings_ip_endpoint(tr_address_type /*type*/) noexcept override
         {
             return ip_endpoints;
         }

--- a/tests/libtransmission/subprocess-test-program.cc
+++ b/tests/libtransmission/subprocess-test-program.cc
@@ -12,6 +12,7 @@
 #include <fstream>
 #include <string>
 
+// NOLINTNEXTLINE(bugprone-exception-escape): test helper; terminating on OOM is fine
 int main(int argc, char** argv)
 {
     if (argc < 3) {


### PR DESCRIPTION
Prerequisite for https://github.com/transmissiontorrent/transmission/pull/119.

The draft clang-tidy runner config is finding more warnings, so this PR fixes them.

