### PR TITLE
fix: app defaults ignored when loading settings

### DIFF
--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -373,9 +373,7 @@ void periodic_update(evutil_socket_t /*fd*/, short /*what*/, void* arg)
 
 [[nodiscard]] auto load_settings(std::string_view const config_dir)
 {
-    auto settings = tr_sessionLoadSettings(config_dir);
-    settings.merge(get_default_settings());
-    return settings;
+    return tr_sessionLoadSettings(config_dir, get_default_settings());
 }
 
 } // namespace

--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -84,9 +84,7 @@ std::string gl_confdir;
 
 [[nodiscard]] auto load_settings(std::string_view const config_dir)
 {
-    auto settings = tr_sessionLoadSettings(config_dir);
-    settings.merge(get_default_app_settings());
-    return settings;
+    return tr_sessionLoadSettings(config_dir, get_default_app_settings());
 }
 
 } // namespace

--- a/libtransmission-app/prefs.cc
+++ b/libtransmission-app/prefs.cc
@@ -31,9 +31,10 @@ namespace
     // get pre-existing settings from the settings config file
     auto fallbacks = tr::settings::load(settings_filename);
 
-    // fill in any missing values with defaults (eg missing/incomplete config file)
-    fallbacks.merge(tr_sessionGetDefaultSettings());
+    // fill in any missing values with the app's defaults,
+    // then with libtransmission's defaults (eg missing/incomplete config file)
     fallbacks.merge(tr::serializer::save(AppPrefs{}, SessionPrefs{}));
+    fallbacks.merge(tr_sessionGetDefaultSettings());
 
     return fallbacks;
 }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -453,10 +453,11 @@ tr::Settings tr_sessionGetSettings(tr_session const* session)
     return settings;
 }
 
-tr::Settings tr_sessionLoadSettings(std::string_view const config_dir)
+tr::Settings tr_sessionLoadSettings(std::string_view const config_dir, tr::Settings const& app_defaults)
 {
-    auto settings = tr::settings::load(get_settings_filename(config_dir));
-    settings.merge(tr_sessionGetDefaultSettings());
+    auto settings = tr::settings::load(get_settings_filename(config_dir)); // file vals
+    settings.merge(app_defaults); // fallbacks from app defaults
+    settings.merge(tr_sessionGetDefaultSettings()); // fallbacks from defaults
     return settings;
 }
 

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -73,8 +73,9 @@ namespace tr::platform
 [[nodiscard]] tr::Settings tr_sessionGetSettings(tr_session const* session);
 
 // Load settings from disk.
-// Fills in any missing settings with defaults from `tr_sessionGetDefaultSettings()`.
-[[nodiscard]] tr::Settings tr_sessionLoadSettings(std::string_view config_dir);
+// Fills in any missing settings with `app_defaults`,
+// then with defaults from `tr_sessionGetDefaultSettings()`.
+[[nodiscard]] tr::Settings tr_sessionLoadSettings(std::string_view config_dir, tr::Settings const& app_defaults = {});
 
 // Save `session`'s settings to disk.
 void tr_sessionSaveSettings(tr_session* session, std::string_view config_dir, tr::Settings const& app_settings);

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -478,8 +478,8 @@ static void removeKeRangerRansomware()
         //upgrading from versions < 2.40: clear recent items
         [NSDocumentController.sharedDocumentController clearRecentDocuments:nil];
 
-        auto settings = tr_sessionGetDefaultSettings();
-        settings.merge(getSettingsFromNSUserDefaults(_fDefaults));
+        auto settings = getSettingsFromNSUserDefaults(_fDefaults);
+        settings.merge(tr_sessionGetDefaultSettings());
 
         initUnits();
 

--- a/tests/libtransmission/session-test.cc
+++ b/tests/libtransmission/session-test.cc
@@ -22,6 +22,7 @@
 #include <libtransmission/quark.h>
 #include <libtransmission/session-id.h>
 #include <libtransmission/session.h>
+#include <libtransmission/tr-strbuf.h>
 #include <libtransmission/variant.h>
 #include <libtransmission/version.h>
 
@@ -310,6 +311,35 @@ TEST_F(SessionTest, getDefaultSettingsIncludesSubmodules)
         ASSERT_TRUE(flag);
         EXPECT_FALSE(*flag);
     }
+}
+
+TEST_F(SessionTest, loadSettingsHonorsAppDefaults)
+{
+    // `rpc_enabled` is `false` in libtransmission's defaults,
+    // but apps, e.g. the daemon, may default it to `true`
+    static auto constexpr Key = TR_KEY_rpc_enabled;
+    auto const config_dir = tr_pathbuf{ sandboxDir(), "/app-defaults-config"sv };
+    auto app_defaults = tr::Settings{};
+    app_defaults.try_emplace(Key, true);
+
+    // app defaults fill in keys missing from the settings file
+    // and take precedence over libtransmission's defaults
+    auto settings = tr_sessionLoadSettings(config_dir, app_defaults);
+    auto flag = settings.value_if<bool>(Key);
+    ASSERT_TRUE(flag);
+    EXPECT_TRUE(*flag);
+
+    // values from the settings file take precedence over app defaults
+    createFileWithContents(tr_pathbuf{ config_dir, "/settings.json"sv }, R"({ "rpc-enabled": false })");
+    settings = tr_sessionLoadSettings(config_dir, app_defaults);
+    flag = settings.value_if<bool>(Key);
+    ASSERT_TRUE(flag);
+    EXPECT_FALSE(*flag);
+
+    // keys absent from both fall back to libtransmission's defaults
+    flag = settings.value_if<bool>(TR_KEY_peer_port_random_on_start);
+    ASSERT_TRUE(flag);
+    EXPECT_FALSE(*flag);
 }
 
 TEST_F(SessionTest, honorsSettings)


### PR DESCRIPTION
Fix a `map::merge()` semantics bug introduced in fbc36e29d when `tr_variant::Map::merge()` was refactored to make its semantics match `std::map::merge()`, I missed a couple of callsites that needed their logic updated.

Add a regression test to confirm the fix.

I'm marking marking as `notes:none` since this regression was never included in any releases

AI disclosure:
- I have reviewed everything in this PR.
- Tests written by Claude Opus 4.8.
