### PR TITLE
build: escape strings inside `tr_add_external_auto_library`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -537,14 +537,12 @@ endif()
 # CMAKE_* variables. Only the tar/zip/raw formats + the gzip (zlib) filter are
 # enabled; everything else is turned off to keep it lean. Its gzip support needs
 # zlib, so forward our prefix path (where the Windows build stages zlib) to the
-# sub-build's find_package(ZLIB). Escape the list separator for
-# ExternalProject so the whole prefix path survives as one -D value.
-string(REPLACE ";" "$<SEMICOLON>" ARCHIVE_CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
+# sub-build's find_package(ZLIB).
 tr_add_external_auto_library(ARCHIVE libarchive
     LIBNAME archive
     TARGET libarchive::libarchive
     CMAKE_ARGS
-        "-DCMAKE_PREFIX_PATH:STRING=${ARCHIVE_CMAKE_PREFIX_PATH}"
+        "-DCMAKE_PREFIX_PATH:STRING=${CMAKE_PREFIX_PATH}"
         -DBUILD_SHARED_LIBS:BOOL=OFF
         -DENABLE_INSTALL:BOOL=ON
         -DENABLE_TEST:BOOL=OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -537,12 +537,9 @@ endif()
 # CMAKE_* variables. Only the tar/zip/raw formats + the gzip (zlib) filter are
 # enabled; everything else is turned off to keep it lean. Its gzip support needs
 # zlib, so forward our prefix path (where the Windows build stages zlib) to the
-# sub-build's find_package(ZLIB). Convert native backslashes to CMake-style
-# forward slashes first, otherwise a Windows path (e.g. D:\x86-prefix) trips
-# cmake_parse_arguments with an "invalid character escape" error; then escape
-# the list separator for ExternalProject.
-string(REPLACE "\\" "/" ARCHIVE_CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
-string(REPLACE ";" "$<SEMICOLON>" ARCHIVE_CMAKE_PREFIX_PATH "${ARCHIVE_CMAKE_PREFIX_PATH}")
+# sub-build's find_package(ZLIB). Escape the list separator for
+# ExternalProject so the whole prefix path survives as one -D value.
+string(REPLACE ";" "$<SEMICOLON>" ARCHIVE_CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
 tr_add_external_auto_library(ARCHIVE libarchive
     LIBNAME archive
     TARGET libarchive::libarchive

--- a/cmake/TrMacros.cmake
+++ b/cmake/TrMacros.cmake
@@ -157,12 +157,11 @@ function(tr_process_list_conditions VAR_PREFIX)
     set(${VAR_PREFIX}_DISALLOWED "${DISALLOWED_ITEMS}" PARENT_SCOPE)
 endfunction()
 
-macro(tr_add_external_auto_library ID PACKAGENAME)
-    cmake_parse_arguments(_TAEAL_ARG
+function(tr_add_external_auto_library ID PACKAGENAME)
+    cmake_parse_arguments(PARSE_ARGV 2 _TAEAL_ARG
         "SUBPROJECT;HEADER_ONLY"
         "LIBNAME;SOURCE_DIR;TARGET"
-        "CMAKE_ARGS;COMPONENTS"
-        ${ARGN})
+        "CMAKE_ARGS;COMPONENTS")
 
     set(_TAEAL_SOURCE_DIR "${TR_THIRD_PARTY_SOURCE_DIR}")
     set(_TAEAL_BINARY_DIR "${TR_THIRD_PARTY_BINARY_DIR}")
@@ -302,7 +301,7 @@ macro(tr_add_external_auto_library ID PACKAGENAME)
     if(_TAEAL_ARG_TARGET AND NOT TARGET ${_TAEAL_ARG_TARGET})
         message(FATAL_ERROR "Build system is misconfigured, this shouldn't happen! Can't find target '${_TAEAL_ARG_TARGET}'")
     endif()
-endmacro()
+endfunction()
 
 function(tr_append_target_property TGT PROP VAL)
     get_target_property(OVAL ${TGT} ${PROP})

--- a/cmake/TrMacros.cmake
+++ b/cmake/TrMacros.cmake
@@ -247,6 +247,14 @@ function(tr_add_external_auto_library ID PACKAGENAME)
                 "-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT:STRING=${CMAKE_MSVC_DEBUG_INFORMATION_FORMAT}")
         endif()
 
+        set(_TAEAL_ESCAPED_CMAKE_ARGS)
+        foreach(ARG IN LISTS _TAEAL_ARG_CMAKE_ARGS)
+            # ExternalProject_Add() forwards CMAKE_ARGS as a list, so preserve
+            # semicolons that belong to individual -D values.
+            string(REPLACE ";" "$<SEMICOLON>" _TAEAL_ESCAPED_ARG "${ARG}")
+            list(APPEND _TAEAL_ESCAPED_CMAKE_ARGS "${_TAEAL_ESCAPED_ARG}")
+        endforeach()
+
         ExternalProject_Add(
             ${${PACKAGENAME}_UPSTREAM_TARGET}
             PREFIX "${_TAEAL_BINARY_DIR}"
@@ -271,7 +279,7 @@ function(tr_add_external_auto_library ID PACKAGENAME)
                 "-DCMAKE_INSTALL_LIBDIR:STRING=lib"
                 "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${CMAKE_INTERPROCEDURAL_OPTIMIZATION}"
                 ${${PACKAGENAME}_EXT_PROJ_CMAKE_ARGS}
-                ${_TAEAL_ARG_CMAKE_ARGS}
+                ${_TAEAL_ESCAPED_CMAKE_ARGS}
             BUILD_BYPRODUCTS "${${PACKAGENAME}_LIBRARY}")
 
         set_property(TARGET ${${PACKAGENAME}_UPSTREAM_TARGET} PROPERTY FOLDER "${TR_THIRD_PARTY_DIR_NAME}")


### PR DESCRIPTION
- Convert `tr_add_external_auto_library` into a function and use `cmake_parse_arguments`'s `PARSE_ARGV` signature, so that the caller don't need to escape strings before passing in values.
- Escape semi-colons `;` within `tr_add_external_auto_library` before calling `ExternalProject_Add`, so the caller doesn't have to.