### PR TITLE
refactor: use `std::span` in `tr_torrentAmountFinished`

### DIFF
--- a/libtransmission/completion.cc
+++ b/libtransmission/completion.cc
@@ -76,14 +76,14 @@ uint64_t tr_completion::size_when_done() const
     return *size_when_done_;
 }
 
-void tr_completion::amount_done(float* tab, size_t n_tabs) const
+void tr_completion::amount_done(std::span<float> const tab) const
 {
-    if (n_tabs < 1) {
+    if (tab.empty()) {
         return;
     }
 
-    auto const blocks_per_tab = std::size(blocks_) / n_tabs;
-    for (size_t i = 0; i < n_tabs; ++i) {
+    auto const blocks_per_tab = std::size(blocks_) / tab.size();
+    for (size_t i = 0; i < tab.size(); ++i) {
         auto const begin = i * blocks_per_tab;
         auto const end = std::min(begin + blocks_per_tab, std::size(blocks_));
         auto const numerator = blocks_.count(begin, end);

--- a/libtransmission/completion.h
+++ b/libtransmission/completion.h
@@ -124,7 +124,7 @@ struct tr_completion {
         return block_info_->piece_size(piece) - count_has_bytes_in_piece(piece);
     }
 
-    void amount_done(float* tab, size_t n_tabs) const;
+    void amount_done(std::span<float> tab) const;
 
     void add_block(tr_block_index_t block);
     void add_piece(tr_piece_index_t piece);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1431,11 +1431,11 @@ void tr_torrentAvailability(tr_torrent const* tor, std::span<int8_t> const tab)
     }
 }
 
-void tr_torrentAmountFinished(tr_torrent const* tor, float* tabs, int n_tabs)
+void tr_torrentAmountFinished(tr_torrent const* const tor, std::span<float> const tabs)
 {
     tr_return_if_fail(tr_isTorrent(tor));
 
-    tor->amount_done_bins(tabs, n_tabs);
+    tor->amount_done_bins(tabs);
 }
 
 // --- Start/Stop Callback

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -379,9 +379,9 @@ struct tr_torrent {
         return completeness_ == TR_PARTIAL_SEED;
     }
 
-    void amount_done_bins(float* tab, int n_tabs) const
+    void amount_done_bins(std::span<float> const tab) const
     {
-        completion_.amount_done(tab, n_tabs);
+        completion_.amount_done(tab);
     }
 
     /// FILE <-> PIECE

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -882,7 +882,7 @@ struct tr_torrent_view tr_torrentView(tr_torrent const* tor);
  */
 void tr_torrentAvailability(tr_torrent const* torrent, std::span<int8_t> tab);
 
-void tr_torrentAmountFinished(tr_torrent const* torrent, float* tab, int n_tabs);
+void tr_torrentAmountFinished(tr_torrent const* torrent, std::span<float> tab);
 
 /**
  * Queue a torrent for verification.

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -225,7 +225,7 @@ static tr_torrent_rename_done_func makeRenameDoneCallback(NSDictionary* contextI
 
 - (void)getAmountFinished:(float*)tab size:(int)size
 {
-    tr_torrentAmountFinished(self.fHandle, tab, size);
+    tr_torrentAmountFinished(self.fHandle, { tab, static_cast<size_t>(size) });
 }
 
 - (NSIndexSet*)previousFinishedPieces

--- a/tests/libtransmission/completion-test.cc
+++ b/tests/libtransmission/completion-test.cc
@@ -389,17 +389,17 @@ TEST_F(CompletionTest, amountDone)
     for (tr_piece_index_t piece = 0; piece < block_info.piece_count(); ++piece) {
         completion.remove_piece(piece);
     }
-    completion.amount_done(std::data(bins), std::size(bins));
+    completion.amount_done(bins);
     std::ranges::for_each(bins, [](float bin) { EXPECT_FLOAT_EQ(0.0, bin); });
 
     // one block
     completion.add_block(0);
-    completion.amount_done(std::data(bins), std::size(bins));
+    completion.amount_done(bins);
     EXPECT_FLOAT_EQ(0.0, bins[1]);
 
     // one piece
     completion.add_piece(0);
-    completion.amount_done(std::data(bins), std::size(bins));
+    completion.amount_done(bins);
     EXPECT_FLOAT_EQ(1.0, bins[0]);
     EXPECT_FLOAT_EQ(0.0, bins[1]);
 
@@ -407,12 +407,12 @@ TEST_F(CompletionTest, amountDone)
     for (tr_piece_index_t piece = 0; piece < block_info.piece_count(); ++piece) {
         completion.add_piece(piece);
     }
-    completion.amount_done(std::data(bins), std::size(bins));
+    completion.amount_done(bins);
     std::ranges::for_each(bins, [](float bin) { EXPECT_FLOAT_EQ(1.0, bin); });
 
     // don't do anything if fed bad input
     auto const backup = bins;
-    completion.amount_done(std::data(bins), 0);
+    completion.amount_done({});
     EXPECT_EQ(backup, bins);
 }
 

--- a/tests/libtransmission/torrents-test.cc
+++ b/tests/libtransmission/torrents-test.cc
@@ -132,7 +132,7 @@ TEST_F(TorrentsTest, invalidArgsAreLogged)
     tr_torrentAvailability(nullptr, {});
     ++expected_log_size;
 
-    tr_torrentAmountFinished(nullptr, nullptr, 0);
+    tr_torrentAmountFinished(nullptr, {});
     ++expected_log_size;
 
     tr_torrentStart(nullptr);


### PR DESCRIPTION
Notes: Moved from C++17 to C++20.

There should be no change in behaviour.