### PR TITLE
refactor: convert `tr_ctor` methods to use `std::span`

### DIFF
--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1655,27 +1655,27 @@ void torrentAdd(tr_session* session, tr_variant::Map const& args_in, tr_rpc_idle
 
     if (auto const val = args_in.find_if<tr_variant::Vector>(TR_KEY_files_unwanted); val != nullptr) {
         auto const files = file_list_from_list(*val);
-        ctor.set_files_wanted(std::data(files), std::size(files), false);
+        ctor.set_files_wanted(files, false);
     }
 
     if (auto const val = args_in.find_if<tr_variant::Vector>(TR_KEY_files_wanted); val != nullptr) {
         auto const files = file_list_from_list(*val);
-        ctor.set_files_wanted(std::data(files), std::size(files), true);
+        ctor.set_files_wanted(files, true);
     }
 
     if (auto const val = args_in.find_if<tr_variant::Vector>(TR_KEY_priority_low); val != nullptr) {
         auto const files = file_list_from_list(*val);
-        ctor.set_file_priorities(std::data(files), std::size(files), TR_PRI_LOW);
+        ctor.set_file_priorities(files, TR_PRI_LOW);
     }
 
     if (auto const* val = args_in.find_if<tr_variant::Vector>(TR_KEY_priority_normal); val != nullptr) {
         auto const files = file_list_from_list(*val);
-        ctor.set_file_priorities(std::data(files), std::size(files), TR_PRI_NORMAL);
+        ctor.set_file_priorities(files, TR_PRI_NORMAL);
     }
 
     if (auto const* val = args_in.find_if<tr_variant::Vector>(TR_KEY_priority_high); val != nullptr) {
         auto const files = file_list_from_list(*val);
-        ctor.set_file_priorities(std::data(files), std::size(files), TR_PRI_HIGH);
+        ctor.set_file_priorities(files, TR_PRI_HIGH);
     }
 
     if (auto const* val = args_in.find_if<tr_variant::Vector>(TR_KEY_labels); val != nullptr) {

--- a/libtransmission/torrent-ctor.h
+++ b/libtransmission/torrent-ctor.h
@@ -16,6 +16,7 @@
 #include <string_view>
 #include <vector>
 
+#include "libtransmission/macros.h"
 #include "libtransmission/torrent-metainfo.h"
 #include "libtransmission/torrent.h"
 #include "libtransmission/types.h"
@@ -72,29 +73,29 @@ public:
 
     // ---
 
-    void set_files_wanted(tr_file_index_t const* files, tr_file_index_t n_files, bool wanted)
+    TR_CONSTEXPR_VEC void set_files_wanted(std::span<tr_file_index_t const> const files, bool wanted)
     {
         auto& indices = wanted ? wanted_ : unwanted_;
-        indices.assign(files, files + n_files);
+        indices.assign(files.begin(), files.end());
     }
 
     void init_torrent_wanted(tr_torrent& tor) const;
 
     // ---
 
-    void set_file_priorities(tr_file_index_t const* const files, tr_file_index_t const n_files, tr_priority_t const priority)
+    TR_CONSTEXPR_VEC void set_file_priorities(std::span<tr_file_index_t const> const files, tr_priority_t const priority)
     {
         switch (priority) {
         case TR_PRI_LOW:
-            low_.assign(files, files + n_files);
+            low_.assign(files.begin(), files.end());
             break;
 
         case TR_PRI_HIGH:
-            high_.assign(files, files + n_files);
+            high_.assign(files.begin(), files.end());
             break;
 
         default: // TR_PRI_NORMAL
-            normal_.assign(files, files + n_files);
+            normal_.assign(files.begin(), files.end());
             break;
         }
     }

--- a/libtransmission/torrent-ctor.h
+++ b/libtransmission/torrent-ctor.h
@@ -57,7 +57,7 @@ public:
         return metainfo_.parseMagnet(magnet_link, error);
     }
 
-    [[nodiscard]] auto const& metainfo() const noexcept
+    [[nodiscard]] constexpr auto const& metainfo() const noexcept
     {
         return metainfo_;
     }
@@ -123,7 +123,7 @@ public:
         return optional_args_[mode].download_dir_;
     }
 
-    void set_download_dir(tr_ctorMode const mode, std::string_view const dir)
+    TR_CONSTEXPR_STR void set_download_dir(tr_ctorMode const mode, std::string_view const dir)
     {
         optional_args_[mode].download_dir_.assign(dir);
     }
@@ -135,7 +135,7 @@ public:
         return incomplete_dir_;
     }
 
-    void set_incomplete_dir(std::string_view const dir)
+    TR_CONSTEXPR_STR void set_incomplete_dir(std::string_view const dir)
     {
         incomplete_dir_.assign(dir);
     }
@@ -147,7 +147,7 @@ public:
         return labels_;
     }
 
-    void set_labels(tr_torrent::labels_t&& labels)
+    TR_CONSTEXPR_VEC void set_labels(tr_torrent::labels_t&& labels)
     {
         labels_ = std::move(labels);
     }


### PR DESCRIPTION
Notes: Moved from C++17 to C++20.

There should be no change in behaviour.