### PR TITLE
ci: skip GTK build on Fedora rawhide

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -789,6 +789,9 @@ jobs:
           - arch: arm64
             runner: windows-11-arm
     runs-on: ${{ matrix.runner }}
+    env:
+      # /Z7 debug info compresses well; the default zstd level overflows the cache cap
+      CCACHE_COMPRESSLEVEL: '8'
     steps:
       - name: Show Configuration
         run: |
@@ -811,6 +814,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ github.job }}-${{ matrix.arch }}-${{ matrix.runner }}
+          max-size: 600M
           save: ${{ github.event_name == 'push' }}
       - name: Configure
         run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1162,7 +1162,10 @@ jobs:
         uses: ./.github/actions/install-deps
         with:
           compiler: gcc
-          enable-gtk: ${{ needs.what-to-make.outputs.make-gtk == 'true' && 'gtk4' || 'false' }}
+          # TODO(ci): rawhide's glibmm2.68 2.88.1 FTBFS against glib 2.89's gtkmm/giomm
+          # headers (conflicting GDBusActionGroupClass/GEmblemClass); skip GTK there
+          # until Fedora rebuilds glibmm. Upstream skew, not a Transmission bug.
+          enable-gtk: ${{ needs.what-to-make.outputs.make-gtk == 'true' && matrix.version != 'rawhide' && 'gtk4' || 'false' }}
           enable-qt: ${{ needs.what-to-make.outputs.make-qt == 'true' && 'qt6' || 'false' }}
           use-sudo: false
           enable-mold: true
@@ -1195,7 +1198,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=pfx \
             -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \
-            -DENABLE_GTK=${{ (needs.what-to-make.outputs.make-gtk == 'true') && 'ON' || 'OFF' }} \
+            -DENABLE_GTK=${{ (needs.what-to-make.outputs.make-gtk == 'true' && matrix.version != 'rawhide') && 'ON' || 'OFF' }} `# rawhide: see enable-gtk note above` \
             -DENABLE_MAC=OFF \
             -DENABLE_QT=${{ (needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }} \


### PR DESCRIPTION
Disable the GTK build on the `fedora (rawhide)` matrix leg. CLI, daemon, Qt, and tests still build there.

Rawhide bumped glib 2.89.1 to  2.89.2 overnight. That change converts `GDBusActionGroup` and `GEmblem` to `G_DECLARE_FINAL_TYPE`. Its headers now emit `GDBusActionGroupClass` / `GEmblemClass` typedefs that conflict with the forward declarations in **glibmm2.68 2.88.1** (still generated against glib 2.88). This is an upstream packaging but, not a Transmission issue.

Added a TODO to re-enable this after Fedora rebuilds `glibmm2.68`.