### PR TITLE
fix: lost wakeup that could hang tr_web shutdown

### DIFF
--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -892,10 +892,9 @@ tr_web::tr_web(Mediator& mediator)
 {
 }
 
-tr_web::~tr_web()
-{
-    impl_->startShutdown(0ms);
-}
+// ~Impl() itself starts an immediate shutdown before joining the curl
+// thread, so there's nothing to do here beyond destroying the members
+tr_web::~tr_web() = default;
 
 std::unique_ptr<tr_web> tr_web::create(Mediator& mediator)
 {

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -230,24 +230,30 @@ public:
 
     ~Impl()
     {
-        deadline_ns_ = to_ns(mediator.now());
-        queued_tasks_cv_.notify_one();
+        startShutdown(0ms);
         curl_thread->join();
     }
 
     void startShutdown(std::chrono::milliseconds deadline)
     {
-        deadline_ns_ = to_ns(mediator.now() + deadline);
+        // the deadline must be set under the mutex: curlThreadFunc() decides
+        // whether to sleep by testing it, so an unsynchronized store could
+        // land between that test and the sleep and never be noticed
+        {
+            auto const lock = std::unique_lock{ tasks_mutex_ };
+            deadline_ns_ = to_ns(mediator.now() + deadline);
+        }
         queued_tasks_cv_.notify_one();
     }
 
     void fetch(FetchOptions&& options)
     {
-        if (deadline_exists()) {
+        auto const lock = std::unique_lock{ tasks_mutex_ };
+
+        if (deadline_exists()) { // no new tasks once shutdown has begun
             return;
         }
 
-        auto const lock = std::unique_lock{ tasks_mutex_ };
         queued_tasks_.emplace_back(*this, std::move(options));
         queued_tasks_cv_.notify_one();
     }
@@ -755,16 +761,18 @@ public:
                 }
             }
 
-            if (deadline_exists() && is_idle()) {
-                break;
-            }
-
             if (auto lock = std::unique_lock{ tasks_mutex_ }; lock.owns_lock()) {
-                // sleep until there's something to do
+                // sleep until there's something to do.
+                // NB: a pending shutdown must stop the wait; if it prolonged
+                // it instead, the loop could sleep through its exit condition
                 auto const stop_waiting = [this]() {
-                    return !is_idle() || !deadline_exists();
+                    return !is_idle() || deadline_exists();
                 };
                 queued_tasks_cv_.wait(lock, stop_waiting);
+
+                if (deadline_exists() && is_idle()) {
+                    break;
+                }
 
                 // add queued tasks
                 if (!std::empty(queued_tasks_)) {

--- a/tests/libtransmission/web-test.cc
+++ b/tests/libtransmission/web-test.cc
@@ -438,4 +438,16 @@ TEST_F(WebTest, timeoutIsReported)
     EXPECT_TRUE(response.did_timeout);
 }
 
+TEST_F(WebTest, destroyRightAfterFetchDoesNotHang)
+{
+    // Stress the shutdown path: destroying a tr_web immediately after a
+    // fetch completes races the destructor's deadline against the curl
+    // thread returning to its condition-variable wait. A lost wakeup there
+    // makes the destructor's join() hang forever and this test time out.
+    for (auto i = 0; i < 50; ++i) {
+        auto web = tr_web::create(mediator_);
+        fetch(*web, options());
+    }
+}
+
 } // namespace

--- a/tests/libtransmission/web-test.cc
+++ b/tests/libtransmission/web-test.cc
@@ -443,7 +443,7 @@ TEST_F(WebTest, destroyRightAfterFetchDoesNotHang)
     // Stress the shutdown path: destroying a tr_web immediately after a
     // fetch completes races the destructor's deadline against the curl
     // thread returning to its condition-variable wait. A lost wakeup there
-    // makes the destructor's join() hang forever and this test time out.
+    // hangs the destructor's join() forever, so this test times out.
     for (auto i = 0; i < 50; ++i) {
         auto web = tr_web::create(mediator_);
         fetch(*web, options());


### PR DESCRIPTION
Sample test error:

```
The following tests FAILED:
	554 - LT.WebTest.userAgentFromMediatorIsSent (Timeout)
Errors while running CTest
```

`~Impl()` and `startShutdown()` stored `deadline_ns_` and notified without holding `tasks_mutex_,` so the notify could be lost if it fired in the gap before the curl worker began its condvar wait. Worse, the wait treated a pending shutdown as a reason to keep sleeping, so nothing could ever wake it and `join()` hung forever.

Fixed by:

- Setting the deadline under the mutex
- Making a pending shutdown stop the wait
- Moving the exit check and fetch()'s deadline check under the mutex.

Added a stress test destroying a tr_web after each fetch.

This fixes a bug in production code; but since (I think?) it would only be exercised in cases where `tr_web` had a short lifespan, I think this only affects tests so I'm marking as `notes:none`.