### PR TITLE
ci: stop cache thrashing in GitHub Actions

### DIFF
--- a/.github/CACHE_POLICY.md
+++ b/.github/CACHE_POLICY.md
@@ -1,0 +1,54 @@
+# CI cache policy
+
+GitHub Actions gives this repository 10 GiB of cache storage. The goal is
+one generation of every cache family, small enough that a generation plus
+the replacements briefly coexisting with it stays under that limit.
+
+## Cache classes
+
+### Compiler output (ccache)
+
+`setup-ccache` derives one key per job from the job name, an optional
+matrix suffix, and the workflow-level `CACHE_SCHEMA`; `finalize-ccache`
+trims, saves, verifies, and deletes the snapshots it supersedes. Pull
+requests restore main's newest snapshot and never save. Jobs whose working
+set outgrows the trim window pass a shorter `trim-age`; the local size
+limit is deliberately generous because trimming, not the limit, governs
+persisted size.
+
+Jobs delete their own superseded snapshots rather than leaving them all to
+the janitor so that, within a push, the cache never holds much more than
+one generation -- the janitor alone would let two full generations coexist
+until the last build finished.
+
+### Incremental analysis (ctcache)
+
+clang-tidy results are keyed by toolkit and configuration hash and saved
+on every run, pull requests included: PR-side reuse is the point, and fork
+PRs' read-only tokens could not supersede anyway, so the janitor collapses
+each family to its newest snapshot instead.
+
+### Content-addressed dependencies
+
+Windows dependency prefixes, Android vcpkg binaries, and the BSD VM images
+are keyed by their inputs, so identical keys hold identical bytes. Branch
+copies are deleted once main holds the same key and version; every branch
+can restore main's copy through the base-branch fallback. Gradle's caches
+are excluded: gradle/actions manages its own rotation.
+
+## Repository maintenance
+
+After all cache producers finish, the janitor (`prune-caches`) removes
+superseded snapshots, keys from retired `CACHE_SCHEMA` generations, and
+branch copies shadowed by main, then warns when usage crosses 9 GiB.
+Families that stop being produced age out through the provider's 7-day
+unused-entry eviction.
+
+When adding a cache:
+
+1. Include every compiler, platform, configuration, or dependency input
+   that changes whether an entry can be reused.
+2. Use a content-addressed key for immutable dependencies.
+3. Use `setup-ccache`/`finalize-ccache` for evolving compiler output.
+4. Add the producing job to the janitor's `needs` list.
+5. Account for its steady-state size within the 9 GiB warning threshold.

--- a/.github/actions/clang-tidy-cached/action.yml
+++ b/.github/actions/clang-tidy-cached/action.yml
@@ -34,52 +34,46 @@ inputs:
 runs:
   using: composite
   steps:
-    # The cache key hashes only the repo's own .clang-tidy files (not '**', which
-    # would also pick up the cloned ctcache-tool) so restore and save agree.
+    - name: Get ctcache
+      shell: bash
+      run: git clone --depth 1 --branch '${{ inputs.ctcache-ref }}' https://github.com/matus-chochlik/ctcache '${{ runner.temp }}/ctcache-tool'
+    - name: Set up the ctcache environment
+      shell: bash
+      env:
+        # the negation keeps vendored projects' .clang-tidy files out of the key
+        STORE_KEY: ctcache-${{ inputs.cache-key }}-${{ hashFiles('**/.clang-tidy', '!third-party/**') }}
+      run: |
+        {
+          echo "CTCACHE_LOCAL=1"
+          echo "CTCACHE_DIR=${{ runner.temp }}/ctcache-store"
+          echo "CTCACHE_STRIP=${{ github.workspace }}"
+          echo "CTCACHE_CLIENT=${{ runner.temp }}/ctcache-tool/src/ctcache/clang_tidy_cache.py"
+          echo "CTCACHE_STORE_KEY=$STORE_KEY"
+          echo "PY=$(command -v python3 || command -v python)"
+          echo "TIDY_REGEX=${{ inputs.regex }}"
+          echo "BUILD_PATH=${{ inputs.build-path }}"
+          echo "CLANG_TIDY=${{ inputs.clang-tidy-binary }}"
+          echo "TIDY_EXTRA_ARG=${{ inputs.extra-arg }}"
+        } >> "$GITHUB_ENV"
     - name: Restore ctcache
       uses: actions/cache/restore@v5
       with:
         path: ${{ runner.temp }}/ctcache-store
-        key: ctcache-${{ inputs.cache-key }}-${{ hashFiles('libtransmission/.clang-tidy', 'libtransmission-app/.clang-tidy', 'gtk/.clang-tidy', 'qt/.clang-tidy', 'tests/libtransmission/.clang-tidy', 'tests/qt/.clang-tidy') }}-${{ github.run_id }}
+        key: ${{ env.CTCACHE_STORE_KEY }}-${{ github.run_id }}
         restore-keys: |
-          ctcache-${{ inputs.cache-key }}-${{ hashFiles('libtransmission/.clang-tidy', 'libtransmission-app/.clang-tidy', 'gtk/.clang-tidy', 'qt/.clang-tidy', 'tests/libtransmission/.clang-tidy', 'tests/qt/.clang-tidy') }}-
-    - name: Get ctcache
-      shell: bash
-      run: git clone --depth 1 --branch ${{ inputs.ctcache-ref }} https://github.com/matus-chochlik/ctcache ctcache-tool
+          ${{ env.CTCACHE_STORE_KEY }}-
     - name: Zero ctcache stats
       shell: bash
-      env:
-        CTCACHE_LOCAL: '1'
-        CTCACHE_DIR: ${{ runner.temp }}/ctcache-store
       run: |
         mkdir -p "$CTCACHE_DIR"
-        py=$(command -v python3 || command -v python || echo python)
-        "$py" ctcache-tool/src/ctcache/clang_tidy_cache.py --zero-stats || true
+        "$PY" "$CTCACHE_CLIENT" --zero-stats || true
     - name: Run clang-tidy (ctcache)
       if: ${{ inputs.msvc-env != 'true' }}
       shell: bash
-      env:
-        CTCACHE_LOCAL: '1'
-        CTCACHE_DIR: ${{ runner.temp }}/ctcache-store
-        CTCACHE_STRIP: ${{ github.workspace }}
-        CTCACHE_CLIENT: ctcache-tool/src/ctcache/clang_tidy_cache.py
-        TIDY_REGEX: ${{ inputs.regex }}
-        BUILD_PATH: ${{ inputs.build-path }}
-        CLANG_TIDY: ${{ inputs.clang-tidy-binary }}
-        TIDY_EXTRA_ARG: ${{ inputs.extra-arg }}
       run: bash .github/actions/clang-tidy-cached/run.sh
     - name: Run clang-tidy (ctcache, MSVC)
       if: ${{ inputs.msvc-env == 'true' }}
       shell: pwsh
-      env:
-        CTCACHE_LOCAL: '1'
-        CTCACHE_DIR: ${{ runner.temp }}/ctcache-store
-        CTCACHE_STRIP: ${{ github.workspace }}
-        CTCACHE_CLIENT: ctcache-tool/src/ctcache/clang_tidy_cache.py
-        TIDY_REGEX: ${{ inputs.regex }}
-        BUILD_PATH: ${{ inputs.build-path }}
-        CLANG_TIDY: ${{ inputs.clang-tidy-binary }}
-        TIDY_EXTRA_ARG: ${{ inputs.extra-arg }}
       run: |
         # ctcache preprocesses each TU with the compile-DB compiler (cl.exe) to
         # compute its hash, and cl.exe -E needs the MSVC environment.
@@ -87,15 +81,11 @@ runs:
     - name: Show ctcache stats
       if: ${{ always() }}
       shell: bash
-      env:
-        CTCACHE_LOCAL: '1'
-        CTCACHE_DIR: ${{ runner.temp }}/ctcache-store
       run: |
-        py=$(command -v python3 || command -v python || echo python)
-        "$py" ctcache-tool/src/ctcache/clang_tidy_cache.py --show-stats | grep -i 'local' || true
+        "$PY" "$CTCACHE_CLIENT" --show-stats | grep -i 'local' || true
     - name: Save ctcache
       if: ${{ always() }}
       uses: actions/cache/save@v5
       with:
         path: ${{ runner.temp }}/ctcache-store
-        key: ctcache-${{ inputs.cache-key }}-${{ hashFiles('libtransmission/.clang-tidy', 'libtransmission-app/.clang-tidy', 'gtk/.clang-tidy', 'qt/.clang-tidy', 'tests/libtransmission/.clang-tidy', 'tests/qt/.clang-tidy') }}-${{ github.run_id }}
+        key: ${{ env.CTCACHE_STORE_KEY }}-${{ github.run_id }}

--- a/.github/actions/clang-tidy-cached/filter-compile-commands.py
+++ b/.github/actions/clang-tidy-cached/filter-compile-commands.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import re
+import sys
+
+
+def main() -> int:
+    database_path, pattern, root = sys.argv[1:]
+    matcher = re.compile(pattern)
+    with open(database_path, encoding="utf-8") as database_file:
+        commands = json.load(database_file)
+
+    seen = set()
+    for command in commands:
+        filename = command["file"]
+        relative = os.path.relpath(filename, root).replace("\\", "/")
+        if matcher.match(relative) and filename not in seen:
+            seen.add(filename)
+            print(filename)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/actions/clang-tidy-cached/run.sh
+++ b/.github/actions/clang-tidy-cached/run.sh
@@ -14,6 +14,7 @@
 #   TIDY_REGEX      (required) regex matched (anchored) against workspace-relative
 #                   paths, e.g. (libtransmission|tests/libtransmission)/.*
 #   CTCACHE_CLIENT  (required) path to ctcache's clang_tidy_cache.py
+#   PY              (required) Python interpreter
 #   BUILD_PATH      (default: obj) dir containing compile_commands.json
 #   CLANG_TIDY      (default: clang-tidy) real clang-tidy executable
 #   TIDY_EXTRA_ARG  (optional) single -extra-arg value appended to every invocation
@@ -23,11 +24,11 @@ set -uo pipefail
 
 : "${TIDY_REGEX:?set TIDY_REGEX}"
 : "${CTCACHE_CLIENT:?set CTCACHE_CLIENT}"
+: "${PY:?set PY}"
 build_path="${BUILD_PATH:-obj}"
 clang_tidy="${CLANG_TIDY:-clang-tidy}"
 extra_arg="${TIDY_EXTRA_ARG:-}"
-
-py="$(command -v python3 || command -v python)"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 if command -v nproc >/dev/null 2>&1; then jobs="$(nproc)"
 elif [ -n "${NUMBER_OF_PROCESSORS:-}" ]; then jobs="$NUMBER_OF_PROCESSORS"
@@ -43,20 +44,7 @@ fi
 # paths (with backslashes normalised) so a repo-dir regex like 'gtk/.*' can
 # never match generated TUs under the build dir (e.g. obj/gtk/*-resources.c,
 # obj/qt/*_autogen/mocs_compilation.cpp), which have no .clang-tidy config.
-if ! files_out="$("$py" - "$db" <<'PY'
-import json, os, re, sys
-db = sys.argv[1]
-rx = os.environ["TIDY_REGEX"]
-root = os.getcwd()
-seen = set()
-for e in json.load(open(db)):
-    f = e["file"]
-    rel = os.path.relpath(f, root).replace("\\", "/")
-    if re.match(rx, rel) and f not in seen:
-        seen.add(f)
-        print(f)
-PY
-)"; then
+if ! files_out="$("$PY" "$script_dir/filter-compile-commands.py" "$db" "$TIDY_REGEX" "$PWD")"; then
   echo "::error::failed to read '$db'"
   exit 1
 fi
@@ -76,7 +64,7 @@ extra=()
 
 printf '%s\0' "${files[@]}" \
   | xargs -0 -P "$jobs" -I{} \
-      "$py" "$CTCACHE_CLIENT" "$clang_tidy" "{}" -p "$build_path" -quiet -warnings-as-errors='*' "${extra[@]}"
+      "$PY" "$CTCACHE_CLIENT" "$clang_tidy" "{}" -p "$build_path" -quiet -warnings-as-errors='*' "${extra[@]}"
 rc=$?
 
 if [ "$rc" -ne 0 ]; then

--- a/.github/actions/finalize-ccache/action.yml
+++ b/.github/actions/finalize-ccache/action.yml
@@ -1,0 +1,67 @@
+name: Finalize ccache
+description: >
+  Trim ccache, save a successful main-branch snapshot, verify it is visible,
+  then delete older snapshots from the same cache family.
+inputs:
+  trim-age:
+    description: Age passed to ccache --evict-older-than
+    default: 7d
+  ignore-trim-errors:
+    description: Continue saving when the installed ccache cannot trim by age
+    default: 'false'
+runs:
+  using: composite
+  steps:
+    - name: Validate ccache environment
+      if: ${{ github.ref == 'refs/heads/main' }}
+      shell: bash
+      run: |
+        : "${CCACHE_KEY:?setup-ccache did not set CCACHE_KEY}"
+        : "${CCACHE_DIR:?CCACHE_DIR is unset; workflow env or setup-ccache container mode must set it}"
+    - name: Trim ccache
+      if: ${{ github.ref == 'refs/heads/main' }}
+      shell: bash
+      env:
+        IGNORE_TRIM_ERRORS: ${{ inputs.ignore-trim-errors }}
+        TRIM_AGE: ${{ inputs.trim-age }}
+      run: ccache --evict-older-than "$TRIM_AGE" || [ "$IGNORE_TRIM_ERRORS" = 'true' ]
+    - name: Save replacement snapshot
+      if: ${{ github.ref == 'refs/heads/main' }}
+      uses: actions/cache/save@v5
+      with:
+        path: ${{ env.CCACHE_DIR }}
+        key: ccache-${{ env.CCACHE_KEY }}-${{ github.run_id }}
+    - name: Delete superseded snapshots
+      # github-script rather than gh: this step also runs inside the debian
+      # and fedora containers, which mount node for JS actions but carry no
+      # GitHub CLI.
+      if: ${{ github.ref == 'refs/heads/main' }}
+      uses: actions/github-script@v8
+      env:
+        KEEP: ccache-${{ env.CCACHE_KEY }}-${{ github.run_id }}
+        PREFIX: ccache-${{ env.CCACHE_KEY }}-
+      with:
+        script: |
+          const caches = await github.paginate(github.rest.actions.getActionsCacheList, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            key: process.env.PREFIX,
+            ref: 'refs/heads/main',
+            per_page: 100,
+          });
+          if (!caches.some(cache => cache.key === process.env.KEEP)) {
+            core.warning(`replacement ${process.env.KEEP} is not visible; keeping superseded snapshots`);
+            return;
+          }
+          for (const cache of caches) {
+            if (cache.key === process.env.KEEP) {
+              continue;
+            }
+            core.info(`deleting ${cache.key} (${(cache.size_in_bytes / 1048576).toFixed(1)} MB)`);
+            // the entry can vanish between the listing and the delete
+            await github.rest.actions.deleteActionsCacheById({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              cache_id: cache.id,
+            }).catch(() => {});
+          }

--- a/.github/actions/prepare-deps-win32/action.yml
+++ b/.github/actions/prepare-deps-win32/action.yml
@@ -1,4 +1,5 @@
 name: Prepare Win32 build dependencies
+description: Restore or build the cached Windows dependency prefix
 inputs:
   arch:
     description: Architecture (x86, x64)
@@ -12,24 +13,20 @@ runs:
     - name: Get Build Tools
       shell: pwsh
       run: |
+        $RepoRoot = if (Test-Path (Join-Path . 'src/release/windows/main.ps1')) { Join-Path . 'src' } else { (Get-Item .).FullName }
         $DepsPrefix = (Join-Path (Get-Item .).Root.Name "${{ inputs.arch }}-prefix")
+        "REPO_ROOT=${RepoRoot}" | Out-File $Env:GITHUB_ENV -Append
         "DEPS_PREFIX=${DepsPrefix}" | Out-File $Env:GITHUB_ENV -Append
         (Join-Path $DepsPrefix bin) | Out-File $Env:GITHUB_PATH -Append
 
-        choco install `
-          jom `
-          nasm `
-          wixtoolset
+        # the preinstalled OpenSSL would shadow the built one at configure time
         & "C:\Program Files\OpenSSL\unins000.exe" /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- | Out-Host
-        (Join-Path $Env:ProgramFiles NASM) | Out-File $Env:GITHUB_PATH -Append
-        (Join-Path (Get-Item -Path "${Env:ProgramFiles(x86)}\WiX Toolset v3.*")[0].FullName bin) | Out-File $Env:GITHUB_PATH -Append
     - name: Get Cache Key
       id: cache-key
       shell: pwsh
       run: |
-        $RepoRoot = if (Test-Path (Join-Path . 'src/release/windows/main.ps1')) { Join-Path . 'src' } else { (Get-Item .).FullName }
         try {
-            $DepsHash = & (Join-Path $RepoRoot release windows main.ps1) -Mode DepsHash -BuildArch ${{ inputs.arch }} -BuildPart ${{ inputs.type }}
+            $DepsHash = & (Join-Path $Env:REPO_ROOT release windows main.ps1) -Mode DepsHash -BuildArch ${{ inputs.arch }} -BuildPart ${{ inputs.type }}
             "hash=${DepsHash}" | Out-File $Env:GITHUB_OUTPUT -Append
         } catch {
             Write-Error ("{1}{0}{2}{0}{3}" -f [Environment]::NewLine, $_.ToString(), $_.InvocationInfo.PositionMessage, $_.ScriptStackTrace) -ErrorAction Continue
@@ -40,14 +37,17 @@ runs:
       id: restore-cache
       with:
         path: ${{ env.DEPS_PREFIX }}
-        key: win-deps-${{ inputs.arch }}-${{ steps.cache-key.outputs.hash }}
+        key: win-deps-${{ inputs.arch }}-${{ inputs.type }}-${{ steps.cache-key.outputs.hash }}
     - name: Build Dependencies
       if: steps.restore-cache.outputs.cache-hit != 'true'
       shell: pwsh
       run: |
-        $RepoRoot = if (Test-Path (Join-Path . 'src/release/windows/main.ps1')) { Join-Path . 'src' } else { (Get-Item .).FullName }
+        choco install `
+          jom `
+          nasm
+        $Env:PATH = "$(Join-Path $Env:ProgramFiles NASM);$Env:PATH"
         try {
-            & (Join-Path $RepoRoot release windows main.ps1) -Mode Build -BuildArch ${{ inputs.arch }} -BuildPart ${{ inputs.type }}
+            & (Join-Path $Env:REPO_ROOT release windows main.ps1) -Mode Build -BuildArch ${{ inputs.arch }} -BuildPart ${{ inputs.type }}
         } catch {
             Write-Error ("{1}{0}{2}{0}{3}" -f [Environment]::NewLine, $_.ToString(), $_.InvocationInfo.PositionMessage, $_.ScriptStackTrace) -ErrorAction Continue
             exit 1
@@ -58,4 +58,4 @@ runs:
       id: cache
       with:
         path: ${{ env.DEPS_PREFIX }}
-        key: win-deps-${{ inputs.arch }}-${{ steps.cache-key.outputs.hash }}
+        key: win-deps-${{ inputs.arch }}-${{ inputs.type }}-${{ steps.cache-key.outputs.hash }}

--- a/.github/actions/setup-ccache/action.yml
+++ b/.github/actions/setup-ccache/action.yml
@@ -1,0 +1,56 @@
+name: Setup ccache
+description: >
+  Derive this job's ccache key, export it as CCACHE_KEY for finalize-ccache,
+  and restore the newest matching snapshot without scheduling a post-job save.
+inputs:
+  in-container:
+    description: >
+      Restore with plain actions/cache instead of the ccache action.
+      Container jobs need this: the workflow-level CCACHE_DIR holds the
+      host's workspace path, and ccache comes from the image's package
+      manager rather than a downloaded static build.
+    default: 'false'
+  key-suffix:
+    description: Extra key component for matrix jobs (e.g. the cell's os or arch)
+    default: ''
+  max-size:
+    description: >
+      Local ccache size limit. This is build-time headroom, not the
+      persisted size -- finalize-ccache's trim governs what a snapshot
+      keeps. A limit under the working set makes ccache clean mid-build,
+      and mid-build cleanup cannot tell dead churn from entries the build
+      has not reached yet.
+    default: 1G
+runs:
+  using: composite
+  steps:
+    - name: Derive the cache key
+      shell: bash
+      env:
+        KEY_SUFFIX: ${{ inputs.key-suffix }}
+      run: |
+        if [ -z "$CACHE_SCHEMA" ]; then
+          echo '::error::CACHE_SCHEMA is unset; define it in the workflow env'
+          exit 1
+        fi
+        echo "CCACHE_KEY=${{ github.job }}${KEY_SUFFIX:+-$KEY_SUFFIX}-$CACHE_SCHEMA" >> "$GITHUB_ENV"
+    - name: Point ccache at the container workspace
+      if: ${{ inputs.in-container == 'true' }}
+      shell: bash
+      run: |
+        echo "CCACHE_DIR=$GITHUB_WORKSPACE/.ccache" >> "$GITHUB_ENV"
+        echo "CCACHE_MAXSIZE=${{ inputs.max-size }}" >> "$GITHUB_ENV"
+    - name: Restore ccache
+      if: ${{ inputs.in-container == 'true' }}
+      uses: actions/cache/restore@v5
+      with:
+        path: ${{ env.CCACHE_DIR }}
+        key: ccache-${{ env.CCACHE_KEY }}-
+        restore-keys: |
+          ccache-${{ env.CCACHE_KEY }}-
+    - if: ${{ inputs.in-container != 'true' }}
+      uses: hendrikmuhs/ccache-action@v1.2.23
+      with:
+        key: ${{ env.CCACHE_KEY }}
+        max-size: ${{ inputs.max-size }}
+        save: false

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,7 +11,20 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  # ccache jobs and the cache janitor delete superseded cache entries
+  actions: write
+
 env:
+  # See .github/CACHE_POLICY.md for cache classes, lifecycle, and budget.
+  CACHE_LIMIT_GIB: '10'
+  CACHE_WARNING_GIB: '9'
+  # Bumping CACHE_SCHEMA re-keys every ccache family; the janitor deletes
+  # keys that do not carry the current value.
+  CACHE_SCHEMA: cache-v2
+  CCACHE_COMPRESSLEVEL: '5'
+  CCACHE_DIR: ${{ github.workspace }}/.ccache
   GTEST_OUTPUT: xml:./
 jobs:
   what-to-make:
@@ -141,12 +154,7 @@ jobs:
           enable-qt: qt6
           use-sudo: true
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
-        with:
-          key: ${{ github.job }}
-          # only main's snapshots are saved; PR runs restore them via the
-          # base-branch fallback but must not multiply them per-ref
-          save: ${{ github.event_name == 'push' }}
+        uses: ./.github/actions/setup-ccache
       - name: Configure
         run: |
           cmake \
@@ -190,9 +198,8 @@ jobs:
           # disable container-overflow reports to avoid false errors
           # that are caused by Qt libraries not being asan instrumented
           extra-asan-options: detect_container_overflow=0
-      - name: Trim ccache
-        if: ${{ always() && github.event_name == 'push' }}
-        run: ccache --evict-older-than 7d
+      - name: Finalize ccache
+        uses: ./.github/actions/finalize-ccache
 
   sanitizer-tests-macos:
     runs-on: macos-26
@@ -213,12 +220,7 @@ jobs:
         with:
           compiler: clang
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
-        with:
-          key: ${{ github.job }}
-          # only main's snapshots are saved; PR runs restore them via the
-          # base-branch fallback but must not multiply them per-ref
-          save: ${{ github.event_name == 'push' }}
+        uses: ./.github/actions/setup-ccache
       - name: Configure
         run: |
           cmake \
@@ -255,9 +257,8 @@ jobs:
           build-dir: obj
           build-config: Debug
           enable-sanitizers: true
-      - name: Trim ccache
-        if: ${{ always() && github.event_name == 'push' }}
-        run: ccache --evict-older-than 7d
+      - name: Finalize ccache
+        uses: ./.github/actions/finalize-ccache
 
   sanitizer-tests-windows:
     runs-on: windows-2022
@@ -632,10 +633,9 @@ jobs:
           enable-gtk: ${{ needs.what-to-make.outputs.make-gtk == 'true' && 'gtk4' || 'false' }}
           enable-qt: ${{ needs.what-to-make.outputs.make-qt == 'true' && 'qt6' || 'false' }}
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: ./.github/actions/setup-ccache
         with:
-          key: ${{ github.job }}-${{ matrix.os }}
-          save: ${{ github.event_name == 'push' }}
+          key-suffix: ${{ matrix.os }}
       - name: Configure
         run: |
           cmake \
@@ -681,9 +681,10 @@ jobs:
         with:
           name: binaries-${{ matrix.os }}-cmake-universal
           path: pfx/**/*
-      - name: Trim ccache
-        if: ${{ always() && github.event_name == 'push' }}
-        run: ccache --evict-older-than 7d
+      - name: Finalize ccache
+        uses: ./.github/actions/finalize-ccache
+        with:
+          trim-age: 3d
 
   alpine-musl:
     needs: [ what-to-make ]
@@ -779,14 +780,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # IPO only on the x64 reference cell: it carries the LTO coverage
+        # and the release-shaped artifacts. The other cells build without
+        # it -- no /LTCG time on throwaway binaries, and since the flag is
+        # the same on push and PR, main's ccache snapshots warm PR builds.
         include:
           - arch: x86
+            ipo: 'OFF'
             runner: windows-2022
           - arch: x64
+            ipo: 'ON'
             runner: windows-2022
           - arch: x64
+            ipo: 'OFF'
             runner: windows-2025-vs2026
           - arch: arm64
+            ipo: 'OFF'
             runner: windows-11-arm
     runs-on: ${{ matrix.runner }}
     env:
@@ -811,11 +820,9 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: ./.github/actions/setup-ccache
         with:
-          key: ${{ github.job }}-${{ matrix.arch }}-${{ matrix.runner }}
-          max-size: 600M
-          save: ${{ github.event_name == 'push' }}
+          key-suffix: ${{ matrix.arch }}-${{ matrix.runner }}-ipo-${{ matrix.ipo }}
       - name: Configure
         run: |
           $CmakeArgs = @(
@@ -833,6 +840,7 @@ jobs:
             "-DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }}"
             "-DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-dist == 'true') && 'ON' || 'OFF' }}"
             '-DENABLE_GTK=OFF'
+            "-DENABLE_IPO=${{ matrix.ipo }}"
             '-DENABLE_MAC=OFF'
             "-DENABLE_QT=${{ (needs.what-to-make.outputs.make-dist == 'true' || needs.what-to-make.outputs.make-qt == 'true') && 'ON' || 'OFF' }}"
             "-DENABLE_TESTS=${{ (needs.what-to-make.outputs.make-tests == 'true') && 'ON' || 'OFF' }}"
@@ -855,21 +863,27 @@ jobs:
           timeout: 600
       - name: Install
         run: cmake --install obj --config RelWithDebInfo
+      - name: Get Packaging Tools
+        if: ${{ needs.what-to-make.outputs.make-dist == 'true' || (needs.what-to-make.outputs.make-daemon == 'true' && needs.what-to-make.outputs.make-qt == 'true') }}
+        run: |
+          choco install wixtoolset
+          (Join-Path (Get-Item -Path "${Env:ProgramFiles(x86)}\WiX Toolset v3.*")[0].FullName bin) | Out-File $Env:GITHUB_PATH -Append
       - name: Package
         if: ${{ needs.what-to-make.outputs.make-dist == 'true' || (needs.what-to-make.outputs.make-daemon == 'true' && needs.what-to-make.outputs.make-qt == 'true') }}
         run: |
           cmd /c "`"$Env:VCVARSALL`" $Env:VC_ARCH >nul && cmake --build obj --config RelWithDebInfo --target pack-msi"
       - uses: actions/upload-artifact@v6
         with:
-          name: binaries-${{ github.job }}-${{ matrix.arch }}
+          name: binaries-${{ github.job }}-${{ matrix.arch }}-${{ matrix.runner }}
           path: pfx/**/*
       - uses: actions/upload-artifact@v6
         with:
-          name: binaries-${{ github.job }}-${{ matrix.arch }}-msi
+          name: binaries-${{ github.job }}-${{ matrix.arch }}-${{ matrix.runner }}-msi
           path: obj/dist/msi/*.msi
-      - name: Trim ccache
-        if: ${{ always() && github.event_name == 'push' }}
-        run: ccache --evict-older-than 7d
+      - name: Finalize ccache
+        uses: ./.github/actions/finalize-ccache
+        with:
+          trim-age: 3d
 
   make-source-tarball:
     runs-on: ubuntu-latest
@@ -907,18 +921,10 @@ jobs:
           path: obj/transmission*.tar.*
 
   macos:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [
-          # This is the last and the only macOS Intel runner that GitHub Actions supports.
-          # Xref https://github.com/actions/runner-images/issues/13046
-          macos-15-intel,
-
-          # Tahoe preview. Added Sept 2025.
-          # Xref https://github.com/actions/runner-images/pull/13007
-          macos-26
-        ]
+    # This job covers source tarballs and bundled dependencies on Tahoe
+    # (runner notes: https://github.com/actions/runner-images/pull/13007).
+    # macos-cmake-universal covers Intel with system dependencies; the
+    # Intel/tarball/bundled combination is intentionally omitted.
     needs: [make-source-tarball, what-to-make]
     if: ${{ needs.what-to-make.outputs.make-cli == 'true' ||
             needs.what-to-make.outputs.make-daemon == 'true' ||
@@ -927,7 +933,7 @@ jobs:
             needs.what-to-make.outputs.make-qt == 'true' ||
             needs.what-to-make.outputs.make-tests == 'true' ||
             needs.what-to-make.outputs.make-utils == 'true' }}
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-26
     steps:
       - name: Show Configuration
         run: |
@@ -955,10 +961,7 @@ jobs:
       - name: Extract Source
         run: mkdir src && tar xf transmission*.tar.* -C src --strip-components 1
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
-        with:
-          key: ${{ github.job }}-${{ matrix.os }}
-          save: ${{ github.event_name == 'push' }}
+        uses: ./.github/actions/setup-ccache
       - name: Configure
         run: |
           cmake \
@@ -997,18 +1000,17 @@ jobs:
         run: cmake --install obj --config RelWithDebInfo --strip
       - uses: actions/upload-artifact@v6
         with:
-          name: binaries-${{ matrix.os }}
+          name: binaries-${{ github.job }}
           path: pfx/**/*
-      - name: Trim ccache
-        if: ${{ always() && github.event_name == 'push' }}
-        run: ccache --evict-older-than 7d
+      - name: Finalize ccache
+        uses: ./.github/actions/finalize-ccache
+        with:
+          trim-age: 3d
 
   debian:
     needs: [ make-source-tarball, what-to-make ]
     if: ${{ needs.what-to-make.outputs.make-cli == 'true' || needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-gtk == 'true' || needs.what-to-make.outputs.make-qt == 'true' || needs.what-to-make.outputs.make-tests == 'true' || needs.what-to-make.outputs.make-utils == 'true' }}
     runs-on: ubuntu-latest
-    env:
-      CCACHE_MAXSIZE: 500M
     strategy:
       fail-fast: false
       matrix:
@@ -1057,15 +1059,10 @@ jobs:
           enable-mold: ${{ matrix.use-legacy-packages != true }}
           enable-ccache: true
       - name: Setup ccache
-        # resolve the workspace path from inside the container
-        run: echo "CCACHE_DIR=$GITHUB_WORKSPACE/.ccache" >> "$GITHUB_ENV"
-      - name: Restore ccache
-        uses: actions/cache/restore@v5
+        uses: ./.github/actions/setup-ccache
         with:
-          path: .ccache
-          key: ccache-${{ github.job }}-${{ matrix.version }}-${{ github.run_id }}
-          restore-keys: |
-            ccache-${{ github.job }}-${{ matrix.version }}-
+          in-container: 'true'
+          key-suffix: ${{ matrix.version }}
       - name: Get Source
         uses: actions/download-artifact@v7
         with:
@@ -1124,26 +1121,19 @@ jobs:
         with:
           name: binaries-${{ github.job }}-${{ matrix.version }}
           path: pfx/**/*
-      - name: Trim ccache
-        if: ${{ always() && github.event_name == 'push' }}
-        # `|| true`: Debian 11's ccache predates --evict-older-than
-        run: ccache --evict-older-than 7d || true
+      - name: Finalize ccache
+        uses: ./.github/actions/finalize-ccache
+        with:
+          ignore-trim-errors: ${{ matrix.use-legacy-packages }}
+          trim-age: 3d
       - name: Show ccache stats
         if: always()
         run: ccache --show-stats
-      - name: Save ccache
-        if: ${{ always() && github.event_name == 'push' }}
-        uses: actions/cache/save@v5
-        with:
-          path: .ccache
-          key: ccache-${{ github.job }}-${{ matrix.version }}-${{ github.run_id }}
 
   fedora:
     needs: [ make-source-tarball, what-to-make ]
     if: ${{ needs.what-to-make.outputs.make-cli == 'true' || needs.what-to-make.outputs.make-daemon == 'true' || needs.what-to-make.outputs.make-gtk == 'true' || needs.what-to-make.outputs.make-qt == 'true' || needs.what-to-make.outputs.make-tests == 'true' || needs.what-to-make.outputs.make-utils == 'true' }}
     runs-on: ubuntu-latest
-    env:
-      CCACHE_MAXSIZE: 500M
     strategy:
       fail-fast: false
       matrix:
@@ -1175,15 +1165,10 @@ jobs:
           enable-mold: true
           enable-ccache: true
       - name: Setup ccache
-        # resolve the workspace path from inside the container
-        run: echo "CCACHE_DIR=$GITHUB_WORKSPACE/.ccache" >> "$GITHUB_ENV"
-      - name: Restore ccache
-        uses: actions/cache/restore@v5
+        uses: ./.github/actions/setup-ccache
         with:
-          path: .ccache
-          key: ccache-${{ github.job }}-${{ matrix.version }}-${{ github.run_id }}
-          restore-keys: |
-            ccache-${{ github.job }}-${{ matrix.version }}-
+          in-container: 'true'
+          key-suffix: ${{ matrix.version }}
       - name: Get Source
         uses: actions/download-artifact@v7
         with:
@@ -1231,19 +1216,13 @@ jobs:
         with:
           name: binaries-${{ github.job }}-${{ matrix.version }}
           path: pfx/**/*
-      - name: Trim ccache
-        if: ${{ always() && github.event_name == 'push' }}
-        # `|| true`: Debian 11's ccache predates --evict-older-than
-        run: ccache --evict-older-than 7d || true
+      - name: Finalize ccache
+        uses: ./.github/actions/finalize-ccache
+        with:
+          trim-age: 3d
       - name: Show ccache stats
         if: always()
         run: ccache --show-stats
-      - name: Save ccache
-        if: ${{ always() && github.event_name == 'push' }}
-        uses: actions/cache/save@v5
-        with:
-          path: .ccache
-          key: ccache-${{ github.job }}-${{ matrix.version }}-${{ github.run_id }}
 
   utp-disabled:
     needs: [ make-source-tarball, what-to-make ]
@@ -1276,12 +1255,7 @@ jobs:
       - name: Extract Source
         run: mkdir src && tar xf transmission*.tar.* -C src --strip-components 1
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
-        with:
-          key: ${{ github.job }}
-          # only main's snapshots are saved; PR runs restore them via the
-          # base-branch fallback but must not multiply them per-ref
-          save: ${{ github.event_name == 'push' }}
+        uses: ./.github/actions/setup-ccache
       - name: Configure
         run: |
           cmake \
@@ -1327,9 +1301,8 @@ jobs:
         with:
           name: binaries-${{ github.job }}-without-utp
           path: pfx/**/*
-      - name: Trim ccache
-        if: ${{ always() && github.event_name == 'push' }}
-        run: ccache --evict-older-than 7d
+      - name: Finalize ccache
+        uses: ./.github/actions/finalize-ccache
 
   android:
     needs: [ what-to-make ]
@@ -1413,12 +1386,7 @@ jobs:
           use-sudo: true
           enable-mold: true
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
-        with:
-          key: ${{ github.job }}
-          # only main's snapshots are saved; PR runs restore them via the
-          # base-branch fallback but must not multiply them per-ref
-          save: ${{ github.event_name == 'push' }}
+        uses: ./.github/actions/setup-ccache
       - name: Configure
         run: |
           cmake \
@@ -1452,9 +1420,8 @@ jobs:
             -DUSE_SYSTEM_WIDE_INTEGER=OFF `# Not packaged in Ubuntu`
       - name: Make
         run: cmake --build obj --config Release -- "-k 0"
-      - name: Trim ccache
-        if: ${{ always() && github.event_name == 'push' }}
-        run: ccache --evict-older-than 7d
+      - name: Finalize ccache
+        uses: ./.github/actions/finalize-ccache
 
   ubuntu-24-04-arm64:
     needs: [ make-source-tarball, what-to-make ]
@@ -1493,12 +1460,7 @@ jobs:
       - name: Extract Source
         run: mkdir src && tar xf transmission*.tar.* -C src --strip-components 1
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
-        with:
-          key: ${{ github.job }}
-          # only main's snapshots are saved; PR runs restore them via the
-          # base-branch fallback but must not multiply them per-ref
-          save: ${{ github.event_name == 'push' }}
+        uses: ./.github/actions/setup-ccache
       - name: Configure
         run: |
           cmake \
@@ -1543,9 +1505,8 @@ jobs:
         with:
           name: binaries-${{ github.job }}
           path: pfx/**/*
-      - name: Trim ccache
-        if: ${{ always() && github.event_name == 'push' }}
-        run: ccache --evict-older-than 7d
+      - name: Finalize ccache
+        uses: ./.github/actions/finalize-ccache
 
   freebsd:
     needs: [ make-source-tarball, what-to-make ]
@@ -1669,10 +1630,9 @@ jobs:
       - name: Extract Source
         run: mkdir src && tar xf transmission*.tar.* -C src --strip-components 1
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: ./.github/actions/setup-ccache
         with:
-          key: ${{ github.job }}-${{ matrix.crypto.cmake }}
-          save: ${{ github.event_name == 'push' }}
+          key-suffix: ${{ matrix.crypto.cmake }}
       - name: Configure
         run: |
           cmake \
@@ -1717,9 +1677,8 @@ jobs:
         with:
           name: binaries-${{ github.job }}-${{ matrix.crypto.cmake }}
           path: pfx/**/*
-      - name: Trim ccache
-        if: ${{ always() && github.event_name == 'push' }}
-        run: ccache --evict-older-than 7d
+      - name: Finalize ccache
+        uses: ./.github/actions/finalize-ccache
 
   openbsd:
     needs: [ make-source-tarball, what-to-make ]
@@ -1888,31 +1847,59 @@ jobs:
           name: binaries-${{ github.job }}
           path: pfx/**/*
 
-  prune-ccache:
-    # The timestamped ccache keys used above are write-once: every push run
-    # saves a new snapshot, and the one it supersedes is never restored again
-    # but only gets deleted by LRU pressure at the repo's 10 GB cache cap --
-    # evicting still-useful caches (e.g. the prebuilt Windows deps) along the
-    # way. Sweep every ref and keep just the newest snapshot per key prefix.
+  prune-caches:
+    # Build jobs supersede their own snapshots as they save, so this sweep
+    # collects what those steps miss: snapshots orphaned by failed or
+    # cancelled runs, keys from retired schemas, and branch copies shadowed
+    # by main. Families that stop being produced age out through the
+    # provider's 7-day unused-entry eviction.
     # Runs only on pushes to main: PR runs from forks get a read-only token.
-    needs: [ crypto, cxx23, debian, fedora, macos, macos-cmake-universal, sanitizer-tests-linux, sanitizer-tests-macos, ubuntu-24-04-arm64, utp-disabled, windows ]
+    needs: [ android, clang-tidy-linux, clang-tidy-windows, crypto, cxx23, debian, fedora, freebsd, macos, macos-cmake-universal, netbsd, openbsd, sanitizer-tests-linux, sanitizer-tests-macos, sanitizer-tests-windows, ubuntu-24-04-arm64, utp-disabled, windows ]
     if: ${{ always() && github.event_name == 'push' }}
     runs-on: ubuntu-slim
-    permissions:
-      actions: write
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Prune superseded ccache snapshots
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Prune redundant cache entries
+        # Selector 1: a "-<run id>" suffix is the only per-run part of a
+        # ccache/ctcache key, so keep just the newest snapshot per
+        # (ref, family). Selector 2: ccache keys lacking the current
+        # CACHE_SCHEMA can never be restored again. Selector 3: the
+        # content-addressed families (win-deps, vcpkg, and vmactions' VM
+        # images, whose freebsd/openbsd/netbsd prefixes are that action's
+        # own naming) are byte-identical per key+version, and every branch
+        # can restore main's copy through the base-branch fallback, so
+        # branch copies are redundant once main holds the key.
         run: |
-          gh api --paginate 'repos/${{ github.repository }}/actions/caches?per_page=100' \
-            --jq '.actions_caches[] | select(.key | startswith("ccache-")) | [.id, .ref, .key, .created_at] | @tsv' |
-            sort -t $'\t' -k 4,4r |
-            awk -F '\t' '{
-              prefix = $3
-              sub(/-[0-9][0-9TZ:.-]*$/, "", prefix) # strip the timestamp / run-id suffix
-              if (seen[$2 "\t" prefix]++) {
-                print $1
-              }
-            }' |
-            xargs --no-run-if-empty -n 1 -I '{}' gh api -X DELETE 'repos/${{ github.repository }}/actions/caches/{}'
+          set -euo pipefail
+          inventory="$RUNNER_TEMP/caches.json"
+          # gh rejects --slurp combined with --jq, so flatten with jq itself
+          gh api --paginate --slurp 'repos/${{ github.repository }}/actions/caches?per_page=100' |
+            jq '[ .[].actions_caches[] ]' > "$inventory"
+          jq -r --arg schema "-${{ env.CACHE_SCHEMA }}-" '
+            . as $inventory
+            | [
+                ($inventory
+                 | map(select(.key | startswith("ccache-") or startswith("ctcache-")))
+                 | group_by([.ref, (.key | sub("-[0-9]+$"; ""))])[]
+                 | sort_by(.created_at) | .[:-1][].id),
+                ($inventory[]
+                 | select((.key | startswith("ccache-")) and ((.key | contains($schema)) | not)).id),
+                ($inventory
+                 | map(select((.key | test("^(win-deps|vcpkg)-")) or (.key | test("^(freebsd|openbsd|netbsd)-"))))
+                 | group_by([.key, .version])[]
+                 | select(any(.[]; .ref == "refs/heads/main"))
+                 | .[] | select(.ref != "refs/heads/main").id)
+              ]
+            | unique[]' "$inventory" |
+            # entries can vanish mid-run (TTL, a re-run's finalize), so a 404
+            # on one id must not abort the sweep
+            xargs --no-run-if-empty -P 4 -I '{}' bash -c 'gh api -X DELETE "repos/${{ github.repository }}/actions/caches/$1" || true' _ '{}'
+      - name: Check cache headroom
+        if: ${{ always() }}
+        run: |
+          bytes=$(gh api 'repos/${{ github.repository }}/actions/cache/usage' --jq '.active_caches_size_in_bytes')
+          if [ "$bytes" -gt $((CACHE_WARNING_GIB * 1024 * 1024 * 1024)) ]; then
+            gib=$(awk -v bytes="$bytes" 'BEGIN { printf "%.2f", bytes / 1024 / 1024 / 1024 }')
+            echo "::warning title=Actions cache near capacity::${gib} GiB of the ${CACHE_LIMIT_GIB} GiB repository limit is in use"
+          fi

--- a/cmake/TrMacros.cmake
+++ b/cmake/TrMacros.cmake
@@ -20,9 +20,13 @@ macro(tr_setup_gtest_target TARGET_NAME TEST_PREFIX)
     endif()
 
     if(NOT CMAKE_CROSSCOMPILING OR CMAKE_CROSSCOMPILING_EMULATOR)
+        # PRE_TEST enumerates at ctest time; the POST_BUILD default runs the
+        # fresh binary during the build, where concurrent LTO links can starve
+        # it past DISCOVERY_TIMEOUT.
         gtest_discover_tests(${TARGET_NAME}
             TEST_PREFIX "${TEST_PREFIX}"
-            DISCOVERY_TIMEOUT 15)
+            DISCOVERY_MODE PRE_TEST
+            DISCOVERY_TIMEOUT 60)
     else()
         add_test(
             NAME ${TARGET_NAME}


### PR DESCRIPTION
Rework the GitHub Actions cache scripts to reduce cache misses & make CI runs faster.

The 10 GiB repo limit was getting filled with timestamped snapshots, causing longer CI runs because important cache items were crowded out.

- Save ccache snapshots only on `main`. PRs can read `main`'s cache, but `main` and other PRs cannot read PR-scoped caches. (This is a security rule set by GitHub.) Saving from PRs would duplicate the entire ccache in every PR.

- Use CCACHE_COMPRESSLEVEL to make the ccache items a little smaller.

- Remove superseded items from the cache.

- Verify each new ccache entry before deleting its predecessor. This preserves the last usable snapshot if an upload fails.

- Allow ccache families up to 1 GiB of room, needed to keep big jobs (eg Windows Qt) from purging items mid-build.

- Build cache keys from the jobs' platform, configuration, and IPO mode. This prevents a job from using cache items from incompatible configs.

- On Windows, also include the dependency type in cache keys to make the distinction between Qt builds and non-gui builds explicit.

- On Windows, use IPO only on the Windows x64 reference build. This way the reference build (which will become the nightly build) gets the optimization, but other CI jobs finish sooner.

- On macOS, run the from-tarball build w/bundled deps on macOS 26. The separate CMake job still builds on Intel with system dependencies, removing one Intel matrix leg while retaining both kinds of coverage.

- Use `DISCOVERY_MODE` and `DISCOVERY_TIMEOUT` in gtest to prevent a busy CI box from starving test discovery and failing with timeout.

- Install Windows dependency and packaging tools only as needed. This shortens warm-cache jobs and avoids unnecessary setup work.