### PR TITLE
fix: `tr_clientForPeer()`

### DIFF
--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -597,6 +597,9 @@ auto constexpr Clients = std::to_array<Client>({
 // the equal_range() lookup below requires this ordering
 static_assert(std::ranges::is_sorted(Clients, {}, &Client::begins_with));
 
+auto constexpr MaxPrefixLen = std::ranges::max(
+    Clients | std::views::transform([](Client const& client) { return std::size(client.begins_with); }));
+
 } // namespace
 
 void tr_clientForId(char* buf, size_t buflen, tr_peer_id_t peer_id)
@@ -614,25 +617,14 @@ void tr_clientForId(char* buf, size_t buflen, tr_peer_id_t peer_id)
         return;
     }
 
-    struct Compare {
-        bool operator()(std::string_view const& key, Client const& client) const
-        {
-            return key.substr(0, std::min(std::size(key), std::size(client.begins_with))) < client.begins_with;
+    // find the longest `begins_with` that starts `key`, e.g. an id matching
+    // both "-WT" and "-WT-" is formatted by the "-WT-" entry
+    for (auto len = MaxPrefixLen; len > 0U; --len) {
+        auto const [eq_begin, eq_end] = std::ranges::equal_range(Clients, key.substr(0, len), {}, &Client::begins_with);
+        if (eq_begin != eq_end) {
+            eq_begin->formatter(buf, buflen, eq_begin->name, peer_id);
+            return;
         }
-        bool operator()(Client const& client, std::string_view const& key) const
-        {
-            return client.begins_with < key.substr(0, std::min(std::size(key), std::size(client.begins_with)));
-        }
-    };
-
-    // NOLINTNEXTLINE(modernize-use-ranges)
-    if (auto const [eq_begin, eq_end] = std::equal_range(std::begin(Clients), std::end(Clients), key, Compare{});
-        eq_begin != eq_end) {
-        // multiple entries can match when one's prefix extends another's,
-        // e.g. "-WT" and "-WT-"; they're sorted, so the longest match is last
-        auto const& client = *std::prev(eq_end);
-        client.formatter(buf, buflen, client.name, peer_id);
-        return;
     }
 
     // no match

--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -451,7 +451,7 @@ constexpr void xfplay_formatter(char* buf, size_t buflen, std::string_view name,
 void xtorrent_formatter(char* buf, size_t buflen, std::string_view name, tr_peer_id_t id)
 {
     std::tie(buf, buflen) = buf_append(buf, buflen, name, ' ', base62str(id[3]), '.', base62str(id[4]), " ("sv);
-    *fmt::format_to_n(buf, buflen - 1, "{:d}", strint(&id[5], 2)).out = '\0';
+    *fmt::format_to_n(buf, buflen - 1, "{:d})", strint(&id[5], 2)).out = '\0';
 }
 
 struct Client {

--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -145,6 +145,9 @@ bool decodeShad0wClient(char* buf, size_t buflen, std::string_view in)
     while (!std::empty(peer_id) && peer_id.back() == '-') {
         peer_id.remove_suffix(1);
     }
+    if (std::empty(peer_id)) { // e.g. an all-dashes id
+        return false;
+    }
     auto vals = std::vector<int>{};
     while (std::size(peer_id) > 1) {
         auto const num = get_shad0w_int(peer_id.back());

--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -591,6 +591,9 @@ auto constexpr Clients = std::to_array<Client>({
     { .begins_with = "martini", .name = "Martini Man", .formatter = no_version_formatter },
 });
 
+// the equal_range() lookup below requires this ordering
+static_assert(std::ranges::is_sorted(Clients, {}, &Client::begins_with));
+
 } // namespace
 
 void tr_clientForId(char* buf, size_t buflen, tr_peer_id_t peer_id)
@@ -621,8 +624,11 @@ void tr_clientForId(char* buf, size_t buflen, tr_peer_id_t peer_id)
 
     // NOLINTNEXTLINE(modernize-use-ranges)
     if (auto const [eq_begin, eq_end] = std::equal_range(std::begin(Clients), std::end(Clients), key, Compare{});
-        eq_begin != std::end(Clients) && eq_begin != eq_end) {
-        eq_begin->formatter(buf, buflen, eq_begin->name, peer_id);
+        eq_begin != eq_end) {
+        // multiple entries can match when one's prefix extends another's,
+        // e.g. "-WT" and "-WT-"; they're sorted, so the longest match is last
+        auto const& client = *std::prev(eq_end);
+        client.formatter(buf, buflen, client.name, peer_id);
         return;
     }
 

--- a/tests/libtransmission/clients-test.cc
+++ b/tests/libtransmission/clients-test.cc
@@ -63,6 +63,7 @@ TEST(Client, clientForId)
         { .peer_id = "-UW1110Q"sv, .expected_client = "\xc2\xb5Torrent Web 1.1.10"sv }, // wider version
         { .peer_id = "-WS1000-"sv, .expected_client = "HTTP Seed"sv },
         { .peer_id = "-WT-abcd"sv, .expected_client = "BitLet"sv }, // nested prefix: "-WT-" must win over "-WT"
+        { .peer_id = "-XC1230-"sv, .expected_client = "Xtorrent 1.2 (30)"sv },
         { .peer_id = "-WW0007-"sv, .expected_client = "WebTorrent 0.0.0.7"sv },
         { .peer_id = "-XF9990-"sv,
           .expected_client = "Xfplay 9.9.9"sv }, // Older Xfplay versions have three digit version number

--- a/tests/libtransmission/clients-test.cc
+++ b/tests/libtransmission/clients-test.cc
@@ -63,6 +63,7 @@ TEST(Client, clientForId)
         { .peer_id = "-UW1110Q"sv, .expected_client = "\xc2\xb5Torrent Web 1.1.10"sv }, // wider version
         { .peer_id = "-WS1000-"sv, .expected_client = "HTTP Seed"sv },
         { .peer_id = "-WT-abcd"sv, .expected_client = "BitLet"sv }, // nested prefix: "-WT-" must win over "-WT"
+        { .peer_id = "-WTX250-"sv, .expected_client = "BitLet 33.2.5.0"sv }, // matches "-WT" but sorts after "-WT-"
         { .peer_id = "-XC1230-"sv, .expected_client = "Xtorrent 1.2 (30)"sv },
         { .peer_id = "-WW0007-"sv, .expected_client = "WebTorrent 0.0.0.7"sv },
         { .peer_id = "-XF9990-"sv,
@@ -73,9 +74,11 @@ TEST(Client, clientForId)
         { .peer_id = "FD6k4SYy9BOU4U4rk3-J"sv,
           .expected_client = "Free Download Manager 6"sv }, // Free Download Manager 6.17.0.4792 (9a17ce2)
         { .peer_id = "Mbrst1-1-3"sv, .expected_client = "burst! 1.1.3"sv }, // nested prefix: "Mbrst" must win over "M"
+        { .peer_id = "MzABCDEF"sv, .expected_client = "BitTorrent"sv }, // matches "M" but sorts after "Mbrst"
         { .peer_id = "S58B-----"sv, .expected_client = "Shad0w 5.8.11"sv },
         { .peer_id = "Q1-23-4-"sv, .expected_client = "Queen Bee 1.23.4"sv },
         { .peer_id = "QVOD0054"sv, .expected_client = "QVOD 0.0.5.4"sv }, // nested prefix: "QVOD" must win over "Q"
+        { .peer_id = "QW111111"sv, .expected_client = "Queen Bee"sv }, // matches "Q" but sorts after "QVOD"
         { .peer_id = "TIX0193-"sv, .expected_client = "Tixati 1.93"sv },
         { .peer_id = "\x65\x78\x62\x63\x00\x38\x4C\x4F\x52\x44\x32\x00\x04\x8E\xCE\xD5\x7B\xD7\x10\x28"sv,
           .expected_client = "BitLord 0.56"sv },

--- a/tests/libtransmission/clients-test.cc
+++ b/tests/libtransmission/clients-test.cc
@@ -42,6 +42,7 @@ TEST(Client, clientForId)
           .expected_client = "Free Download Manager 5.1.x"sv }, // Free Download Manager 5.1.38.7312 (79f26aa)
         { .peer_id = "-FL51FF-"sv, .expected_client = "Folx 5.x"sv }, // Folx v5.2.1.13690
         { .peer_id = "-FW6830-"sv, .expected_client = "FrostWire 6.8.3"sv },
+        { .peer_id = "---------"sv, .expected_client = "--------"sv }, // all-dashes id must not crash the Shad0w decoder
         { .peer_id = "-IIO\x10\x2D\x04-"sv, .expected_client = "-IIO%10-%04-"sv },
         { .peer_id = "-I\05O\x08\x03\x01-"sv, .expected_client = "-I%05O%08%03%01-"sv },
         { .peer_id = "-KT33D1-"sv, .expected_client = "KTorrent 3.3 Dev 1"sv },

--- a/tests/libtransmission/clients-test.cc
+++ b/tests/libtransmission/clients-test.cc
@@ -61,6 +61,7 @@ TEST(Client, clientForId)
         { .peer_id = "-UW110Q-"sv, .expected_client = "\xc2\xb5Torrent Web 1.1.0"sv },
         { .peer_id = "-UW1110Q"sv, .expected_client = "\xc2\xb5Torrent Web 1.1.10"sv }, // wider version
         { .peer_id = "-WS1000-"sv, .expected_client = "HTTP Seed"sv },
+        { .peer_id = "-WT-abcd"sv, .expected_client = "BitLet"sv }, // nested prefix: "-WT-" must win over "-WT"
         { .peer_id = "-WW0007-"sv, .expected_client = "WebTorrent 0.0.0.7"sv },
         { .peer_id = "-XF9990-"sv,
           .expected_client = "Xfplay 9.9.9"sv }, // Older Xfplay versions have three digit version number
@@ -69,8 +70,10 @@ TEST(Client, clientForId)
         { .peer_id = "A2-1-2-0-"sv, .expected_client = "aria2 1.2.0"sv },
         { .peer_id = "FD6k4SYy9BOU4U4rk3-J"sv,
           .expected_client = "Free Download Manager 6"sv }, // Free Download Manager 6.17.0.4792 (9a17ce2)
+        { .peer_id = "Mbrst1-1-3"sv, .expected_client = "burst! 1.1.3"sv }, // nested prefix: "Mbrst" must win over "M"
         { .peer_id = "S58B-----"sv, .expected_client = "Shad0w 5.8.11"sv },
         { .peer_id = "Q1-23-4-"sv, .expected_client = "Queen Bee 1.23.4"sv },
+        { .peer_id = "QVOD0054"sv, .expected_client = "QVOD 0.0.5.4"sv }, // nested prefix: "QVOD" must win over "Q"
         { .peer_id = "TIX0193-"sv, .expected_client = "Tixati 1.93"sv },
         { .peer_id = "\x65\x78\x62\x63\x00\x38\x4C\x4F\x52\x44\x32\x00\x04\x8E\xCE\xD5\x7B\xD7\x10\x28"sv,
           .expected_client = "BitLord 0.56"sv },


### PR DESCRIPTION
Fix a couple of edge cases in the get-human-readable-torrent-appname utility that could misidentify some apps.

Notes: Fixed bugs that could misidentify which torrent software a peer was using.

AI disclosure:
- I have reviewed all changes in this PR.
- The bugs were found & fixed by Claude Opus 4.8. 
- Regression tests added by Claude Opus 4.8.
