### PR TITLE
ci: faster BSD tests

### DIFF
--- a/.github/actions/prepare-deps-win32/action.yml
+++ b/.github/actions/prepare-deps-win32/action.yml
@@ -40,7 +40,7 @@ runs:
       id: restore-cache
       with:
         path: ${{ env.DEPS_PREFIX }}
-        key: ${{ github.job }}-${{ inputs.arch }}-${{ steps.cache-key.outputs.hash }}
+        key: win-deps-${{ inputs.arch }}-${{ steps.cache-key.outputs.hash }}
     - name: Build Dependencies
       if: steps.restore-cache.outputs.cache-hit != 'true'
       shell: pwsh
@@ -58,4 +58,4 @@ runs:
       id: cache
       with:
         path: ${{ env.DEPS_PREFIX }}
-        key: ${{ github.job }}-${{ inputs.arch }}-${{ steps.cache-key.outputs.hash }}
+        key: win-deps-${{ inputs.arch }}-${{ steps.cache-key.outputs.hash }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1589,7 +1589,6 @@ jobs:
         uses: vmactions/freebsd-vm@v1
         with:
           usesh: true
-          cpu: 4
           mem: 12288
           prepare: |
             set -ex
@@ -1769,7 +1768,6 @@ jobs:
         uses: vmactions/openbsd-vm@v1
         with:
           usesh: true
-          cpu: 4
           mem: 12288
           prepare: |
             set -ex
@@ -1849,7 +1847,6 @@ jobs:
         uses: vmactions/netbsd-vm@v1
         with:
           usesh: true
-          cpu: 4
           mem: 12288
           prepare: |
             set -ex

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1541,6 +1541,8 @@ jobs:
         uses: vmactions/freebsd-vm@v1
         with:
           usesh: true
+          cpu: 4
+          mem: 12288
           prepare: |
             set -ex
             uname -a
@@ -1721,6 +1723,8 @@ jobs:
         uses: vmactions/openbsd-vm@v1
         with:
           usesh: true
+          cpu: 4
+          mem: 12288
           prepare: |
             set -ex
             uname -a
@@ -1805,6 +1809,8 @@ jobs:
         uses: vmactions/netbsd-vm@v1
         with:
           usesh: true
+          cpu: 4
+          mem: 12288
           prepare: |
             set -ex
             uname -a

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -146,6 +146,9 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ github.job }}
+          # only main's snapshots are saved; PR runs restore them via the
+          # base-branch fallback but must not multiply them per-ref
+          save: ${{ github.event_name == 'push' }}
       - name: Configure
         run: |
           cmake \
@@ -190,7 +193,7 @@ jobs:
           # that are caused by Qt libraries not being asan instrumented
           extra-asan-options: detect_container_overflow=0
       - name: Trim ccache
-        if: always()
+        if: ${{ always() && github.event_name == 'push' }}
         run: ccache --evict-older-than 7d
 
   sanitizer-tests-macos:
@@ -215,6 +218,9 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ github.job }}
+          # only main's snapshots are saved; PR runs restore them via the
+          # base-branch fallback but must not multiply them per-ref
+          save: ${{ github.event_name == 'push' }}
       - name: Configure
         run: |
           cmake \
@@ -252,7 +258,7 @@ jobs:
           build-config: Debug
           enable-sanitizers: true
       - name: Trim ccache
-        if: always()
+        if: ${{ always() && github.event_name == 'push' }}
         run: ccache --evict-older-than 7d
 
   sanitizer-tests-windows:
@@ -631,6 +637,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ github.job }}-${{ matrix.os }}
+          save: ${{ github.event_name == 'push' }}
       - name: Configure
         run: |
           cmake \
@@ -677,7 +684,7 @@ jobs:
           name: binaries-${{ matrix.os }}-cmake-universal
           path: pfx/**/*
       - name: Trim ccache
-        if: always()
+        if: ${{ always() && github.event_name == 'push' }}
         run: ccache --evict-older-than 7d
 
   alpine-musl:
@@ -807,6 +814,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ github.job }}-${{ matrix.arch }}-${{ matrix.runner }}
+          save: ${{ github.event_name == 'push' }}
       - name: Configure
         run: |
           $CmakeArgs = @(
@@ -859,7 +867,7 @@ jobs:
           name: binaries-${{ github.job }}-${{ matrix.arch }}-msi
           path: obj/dist/msi/*.msi
       - name: Trim ccache
-        if: always()
+        if: ${{ always() && github.event_name == 'push' }}
         run: ccache --evict-older-than 7d
 
   make-source-tarball:
@@ -949,6 +957,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ github.job }}-${{ matrix.os }}
+          save: ${{ github.event_name == 'push' }}
       - name: Configure
         run: |
           cmake \
@@ -990,7 +999,7 @@ jobs:
           name: binaries-${{ matrix.os }}
           path: pfx/**/*
       - name: Trim ccache
-        if: always()
+        if: ${{ always() && github.event_name == 'push' }}
         run: ccache --evict-older-than 7d
 
   debian:
@@ -1120,14 +1129,14 @@ jobs:
           name: binaries-${{ github.job }}-${{ matrix.version }}
           path: pfx/**/*
       - name: Trim ccache
-        if: always()
+        if: ${{ always() && github.event_name == 'push' }}
         # `|| true`: Debian 11's ccache predates --evict-older-than
         run: ccache --evict-older-than 7d || true
       - name: Show ccache stats
         if: always()
         run: ccache --show-stats
       - name: Save ccache
-        if: always()
+        if: ${{ always() && github.event_name == 'push' }}
         uses: actions/cache/save@v5
         with:
           path: .ccache
@@ -1229,14 +1238,14 @@ jobs:
           name: binaries-${{ github.job }}-${{ matrix.version }}
           path: pfx/**/*
       - name: Trim ccache
-        if: always()
+        if: ${{ always() && github.event_name == 'push' }}
         # `|| true`: Debian 11's ccache predates --evict-older-than
         run: ccache --evict-older-than 7d || true
       - name: Show ccache stats
         if: always()
         run: ccache --show-stats
       - name: Save ccache
-        if: always()
+        if: ${{ always() && github.event_name == 'push' }}
         uses: actions/cache/save@v5
         with:
           path: .ccache
@@ -1281,6 +1290,9 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ github.job }}
+          # only main's snapshots are saved; PR runs restore them via the
+          # base-branch fallback but must not multiply them per-ref
+          save: ${{ github.event_name == 'push' }}
       - name: Configure
         run: |
           cmake \
@@ -1327,7 +1339,7 @@ jobs:
           name: binaries-${{ github.job }}-without-utp
           path: pfx/**/*
       - name: Trim ccache
-        if: always()
+        if: ${{ always() && github.event_name == 'push' }}
         run: ccache --evict-older-than 7d
 
   android:
@@ -1415,6 +1427,9 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ github.job }}
+          # only main's snapshots are saved; PR runs restore them via the
+          # base-branch fallback but must not multiply them per-ref
+          save: ${{ github.event_name == 'push' }}
       - name: Configure
         run: |
           cmake \
@@ -1449,7 +1464,7 @@ jobs:
       - name: Make
         run: cmake --build obj --config Release -- "-k 0"
       - name: Trim ccache
-        if: always()
+        if: ${{ always() && github.event_name == 'push' }}
         run: ccache --evict-older-than 7d
 
   ubuntu-24-04-arm64:
@@ -1497,6 +1512,9 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ github.job }}
+          # only main's snapshots are saved; PR runs restore them via the
+          # base-branch fallback but must not multiply them per-ref
+          save: ${{ github.event_name == 'push' }}
       - name: Configure
         run: |
           cmake \
@@ -1542,7 +1560,7 @@ jobs:
           name: binaries-${{ github.job }}
           path: pfx/**/*
       - name: Trim ccache
-        if: always()
+        if: ${{ always() && github.event_name == 'push' }}
         run: ccache --evict-older-than 7d
 
   freebsd:
@@ -1676,6 +1694,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ github.job }}-${{ matrix.crypto.cmake }}
+          save: ${{ github.event_name == 'push' }}
       - name: Configure
         run: |
           cmake \
@@ -1721,7 +1740,7 @@ jobs:
           name: binaries-${{ github.job }}-${{ matrix.crypto.cmake }}
           path: pfx/**/*
       - name: Trim ccache
-        if: always()
+        if: ${{ always() && github.event_name == 'push' }}
         run: ccache --evict-older-than 7d
 
   openbsd:
@@ -1894,12 +1913,12 @@ jobs:
           path: pfx/**/*
 
   prune-ccache:
-    # The timestamped ccache keys used above are write-once: every run saves a
-    # new snapshot, and the one it supersedes is never restored again but only
-    # gets deleted by LRU pressure at the repo's 10 GB cache cap -- evicting
-    # still-useful caches (e.g. the prebuilt Windows deps) along the way.
-    # Sweep every ref and keep just the newest snapshot per key prefix. Runs
-    # only on pushes to main: PR runs from forks get a read-only token.
+    # The timestamped ccache keys used above are write-once: every push run
+    # saves a new snapshot, and the one it supersedes is never restored again
+    # but only gets deleted by LRU pressure at the repo's 10 GB cache cap --
+    # evicting still-useful caches (e.g. the prebuilt Windows deps) along the
+    # way. Sweep every ref and keep just the newest snapshot per key prefix.
+    # Runs only on pushes to main: PR runs from forks get a read-only token.
     needs: [ crypto, cxx23, debian, fedora, macos, macos-cmake-universal, sanitizer-tests-linux, sanitizer-tests-macos, ubuntu-24-04-arm64, utp-disabled, windows ]
     if: ${{ always() && github.event_name == 'push' }}
     runs-on: ubuntu-slim

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1518,8 +1518,6 @@ jobs:
     if: |
       needs.what-to-make.outputs.make-cli == 'true' ||
       needs.what-to-make.outputs.make-daemon == 'true' ||
-      needs.what-to-make.outputs.make-gtk == 'true' ||
-      needs.what-to-make.outputs.make-qt == 'true' ||
       needs.what-to-make.outputs.make-tests == 'true' ||
       needs.what-to-make.outputs.make-utils == 'true'
     runs-on: ubuntu-latest
@@ -1552,17 +1550,13 @@ jobs:
               cmake \
               dht \
               fast_float \
-              gettext \
-              `[ '${{ needs.what-to-make.outputs.make-gtk }}' = 'true' ] && echo gtkmm40` \
               libevent \
               libfmt \
               libnatpmp \
               libpsl \
               miniupnpc \
               ninja \
-              `[ '${{ needs.what-to-make.outputs.make-web }}' = 'true' ] && echo npm` \
               pkgconf \
-              `[ '${{ needs.what-to-make.outputs.make-qt }}' = 'true' ] && echo qt6-svg qt6-tools` \
               rapidjson \
               simdutf
           run: |
@@ -1576,12 +1570,12 @@ jobs:
               -DCMAKE_INSTALL_PREFIX=pfx \
               -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \
-              -DENABLE_GTK=${{ (needs.what-to-make.outputs.make-gtk == 'true') && 'ON' || 'OFF' }} \
+              -DENABLE_GTK=OFF `# GUI clients are covered on non-emulated runners` \
               -DENABLE_IPO=OFF `# LTO is too slow for a portability smoke test` \
-              -DENABLE_QT=${{ (needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }} \
+              -DENABLE_QT=OFF `# GUI clients are covered on non-emulated runners` \
               -DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_UTILS=${{ (needs.what-to-make.outputs.make-utils == 'true') && 'ON' || 'OFF' }} \
-              -DREBUILD_WEB=${{ (needs.what-to-make.outputs.make-web == 'true') && 'ON' || 'OFF' }} \
+              -DREBUILD_WEB=OFF \
               -DENABLE_WERROR=ON \
               -DRUN_CLANG_TIDY=OFF \
               -DUSE_SYSTEM_DEFAULT=ON \
@@ -1592,7 +1586,7 @@ jobs:
               -DWITH_CRYPTO=openssl
             cmake --build obj --config Release
             if [ '${{ needs.what-to-make.outputs.make-tests }}' = 'true' ]; then
-              QT_QPA_PLATFORM=offscreen cmake -E chdir obj ctest -j `getconf NPROCESSORS_ONLN` --build-config Release --output-on-failure
+              cmake -E chdir obj ctest -j `getconf NPROCESSORS_ONLN` --build-config Release --output-on-failure
             fi
             cmake --install obj --config Release --strip
             rm -rf obj src
@@ -1700,8 +1694,6 @@ jobs:
     if: |
       needs.what-to-make.outputs.make-cli == 'true' ||
       needs.what-to-make.outputs.make-daemon == 'true' ||
-      needs.what-to-make.outputs.make-gtk == 'true' ||
-      needs.what-to-make.outputs.make-qt == 'true' ||
       needs.what-to-make.outputs.make-tests == 'true' ||
       needs.what-to-make.outputs.make-utils == 'true'
     runs-on: ubuntu-latest
@@ -1733,16 +1725,12 @@ jobs:
               cmake \
               fast-float \
               fmt \
-              gettext-tools \
               gtar-- \
-              `[ '${{ needs.what-to-make.outputs.make-gtk }}' = 'true' ] && echo gtkmm40` \
               libevent \
               libnatpmp \
               libpsl \
               miniupnpc \
               ninja \
-              `[ '${{ needs.what-to-make.outputs.make-web }}' = 'true' ] && echo node` \
-              `[ '${{ needs.what-to-make.outputs.make-qt }}' = 'true' ] && echo qt6-qtsvg qt6-qttools` \
               rapidjson \
               simdutf
           run: |
@@ -1756,12 +1744,12 @@ jobs:
               -DCMAKE_INSTALL_PREFIX=pfx \
               -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \
-              -DENABLE_GTK=${{ (needs.what-to-make.outputs.make-gtk == 'true') && 'ON' || 'OFF' }} \
+              -DENABLE_GTK=OFF `# GUI clients are covered on non-emulated runners` \
               -DENABLE_IPO=OFF `# LTO is too slow for a portability smoke test` \
-              -DENABLE_QT=${{ (needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }} \
+              -DENABLE_QT=OFF `# GUI clients are covered on non-emulated runners` \
               -DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_UTILS=${{ (needs.what-to-make.outputs.make-utils == 'true') && 'ON' || 'OFF' }} \
-              -DREBUILD_WEB=${{ (needs.what-to-make.outputs.make-web == 'true') && 'ON' || 'OFF' }} \
+              -DREBUILD_WEB=OFF \
               -DENABLE_WERROR=ON \
               -DRUN_CLANG_TIDY=OFF \
               -DUSE_SYSTEM_DEFAULT=ON \
@@ -1772,7 +1760,7 @@ jobs:
               -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in OpenBSD`
             cmake --build obj --config Release
             if [ '${{ needs.what-to-make.outputs.make-tests }}' = 'true' ]; then
-              QT_QPA_PLATFORM=offscreen cmake -E chdir obj ctest -j `getconf NPROCESSORS_ONLN` --build-config Release --output-on-failure
+              cmake -E chdir obj ctest -j `getconf NPROCESSORS_ONLN` --build-config Release --output-on-failure
             fi
             cmake --install obj --config Release --strip
             rm -rf obj src
@@ -1786,8 +1774,6 @@ jobs:
     if: |
       needs.what-to-make.outputs.make-cli == 'true' ||
       needs.what-to-make.outputs.make-daemon == 'true' ||
-      needs.what-to-make.outputs.make-gtk == 'true' ||
-      needs.what-to-make.outputs.make-qt == 'true' ||
       needs.what-to-make.outputs.make-tests == 'true' ||
       needs.what-to-make.outputs.make-utils == 'true'
     runs-on: ubuntu-latest
@@ -1822,21 +1808,12 @@ jobs:
               fast_float \
               fmtlib \
               gcc14 \
-              gettext-tools \
-              `[ '${{ needs.what-to-make.outputs.make-gtk }}' = 'true' ] && echo gtkmm4` \
               libevent \
               libpsl \
               miniupnpc \
               ninja-build \
-              `[ '${{ needs.what-to-make.outputs.make-web }}' = 'true' ] && echo nodejs` \
               pkgconf \
-              `[ '${{ needs.what-to-make.outputs.make-qt }}' = 'true' ] && echo qt6-qtsvg qt6-qttools` \
               rapidjson
-            if [ '${{ needs.what-to-make.outputs.make-gtk }}' = 'true' ] || [ '${{ needs.what-to-make.outputs.make-qt }}' = 'true' ]; then
-              for set in xbase xcomp; do
-                curl -sL "https://cdn.netbsd.org/pub/NetBSD/NetBSD-`uname -r`/amd64/binary/sets/$set.tar.xz" | tar xJpf - -C /
-              done
-            fi
           run: |
             set -ex
             export TMPDIR=/var/tmp # gcc's LTO takes up a lot of space in TMPDIR, and /tmp is too small
@@ -1851,15 +1828,15 @@ jobs:
               -DCMAKE_C_COMPILER='/usr/pkg/gcc14/bin/gcc' \
               -DCMAKE_BUILD_RPATH='/usr/pkg/gcc14/lib' \
               -DCMAKE_INSTALL_PREFIX=pfx \
-              -DCMAKE_PREFIX_PATH='/usr/pkg/qt6;/usr/pkg' \
+              -DCMAKE_PREFIX_PATH='/usr/pkg' \
               -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \
-              -DENABLE_GTK=${{ (needs.what-to-make.outputs.make-gtk == 'true') && 'ON' || 'OFF' }} \
+              -DENABLE_GTK=OFF `# GUI clients are covered on non-emulated runners` \
               -DENABLE_IPO=OFF `# LTO is too slow for a portability smoke test` \
-              -DENABLE_QT=${{ (needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }} \
+              -DENABLE_QT=OFF `# GUI clients are covered on non-emulated runners` \
               -DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_UTILS=${{ (needs.what-to-make.outputs.make-utils == 'true') && 'ON' || 'OFF' }} \
-              -DREBUILD_WEB=${{ (needs.what-to-make.outputs.make-web == 'true') && 'ON' || 'OFF' }} \
+              -DREBUILD_WEB=OFF \
               -DENABLE_WERROR=ON \
               -DRUN_CLANG_TIDY=OFF \
               -DUSE_SYSTEM_DEFAULT=ON \
@@ -1872,7 +1849,7 @@ jobs:
               -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in NetBSD`
             cmake --build obj --config Release
             if [ '${{ needs.what-to-make.outputs.make-tests }}' = 'true' ]; then
-              QT_QPA_PLATFORM=offscreen cmake -E chdir obj ctest -j `getconf NPROCESSORS_ONLN` --build-config Release --output-on-failure
+              cmake -E chdir obj ctest -j `getconf NPROCESSORS_ONLN` --build-config Release --output-on-failure
             fi
             cmake --install obj --config Release --strip
             rm -rf obj src

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1576,6 +1576,7 @@ jobs:
               -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_GTK=${{ (needs.what-to-make.outputs.make-gtk == 'true') && 'ON' || 'OFF' }} \
+              -DENABLE_IPO=OFF `# LTO is too slow for a portability smoke test` \
               -DENABLE_QT=${{ (needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_UTILS=${{ (needs.what-to-make.outputs.make-utils == 'true') && 'ON' || 'OFF' }} \
@@ -1754,6 +1755,7 @@ jobs:
               -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_GTK=${{ (needs.what-to-make.outputs.make-gtk == 'true') && 'ON' || 'OFF' }} \
+              -DENABLE_IPO=OFF `# LTO is too slow for a portability smoke test` \
               -DENABLE_QT=${{ (needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_UTILS=${{ (needs.what-to-make.outputs.make-utils == 'true') && 'ON' || 'OFF' }} \
@@ -1849,6 +1851,7 @@ jobs:
               -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_GTK=${{ (needs.what-to-make.outputs.make-gtk == 'true') && 'ON' || 'OFF' }} \
+              -DENABLE_IPO=OFF `# LTO is too slow for a portability smoke test` \
               -DENABLE_QT=${{ (needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_UTILS=${{ (needs.what-to-make.outputs.make-utils == 'true') && 'ON' || 'OFF' }} \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1545,7 +1545,6 @@ jobs:
             set -ex
             uname -a
             pkg update
-            pkg upgrade -y
             pkg install -y \
               curl \
               cmake \
@@ -1725,7 +1724,6 @@ jobs:
           prepare: |
             set -ex
             uname -a
-            pkg_add -u
             pkg_add -I -v \
               curl \
               cmake \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1572,7 +1572,7 @@ jobs:
               -S src \
               -B obj \
               -G Ninja \
-              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+              -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX=pfx \
               -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \
@@ -1590,11 +1590,11 @@ jobs:
               -DUSE_SYSTEM_UTP=OFF `# Not packaged in FreeBSD` \
               -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in FreeBSD` \
               -DWITH_CRYPTO=openssl
-            cmake --build obj --config RelWithDebInfo
+            cmake --build obj --config Release
             if [ '${{ needs.what-to-make.outputs.make-tests }}' = 'true' ]; then
-              QT_QPA_PLATFORM=offscreen cmake -E chdir obj ctest -j `getconf NPROCESSORS_ONLN` --build-config RelWithDebInfo --output-on-failure
+              QT_QPA_PLATFORM=offscreen cmake -E chdir obj ctest -j `getconf NPROCESSORS_ONLN` --build-config Release --output-on-failure
             fi
-            cmake --install obj --config RelWithDebInfo --strip
+            cmake --install obj --config Release --strip
             rm -rf obj src
       - uses: actions/upload-artifact@v6
         with:
@@ -1752,7 +1752,7 @@ jobs:
               -S src \
               -B obj \
               -G Ninja \
-              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+              -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX=pfx \
               -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
               -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \
@@ -1770,11 +1770,11 @@ jobs:
               -DUSE_SYSTEM_SMALL=OFF `# Not packaged in OpenBSD` \
               -DUSE_SYSTEM_UTP=OFF `# Not packaged in OpenBSD` \
               -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in OpenBSD`
-            cmake --build obj --config RelWithDebInfo
+            cmake --build obj --config Release
             if [ '${{ needs.what-to-make.outputs.make-tests }}' = 'true' ]; then
-              QT_QPA_PLATFORM=offscreen cmake -E chdir obj ctest -j `getconf NPROCESSORS_ONLN` --build-config RelWithDebInfo --output-on-failure
+              QT_QPA_PLATFORM=offscreen cmake -E chdir obj ctest -j `getconf NPROCESSORS_ONLN` --build-config Release --output-on-failure
             fi
-            cmake --install obj --config RelWithDebInfo --strip
+            cmake --install obj --config Release --strip
             rm -rf obj src
       - uses: actions/upload-artifact@v6
         with:
@@ -1846,7 +1846,7 @@ jobs:
               -S src \
               -B obj \
               -G Ninja \
-              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+              -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_CXX_COMPILER='/usr/pkg/gcc14/bin/g++' \
               -DCMAKE_C_COMPILER='/usr/pkg/gcc14/bin/gcc' \
               -DCMAKE_BUILD_RPATH='/usr/pkg/gcc14/lib' \
@@ -1870,11 +1870,11 @@ jobs:
               -DUSE_SYSTEM_SMALL=OFF `# Not packaged in NetBSD` \
               -DUSE_SYSTEM_UTP=OFF `# Not packaged in NetBSD` \
               -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in NetBSD`
-            cmake --build obj --config RelWithDebInfo
+            cmake --build obj --config Release
             if [ '${{ needs.what-to-make.outputs.make-tests }}' = 'true' ]; then
-              QT_QPA_PLATFORM=offscreen cmake -E chdir obj ctest -j `getconf NPROCESSORS_ONLN` --build-config RelWithDebInfo --output-on-failure
+              QT_QPA_PLATFORM=offscreen cmake -E chdir obj ctest -j `getconf NPROCESSORS_ONLN` --build-config Release --output-on-failure
             fi
-            cmake --install obj --config RelWithDebInfo --strip
+            cmake --install obj --config Release --strip
             rm -rf obj src
       - uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -189,6 +189,9 @@ jobs:
           # disable container-overflow reports to avoid false errors
           # that are caused by Qt libraries not being asan instrumented
           extra-asan-options: detect_container_overflow=0
+      - name: Trim ccache
+        if: always()
+        run: ccache --evict-older-than 7d
 
   sanitizer-tests-macos:
     runs-on: macos-26
@@ -248,6 +251,9 @@ jobs:
           build-dir: obj
           build-config: Debug
           enable-sanitizers: true
+      - name: Trim ccache
+        if: always()
+        run: ccache --evict-older-than 7d
 
   sanitizer-tests-windows:
     runs-on: windows-2022
@@ -670,6 +676,9 @@ jobs:
         with:
           name: binaries-${{ matrix.os }}-cmake-universal
           path: pfx/**/*
+      - name: Trim ccache
+        if: always()
+        run: ccache --evict-older-than 7d
 
   alpine-musl:
     needs: [ what-to-make ]
@@ -726,7 +735,7 @@ jobs:
             -S . \
             -B obj \
             -G Ninja \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=pfx \
             -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \
@@ -746,15 +755,15 @@ jobs:
             -DUSE_SYSTEM_UTP=OFF `# Not packaged in Alpine` \
             -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in Alpine`
       - name: Make
-        run: cmake --build obj --config RelWithDebInfo
+        run: cmake --build obj --config Release
       - name: Test
         if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
         uses: ./.github/actions/run-tests
         with:
           build-dir: obj
-          build-config: RelWithDebInfo
+          build-config: Release
       - name: Install
-        run: cmake --install obj --config RelWithDebInfo --strip
+        run: cmake --install obj --config Release --strip
       - uses: actions/upload-artifact@v6
         with:
           name: binaries-${{ github.job }}
@@ -849,6 +858,9 @@ jobs:
         with:
           name: binaries-${{ github.job }}-${{ matrix.arch }}-msi
           path: obj/dist/msi/*.msi
+      - name: Trim ccache
+        if: always()
+        run: ccache --evict-older-than 7d
 
   make-source-tarball:
     runs-on: ubuntu-latest
@@ -977,6 +989,9 @@ jobs:
         with:
           name: binaries-${{ matrix.os }}
           path: pfx/**/*
+      - name: Trim ccache
+        if: always()
+        run: ccache --evict-older-than 7d
 
   debian:
     needs: [ make-source-tarball, what-to-make ]
@@ -1060,7 +1075,7 @@ jobs:
             -G Ninja \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=pfx \
             -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \
@@ -1091,19 +1106,23 @@ jobs:
 
           cmake "$@"
       - name: Build
-        run: cmake --build obj --config RelWithDebInfo
+        run: cmake --build obj --config Release
       - name: Test
         if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
         uses: ./.github/actions/run-tests
         with:
           build-dir: obj
-          build-config: RelWithDebInfo
+          build-config: Release
       - name: Install
-        run: cmake --install obj --config RelWithDebInfo --strip
+        run: cmake --install obj --config Release --strip
       - uses: actions/upload-artifact@v6
         with:
           name: binaries-${{ github.job }}-${{ matrix.version }}
           path: pfx/**/*
+      - name: Trim ccache
+        if: always()
+        # `|| true`: Debian 11's ccache predates --evict-older-than
+        run: ccache --evict-older-than 7d || true
       - name: Show ccache stats
         if: always()
         run: ccache --show-stats
@@ -1176,7 +1195,7 @@ jobs:
             -G Ninja \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=pfx \
             -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \
@@ -1196,19 +1215,23 @@ jobs:
             -DUSE_SYSTEM_UTP=OFF `# Not packaged in Fedora` \
             -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in Fedora`
       - name: Build
-        run: cmake --build obj --config RelWithDebInfo
+        run: cmake --build obj --config Release
       - name: Test
         if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
         uses: ./.github/actions/run-tests
         with:
           build-dir: obj
-          build-config: RelWithDebInfo
+          build-config: Release
       - name: Install
-        run: cmake --install obj --config RelWithDebInfo --strip
+        run: cmake --install obj --config Release --strip
       - uses: actions/upload-artifact@v6
         with:
           name: binaries-${{ github.job }}-${{ matrix.version }}
           path: pfx/**/*
+      - name: Trim ccache
+        if: always()
+        # `|| true`: Debian 11's ccache predates --evict-older-than
+        run: ccache --evict-older-than 7d || true
       - name: Show ccache stats
         if: always()
         run: ccache --show-stats
@@ -1266,7 +1289,7 @@ jobs:
             -G Ninja \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_COMPILER='clang++' \
             -DCMAKE_C_COMPILER='clang' \
             -DCMAKE_INSTALL_PREFIX=pfx \
@@ -1290,19 +1313,22 @@ jobs:
             -DUSE_SYSTEM_UTP=OFF `# Not packaged in Ubuntu` \
             -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in Ubuntu`
       - name: Make
-        run: cmake --build obj --config RelWithDebInfo
+        run: cmake --build obj --config Release
       - name: Test
         if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
         uses: ./.github/actions/run-tests
         with:
           build-dir: obj
-          build-config: RelWithDebInfo
+          build-config: Release
       - name: Install
-        run: cmake --install obj --config RelWithDebInfo --strip
+        run: cmake --install obj --config Release --strip
       - uses: actions/upload-artifact@v6
         with:
           name: binaries-${{ github.job }}-without-utp
           path: pfx/**/*
+      - name: Trim ccache
+        if: always()
+        run: ccache --evict-older-than 7d
 
   android:
     needs: [ what-to-make ]
@@ -1400,7 +1426,7 @@ jobs:
             -DCMAKE_CXX_STANDARD=23 \
             -DCMAKE_CXX_COMPILER='clang++' \
             -DCMAKE_C_COMPILER='clang' \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=pfx \
             -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold \
             -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
@@ -1421,7 +1447,10 @@ jobs:
             -DUSE_SYSTEM_UTP=OFF `# Not packaged in Ubuntu` \
             -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in Ubuntu`
       - name: Make
-        run: cmake --build obj --config RelWithDebInfo -- "-k 0"
+        run: cmake --build obj --config Release -- "-k 0"
+      - name: Trim ccache
+        if: always()
+        run: ccache --evict-older-than 7d
 
   ubuntu-24-04-arm64:
     needs: [ make-source-tarball, what-to-make ]
@@ -1478,7 +1507,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER='clang++' \
             -DCMAKE_C_COMPILER='clang' \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=pfx \
             -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold \
             -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
@@ -1499,19 +1528,22 @@ jobs:
             -DUSE_SYSTEM_UTP=OFF `# Not packaged in Ubuntu` \
             -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in Ubuntu`
       - name: Build
-        run: cmake --build obj --config RelWithDebInfo
+        run: cmake --build obj --config Release
       - name: Test
         if: needs.what-to-make.outputs.make-tests == 'true'
         uses: ./.github/actions/run-tests
         with:
           build-dir: obj
-          build-config: RelWithDebInfo
+          build-config: Release
       - name: Install
-        run: cmake --install obj --config RelWithDebInfo --strip
+        run: cmake --install obj --config Release --strip
       - uses: actions/upload-artifact@v6
         with:
           name: binaries-${{ github.job }}
           path: pfx/**/*
+      - name: Trim ccache
+        if: always()
+        run: ccache --evict-older-than 7d
 
   freebsd:
     needs: [ make-source-tarball, what-to-make ]
@@ -1652,7 +1684,7 @@ jobs:
             -G Ninja \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_COMPILER='clang++' \
             -DCMAKE_C_COMPILER='clang' \
             -DCMAKE_INSTALL_PREFIX=pfx \
@@ -1676,18 +1708,21 @@ jobs:
             -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in Ubuntu` \
             -DWITH_CRYPTO=${{ matrix.crypto.cmake }}
       - name: Make
-        run: cmake --build obj --config RelWithDebInfo
+        run: cmake --build obj --config Release
       - name: Test
         uses: ./.github/actions/run-tests
         with:
           build-dir: obj
-          build-config: RelWithDebInfo
+          build-config: Release
       - name: Install
-        run: cmake --install obj --config RelWithDebInfo --strip
+        run: cmake --install obj --config Release --strip
       - uses: actions/upload-artifact@v6
         with:
           name: binaries-${{ github.job }}-${{ matrix.crypto.cmake }}
           path: pfx/**/*
+      - name: Trim ccache
+        if: always()
+        run: ccache --evict-older-than 7d
 
   openbsd:
     needs: [ make-source-tarball, what-to-make ]
@@ -1857,3 +1892,32 @@ jobs:
         with:
           name: binaries-${{ github.job }}
           path: pfx/**/*
+
+  prune-ccache:
+    # The timestamped ccache keys used above are write-once: every run saves a
+    # new snapshot, and the one it supersedes is never restored again but only
+    # gets deleted by LRU pressure at the repo's 10 GB cache cap -- evicting
+    # still-useful caches (e.g. the prebuilt Windows deps) along the way.
+    # Sweep every ref and keep just the newest snapshot per key prefix. Runs
+    # only on pushes to main: PR runs from forks get a read-only token.
+    needs: [ crypto, cxx23, debian, fedora, macos, macos-cmake-universal, sanitizer-tests-linux, sanitizer-tests-macos, ubuntu-24-04-arm64, utp-disabled, windows ]
+    if: ${{ always() && github.event_name == 'push' }}
+    runs-on: ubuntu-slim
+    permissions:
+      actions: write
+    steps:
+      - name: Prune superseded ccache snapshots
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api --paginate 'repos/${{ github.repository }}/actions/caches?per_page=100' \
+            --jq '.actions_caches[] | select(.key | startswith("ccache-")) | [.id, .ref, .key, .created_at] | @tsv' |
+            sort -t $'\t' -k 4,4r |
+            awk -F '\t' '{
+              prefix = $3
+              sub(/-[0-9][0-9TZ:.-]*$/, "", prefix) # strip the timestamp / run-id suffix
+              if (seen[$2 "\t" prefix]++) {
+                print $1
+              }
+            }' |
+            xargs --no-run-if-empty -n 1 -I '{}' gh api -X DELETE 'repos/${{ github.repository }}/actions/caches/{}'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -86,6 +86,7 @@ jobs:
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
+        trap-caching: false
 
     - name: Build Project
       if: ${{ matrix.language == 'cpp' }}


### PR DESCRIPTION
The emulated BSD jobs are three of the slowest bottlenecks.

This PR tries to improve this with these BSD-specific changes:

- The biggie is don't do Qt / GTK builds there. Neither UI has BSD-specific code, and there are other jobs already exercising GTK3, GTK4, Qt5, Qt6 builds. The real benefit to the `Sanity / BSD` runs is building libtransmission on BSD.
- Be explicit about how much memory & how many CPUs the emulator can use. (Based on the `ubuntu-latest` runner specs from GitHub Actions hosted runners docs)
- Don't upgrade packages when we don't need to.
- Don't compile with debug info; these binaries are built to be thrown away anyway.
- Don't link with LTO; these binaries are built to be thrown away anyway.

*edit:* piggybacking on this PR to fix a CI limit I hadn't expected: we're hitting GitHub's 10GB cache limit, which causes Qt to have to be rebuilt more often on Windows. :skull:  Switch the builds-we-are-never-going-to-use-for-testing-or-nightlies to `CMAKE_BUILD_TYPE=Release` to reduce their ccache size by removing debug info. Add ccache pruning rules.