### PR TITLE
chore: allow braceless single-line statement bodies

### DIFF
--- a/gtk/.clang-tidy
+++ b/gtk/.clang-tidy
@@ -18,6 +18,7 @@ Checks:
   - -cppcoreguidelines-pro-bounds-constant-array-index
   - -cppcoreguidelines-use-enum-class
   - hicpp-*
+  - -hicpp-braces-around-statements # alias of `readability-braces-around-statements`
   - -hicpp-no-array-decay # alias of `cppcoreguidelines-pro-bounds-array-to-pointer-decay`
   - -hicpp-special-member-functions # alias of `cppcoreguidelines-special-member-functions`
   - -hicpp-use-nullptr # alias of `modernize-use-nullptr`
@@ -45,4 +46,5 @@ CheckOptions:
   - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros, value: true }
   - { key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic, value: true }
   - { key: modernize-pass-by-value.ValuesOnly, value: true }
+  - { key: readability-braces-around-statements.ShortStatementLines, value: 2 }
   - { key: readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix, value: true }

--- a/libtransmission-app/.clang-tidy
+++ b/libtransmission-app/.clang-tidy
@@ -60,6 +60,7 @@ CheckOptions:
   - { key: cppcoreguidelines-rvalue-reference-param-not-moved.IgnoreUnnamedParams,  value: true       }
   - { key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor,         value: true       }
   - { key: performance-move-const-arg.CheckTriviallyCopyableMove,                   value: false      }
+  - { key: readability-braces-around-statements.ShortStatementLines,                value: 2          }
   - { key: readability-identifier-naming.ConstexprVariableCase,                     value: CamelCase  }
   - { key: readability-identifier-naming.ParameterCase,                             value: lower_case }
   - { key: readability-identifier-naming.PrivateMemberSuffix,                       value: _          }

--- a/libtransmission/.clang-tidy
+++ b/libtransmission/.clang-tidy
@@ -63,6 +63,7 @@ CheckOptions:
   - { key: cppcoreguidelines-rvalue-reference-param-not-moved.IgnoreUnnamedParams,  value: true       }
   - { key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor,         value: true       }
   - { key: performance-move-const-arg.CheckTriviallyCopyableMove,                   value: false      }
+  - { key: readability-braces-around-statements.ShortStatementLines,                value: 2          }
   - { key: readability-identifier-naming.ConstexprVariableCase,                     value: CamelCase  }
   - { key: readability-identifier-naming.ParameterCase,                             value: lower_case }
   - { key: readability-identifier-naming.PrivateMemberSuffix,                       value: _          }

--- a/qt/.clang-tidy
+++ b/qt/.clang-tidy
@@ -26,8 +26,10 @@ Checks:
   - -cppcoreguidelines-pro-type-const-cast
   - -cppcoreguidelines-use-enum-class
   - google-readability-*
+  - -google-readability-braces-around-statements # alias of `readability-braces-around-statements`
   - google-runtime-operator
   - hicpp-*
+  - -hicpp-braces-around-statements # alias of `readability-braces-around-statements`
   - -hicpp-multiway-paths-covered
   - -hicpp-named-parameter # alias of `readability-named-parameter`
   - -hicpp-signed-bitwise
@@ -59,6 +61,7 @@ Checks:
 
 CheckOptions:
   - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros,                   value: true       }
+  - { key: readability-braces-around-statements.ShortStatementLines,        value: 2          }
   - { key: readability-identifier-naming.ClassCase,                         value: CamelCase  }
 #  - { key: readability-identifier-naming.ClassMethodCase,                   value: lower_case } TODO: enable later
   - { key: readability-identifier-naming.ConstexprVariableCase,             value: CamelCase  }

--- a/tests/libtransmission/.clang-tidy
+++ b/tests/libtransmission/.clang-tidy
@@ -24,8 +24,10 @@ Checks:
   - -cppcoreguidelines-pro-type-reinterpret-cast
   - -cppcoreguidelines-use-enum-class
   - google-readability-*
+  - -google-readability-braces-around-statements # alias of `readability-braces-around-statements`
   - google-runtime-operator
   - hicpp-*
+  - -hicpp-braces-around-statements # alias of `readability-braces-around-statements`
   - -hicpp-signed-bitwise
   - -hicpp-use-nullptr # alias of `modernize-use-nullptr
   - misc-*
@@ -51,6 +53,7 @@ Checks:
 
 CheckOptions:
   - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros,                   value: true       }
+  - { key: readability-braces-around-statements.ShortStatementLines,        value: 2          }
   - { key: readability-identifier-naming.ClassCase,                         value: CamelCase  }
   - { key: readability-identifier-naming.ClassMethodCase,                   value: camelBack  }
   - { key: readability-identifier-naming.ConstexprVariableCase,             value: CamelCase  }

--- a/tests/qt/.clang-tidy
+++ b/tests/qt/.clang-tidy
@@ -59,6 +59,7 @@ CheckOptions:
   - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros,                           value: true       }
   - { key: cppcoreguidelines-rvalue-reference-param-not-moved.IgnoreUnnamedParams,  value: true       }
   - { key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor,         value: true       }
+  - { key: readability-braces-around-statements.ShortStatementLines,                value: 2          }
   - { key: readability-identifier-naming.ConstexprVariableCase,                     value: CamelCase  }
   - { key: readability-identifier-naming.ParameterCase,                             value: lower_case }
   - { key: readability-identifier-naming.PrivateMemberSuffix,                       value: _          }


### PR DESCRIPTION
A followup to #28, when we change the brace style from Allman to Linux. This one is more opinionated, so I'm making it a standalone PR where it can get approved or rejected on its own.

tldr, I'd like to be able to omit braces in an `if` statement if the clause is only a single line:

```c++
if (foo) { // <-- braces required before this PR; still allowed with this PR
  bar();
}

if (foo) // <-- this PR: braceless allowed, but not required
  bar();

if (baz) { // <-- unchanged
  qux();
  thud();
}
```

This is 100% opinion and probably comes from me spending a lot of time in the Chromium codebase. 