### PR TITLE
fix: bump deprecated rpc-version to 20

### DIFF
--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -1121,7 +1121,7 @@ Transmission 4.1.1 (`rpc_version_semver` 6.0.1, `rpc_version`: 19)
 | `group_get` | `speed_limit_down` reverted to return an integer
 | `group_get` | `speed_limit_up` reverted to return an integer
 
-Transmission 4.2.0 (`rpc_version_semver` 6.1.0, `rpc_version`: ?)
+Transmission 4.2.0 (`rpc_version_semver` 6.1.0, `rpc_version`: 20)
 
 | Method | Description
 |:---|:---

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -181,7 +181,7 @@ namespace
 namespace
 {
 auto constexpr RecentlyActiveSeconds = time_t{ 60 };
-auto constexpr RpcVersion = int64_t{ 18 }; // TODO: 18 == 6.0.0, bump after all 6.0.x releases and before releasing 6.1.0
+auto constexpr RpcVersion = int64_t{ 20 };
 auto constexpr RpcVersionMin = int64_t{ 14 };
 
 enum class TrFormat : uint8_t { Object, Table };

--- a/libtransmission/rpcimpl.h
+++ b/libtransmission/rpcimpl.h
@@ -15,6 +15,7 @@ struct tr_variant;
     auto inline constexpr TrRpcVersionSemver = std::string_view{ #major "." #minor "." #patch }; \
     auto inline constexpr TrRpcVersionSemverMajor = major;
 
+// When bumping here, remember to bump `RpcVersion` and maybe `RpcVersionMin`.
 RPC_VERSION_VARS(6, 1, 0)
 
 #undef RPC_VERSION_VARS


### PR DESCRIPTION
Bump deprecated rpc-version to 20 for 6.1.0
    
Latest previous version: rpc-version 19 (semver 6.0.1) in `4.1.1`
