### PR TITLE
refactor: convert `tr_torrent_files` methods to use `std::span`

### DIFF
--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -110,16 +110,13 @@ bool is_junk_file(std::string_view filename)
 // ---
 
 std::optional<tr_torrent_files::FoundFile> tr_torrent_files::find(
-    tr_file_index_t file_index,
-    std::string_view const* paths,
-    size_t n_paths) const
+    tr_file_index_t const file_index,
+    std::span<std::string_view const> const paths) const
 {
     auto filename = tr_pathbuf{};
     auto const& subpath = path(file_index);
 
-    for (size_t path_idx = 0; path_idx < n_paths; ++path_idx) {
-        auto const base = paths[path_idx];
-
+    for (auto const base : paths) {
         filename.assign(base, '/', subpath);
         if (auto const info = tr_sys_path_get_info(filename); info) {
             return FoundFile{ *info, std::move(filename), std::size(base) };
@@ -134,10 +131,10 @@ std::optional<tr_torrent_files::FoundFile> tr_torrent_files::find(
     return {};
 }
 
-bool tr_torrent_files::has_any_local_data(std::string_view const* paths, size_t n_paths) const
+bool tr_torrent_files::has_any_local_data(std::span<std::string_view const> const paths) const
 {
     for (tr_file_index_t i = 0, n = file_count(); i < n; ++i) {
-        if (find(i, paths, n_paths)) {
+        if (find(i, paths)) {
             return true;
         }
     }
@@ -193,7 +190,7 @@ bool tr_torrent_files::move(
     auto err = bool{};
 
     for (tr_file_index_t i = 0, n = file_count(); i < n; ++i) {
-        auto const found = find(i, std::data(paths), std::size(paths));
+        auto const found = find(i, paths);
         if (!found) {
             continue;
         }
@@ -272,7 +269,7 @@ void tr_torrent_files::remove(
     // move the local data to the tmpdir
     auto const paths = std::to_array<std::string_view>({ parent.sv() });
     for (tr_file_index_t idx = 0, n_files = file_count(); idx < n_files; ++idx) {
-        if (auto const found = find(idx, std::data(paths), std::size(paths)); found) {
+        if (auto const found = find(idx, paths); found) {
             // if moving a file fails, give up and let the error propagate
             if (!tr_file_move(found->filename(), tr_pathbuf{ tmpdir, '/', found->subpath() }, false, error)) {
                 return;

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -11,6 +11,7 @@
 #include <functional>
 #include <iterator>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -149,8 +150,8 @@ public:
         size_t base_len_;
     };
 
-    [[nodiscard]] std::optional<FoundFile> find(tr_file_index_t file, std::string_view const* paths, size_t n_paths) const;
-    [[nodiscard]] bool has_any_local_data(std::string_view const* paths, size_t n_paths) const;
+    [[nodiscard]] std::optional<FoundFile> find(tr_file_index_t file_index, std::span<std::string_view const> paths) const;
+    [[nodiscard]] bool has_any_local_data(std::span<std::string_view const> paths) const;
     [[nodiscard]] std::string_view primary_mime_type() const;
 
     static void sanitize_subpath(std::string_view path, tr_pathbuf& append_me, bool os_specific = true);

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1097,7 +1097,7 @@ std::optional<tr_torrent_files::FoundFile> tr_torrent::find_file(tr_file_index_t
 
     auto paths = std::array<std::string_view, 4>{};
     auto const n_paths = buildSearchPathArray(this, std::data(paths));
-    return files().find(file_index, std::data(paths), n_paths);
+    return files().find(file_index, { paths.data(), n_paths });
 }
 
 bool tr_torrent::has_any_local_data() const
@@ -1106,7 +1106,7 @@ bool tr_torrent::has_any_local_data() const
 
     auto paths = std::array<std::string_view, 4>{};
     auto const n_paths = buildSearchPathArray(this, std::data(paths));
-    return files().has_any_local_data(std::data(paths), n_paths);
+    return files().has_any_local_data({ paths.data(), n_paths });
 }
 
 void tr_torrentSetDownloadDir(tr_torrent* tor, std::string_view const path)

--- a/tests/libtransmission/torrent-files-test.cc
+++ b/tests/libtransmission/torrent-files-test.cc
@@ -90,14 +90,14 @@ TEST_F(TorrentFilesTest, find)
     auto const search_path_2 = tr_pathbuf{ "/tmp"sv };
 
     auto search_path = std::vector<std::string_view>{ search_path_1.sv(), search_path_2.sv() };
-    auto found = files.find(file_index, std::data(search_path), std::size(search_path));
+    auto found = files.find(file_index, search_path);
     EXPECT_TRUE(found.has_value());
     assert(found.has_value());
     EXPECT_EQ(filename, found->filename());
 
     // same search, but with the search paths reversed
     search_path = std::vector<std::string_view>{ search_path_2.sv(), search_path_1.sv() };
-    found = files.find(file_index, std::data(search_path), std::size(search_path));
+    found = files.find(file_index, search_path);
     EXPECT_TRUE(found.has_value());
     assert(found.has_value());
     EXPECT_EQ(filename, found->filename());
@@ -106,21 +106,21 @@ TEST_F(TorrentFilesTest, find)
     auto const partial_filename = tr_pathbuf{ filename, tr_torrent_files::PartialFileSuffix };
     EXPECT_TRUE(tr_sys_path_rename(filename, partial_filename));
     search_path = std::vector<std::string_view>{ search_path_1.sv(), search_path_2.sv() };
-    found = files.find(file_index, std::data(search_path), std::size(search_path));
+    found = files.find(file_index, search_path);
     EXPECT_TRUE(found.has_value());
     assert(found.has_value());
     EXPECT_EQ(partial_filename, found->filename());
 
     // same search, but with the search paths reversed
     search_path = std::vector<std::string_view>{ search_path_2.sv(), search_path_1.sv() };
-    found = files.find(file_index, std::data(search_path), std::size(search_path));
+    found = files.find(file_index, search_path);
     EXPECT_TRUE(found.has_value());
     assert(found.has_value());
     EXPECT_EQ(partial_filename, found->filename());
 
     // what about if we look for a file that does not exist
     EXPECT_TRUE(tr_sys_path_remove(partial_filename));
-    EXPECT_FALSE(files.find(file_index, std::data(search_path), std::size(search_path)));
+    EXPECT_FALSE(files.find(file_index, search_path));
 }
 
 TEST_F(TorrentFilesTest, hasAnyLocalData)
@@ -135,11 +135,12 @@ TEST_F(TorrentFilesTest, hasAnyLocalData)
     auto const search_path_1 = tr_pathbuf{ sandboxDir() };
     auto const search_path_2 = tr_pathbuf{ "/tmp"sv };
 
-    auto search_path = std::vector<std::string_view>{ search_path_1.sv(), search_path_2.sv() };
-    EXPECT_TRUE(files.has_any_local_data(std::data(search_path), 2U));
-    EXPECT_TRUE(files.has_any_local_data(std::data(search_path), 1U));
-    EXPECT_FALSE(files.has_any_local_data(std::data(search_path) + 1, 1U));
-    EXPECT_FALSE(files.has_any_local_data(std::data(search_path), 0U));
+    auto const search_path = std::vector<std::string_view>{ search_path_1.sv(), search_path_2.sv() };
+    auto const span = std::span{ search_path };
+    EXPECT_TRUE(files.has_any_local_data(span));
+    EXPECT_TRUE(files.has_any_local_data(span.first(1U)));
+    EXPECT_FALSE(files.has_any_local_data(span.subspan(1U)));
+    EXPECT_FALSE(files.has_any_local_data({}));
 }
 
 TEST_F(TorrentFilesTest, mimeType)


### PR DESCRIPTION
Notes: Moved from C++17 to C++20.

There should be no change in behaviour.