### PR TITLE
ci: publish rolling nightly builds from main

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -782,12 +782,17 @@ jobs:
         include:
           - arch: x86
             runner: windows-2022
+            publish: true
           - arch: x64
             runner: windows-2022
+            publish: true
+          # Coverage-only (newer toolchain, extra warnings). Not published: its
+          # MSI would require a VC++ redist too new for most machines.
           - arch: x64
             runner: windows-2025-vs2026
           - arch: arm64
             runner: windows-11-arm
+            publish: true
     runs-on: ${{ matrix.runner }}
     env:
       # /Z7 debug info compresses well; the default zstd level overflows the cache cap
@@ -856,14 +861,16 @@ jobs:
       - name: Install
         run: cmake --install obj --config RelWithDebInfo
       - name: Package
-        if: ${{ needs.what-to-make.outputs.make-dist == 'true' || (needs.what-to-make.outputs.make-daemon == 'true' && needs.what-to-make.outputs.make-qt == 'true') }}
+        if: ${{ matrix.publish && (needs.what-to-make.outputs.make-dist == 'true' || (needs.what-to-make.outputs.make-daemon == 'true' && needs.what-to-make.outputs.make-qt == 'true')) }}
         run: |
           cmd /c "`"$Env:VCVARSALL`" $Env:VC_ARCH >nul && cmake --build obj --config RelWithDebInfo --target pack-msi"
       - uses: actions/upload-artifact@v6
+        if: ${{ matrix.publish }}
         with:
           name: binaries-${{ github.job }}-${{ matrix.arch }}
           path: pfx/**/*
       - uses: actions/upload-artifact@v6
+        if: ${{ matrix.publish }}
         with:
           name: binaries-${{ github.job }}-${{ matrix.arch }}-msi
           path: obj/dist/msi/*.msi

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -867,12 +867,12 @@ jobs:
       - uses: actions/upload-artifact@v6
         if: ${{ matrix.publish }}
         with:
-          name: binaries-${{ github.job }}-${{ matrix.arch }}
+          name: binaries-${{ github.job }}-${{ matrix.arch }}-${{ matrix.runner }}
           path: pfx/**/*
       - uses: actions/upload-artifact@v6
         if: ${{ matrix.publish }}
         with:
-          name: binaries-${{ github.job }}-${{ matrix.arch }}-msi
+          name: binaries-${{ github.job }}-${{ matrix.arch }}-${{ matrix.runner }}-msi
           path: obj/dist/msi/*.msi
       - name: Trim ccache
         if: ${{ always() && github.event_name == 'push' }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,132 @@
+name: Nightly
+
+# Publishes a single, rolling "nightly" pre-release from the tip of main.
+#
+# It runs after the "Sanity" workflow succeeds on a push to main, pulls the
+# user-facing artifacts from that run, and refreshes the assets on ONE
+# permanent pre-release tagged `nightly` -- so it never clutters the releases
+# list with a new entry per day. Also runnable by hand (workflow_dispatch)
+# against the latest successful main run, for testing.
+
+on:
+  workflow_run:
+    workflows: [ Sanity ]
+    types: [ completed ]
+    branches: [ main ]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write   # create / update the release
+  actions: read     # read + download the source run's artifacts
+
+concurrency:
+  group: nightly
+  cancel-in-progress: false   # let an in-progress publish finish
+
+jobs:
+  publish:
+    name: Publish nightly build
+    runs-on: ubuntu-latest
+    # Only the real repo, and (for workflow_run) only a green push-triggered run.
+    if: >-
+      github.repository == 'retransmission/retransmission' &&
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push'))
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Resolve the source Sanity run
+        id: src
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            rid='${{ github.event.workflow_run.id }}'
+            sha='${{ github.event.workflow_run.head_sha }}'
+          else
+            read -r rid sha < <(gh api \
+              "repos/${{ github.repository }}/actions/workflows/actions.yml/runs?branch=main&event=push&status=success&per_page=1" \
+              --jq '.workflow_runs[0] | "\(.id) \(.head_sha)"')
+          fi
+          [ -n "$rid" ] || { echo '::error::no successful Sanity run found'; exit 1; }
+          {
+            echo "rid=$rid"
+            echo "sha=$sha"
+          } >> "$GITHUB_OUTPUT"
+          echo "Using Sanity run $rid @ $sha"
+
+      - name: Download the user-facing artifacts
+        run: |
+          set -euo pipefail
+          rid='${{ steps.src.outputs.rid }}'
+          mkdir -p in
+          dl() {
+            local id
+            id=$(gh api "repos/${{ github.repository }}/actions/runs/$rid/artifacts" \
+                   --jq ".artifacts[] | select(.name==\"$1\") | .id" | head -n1)
+            if [ -z "${id:-}" ]; then
+              echo "::warning::artifact '$1' not found in run $rid; skipping"
+              return 0
+            fi
+            echo "downloading $1 (id=$id)"
+            gh api "repos/${{ github.repository }}/actions/artifacts/$id/zip" > "in/$1.zip"
+          }
+          dl binaries-macos-xcodebuild-universal
+          dl binaries-windows-x64-msi
+          dl binaries-windows-arm64-msi
+          dl binaries-windows-x86-msi
+          dl source-tarball
+
+      - name: Stage clean release assets
+        run: |
+          set -euo pipefail
+          mkdir -p dist work
+          # macOS: repackage the .app in a clean zip (Transmission.app at the root)
+          if [ -f in/binaries-macos-xcodebuild-universal.zip ]; then
+            unzip -q in/binaries-macos-xcodebuild-universal.zip -d work/macos
+            app=$(find work/macos -name Transmission.app -type d | head -n1)
+            if [ -n "$app" ]; then
+              ( cd "$(dirname "$app")" && zip -q -y -r "$GITHUB_WORKSPACE/dist/Retransmission-nightly-macos-universal.zip" Transmission.app )
+            fi
+          fi
+          # Windows: pull the .msi out of each artifact
+          for arch in x64 arm64 x86; do
+            z="in/binaries-windows-$arch-msi.zip"
+            [ -f "$z" ] || continue
+            unzip -q "$z" -d "work/win-$arch"
+            msi=$(find "work/win-$arch" -name '*.msi' | head -n1)
+            [ -n "$msi" ] && cp "$msi" "dist/Retransmission-nightly-$arch.msi"
+          done
+          # Source tarball: keep the semver name, add a -nightly.<date> pre-release tag
+          if [ -f in/source-tarball.zip ]; then
+            unzip -q in/source-tarball.zip -d work/src
+            tb=$(find work/src -name 'transmission*.tar.*' | head -n1)
+            if [ -n "$tb" ]; then
+              base=$(basename "$tb")   # e.g. transmission-4.2.0.tar.xz
+              stem=${base%.tar.*}      # transmission-4.2.0
+              ext=${base#"$stem"}      # .tar.xz
+              cp "$tb" "dist/${stem}-nightly.$(date -u +%Y%m%d)${ext}"
+            fi
+          fi
+          echo 'Staged assets:'
+          ls -l dist
+          [ -n "$(ls -A dist)" ] || { echo '::error::no assets staged'; exit 1; }
+
+      - name: Publish / refresh the rolling nightly pre-release
+        run: |
+          set -euo pipefail
+          repo='${{ github.repository }}'
+          sha='${{ steps.src.outputs.sha }}'
+          notes="$RUNNER_TEMP/notes.md"
+          {
+            printf 'Rolling development build from the tip of main, refreshed on every green push.\n\n'
+            printf 'These are **unsigned** builds -- macOS Gatekeeper and Windows SmartScreen will warn you. '
+            printf 'Prefer the stable downloads at https://retransmission.org/download unless you specifically want to test main.\n\n'
+            printf 'Latest build: %s -- %s UTC\n' "$sha" "$(date -u '+%Y-%m-%d %H:%M')"
+          } > "$notes"
+          if gh release view nightly --repo "$repo" >/dev/null 2>&1; then
+            gh release edit nightly --repo "$repo" --prerelease --notes-file "$notes"
+          else
+            gh release create nightly --repo "$repo" --prerelease --title 'Nightly build' --notes-file "$notes" --target "$sha"
+          fi
+          gh release upload nightly dist/* --repo "$repo" --clobber

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,16 +60,19 @@ jobs:
           set -euo pipefail
           rid='${{ steps.src.outputs.rid }}'
           mkdir -p in
+          inventory="$RUNNER_TEMP/artifacts.json"
+          gh api --paginate --slurp \
+            "repos/${{ github.repository }}/actions/runs/$rid/artifacts?per_page=100" |
+            jq '[ .[].artifacts[] ]' > "$inventory"
           dl() {
-            local id
-            id=$(gh api "repos/${{ github.repository }}/actions/runs/$rid/artifacts" \
-                   --jq ".artifacts[] | select(.name==\"$1\") | .id" | head -n1)
-            if [ -z "${id:-}" ]; then
-              echo "::warning::artifact '$1' not found in run $rid; skipping"
-              return 0
+            local ids=()
+            mapfile -t ids < <(jq -r --arg name "$1" '.[] | select(.name == $name) | .id' "$inventory")
+            if [ "${#ids[@]}" -ne 1 ]; then
+              echo "::error::expected one artifact '$1' in run $rid; found ${#ids[@]}"
+              return 1
             fi
-            echo "downloading $1 (id=$id)"
-            gh api "repos/${{ github.repository }}/actions/artifacts/$id/zip" > "in/$1.zip"
+            echo "downloading $1 (id=${ids[0]})"
+            gh api "repos/${{ github.repository }}/actions/artifacts/${ids[0]}/zip" > "in/$1.zip"
           }
           dl binaries-macos-xcodebuild-universal
           dl binaries-windows-x64-windows-2022-msi
@@ -82,37 +85,50 @@ jobs:
           set -euo pipefail
           mkdir -p dist work
           # macOS: repackage the .app in a clean zip (Transmission.app at the root)
-          if [ -f in/binaries-macos-xcodebuild-universal.zip ]; then
-            unzip -q in/binaries-macos-xcodebuild-universal.zip -d work/macos
-            app=$(find work/macos -name Transmission.app -type d | head -n1)
-            if [ -n "$app" ]; then
-              ( cd "$(dirname "$app")" && zip -q -y -r "$GITHUB_WORKSPACE/dist/Retransmission-nightly-macos-universal.zip" Transmission.app )
-            fi
+          unzip -q in/binaries-macos-xcodebuild-universal.zip -d work/macos
+          apps=()
+          mapfile -t apps < <(find work/macos -name Transmission.app -type d)
+          if [ "${#apps[@]}" -ne 1 ]; then
+            echo "::error::expected one Transmission.app; found ${#apps[@]}"
+            exit 1
           fi
+          app=${apps[0]}
+          ( cd "$(dirname "$app")" && zip -q -y -r "$GITHUB_WORKSPACE/dist/Retransmission-nightly-macos-universal.zip" Transmission.app )
           # Windows: pull the .msi out of each artifact
           for pair in x64:windows-2022 arm64:windows-11-arm x86:windows-2022; do
             arch=${pair%%:*}
             runner=${pair#*:}
             z="in/binaries-windows-$arch-$runner-msi.zip"
-            [ -f "$z" ] || continue
             unzip -q "$z" -d "work/win-$arch"
-            msi=$(find "work/win-$arch" -name '*.msi' | head -n1)
-            [ -n "$msi" ] && cp "$msi" "dist/Retransmission-nightly-$arch.msi"
+            msis=()
+            mapfile -t msis < <(find "work/win-$arch" -name '*.msi' -type f)
+            if [ "${#msis[@]}" -ne 1 ]; then
+              echo "::error::expected one $arch MSI; found ${#msis[@]}"
+              exit 1
+            fi
+            cp "${msis[0]}" "dist/Retransmission-nightly-$arch.msi"
           done
           # Source tarball: keep the semver name, add a -nightly.<date> pre-release tag
-          if [ -f in/source-tarball.zip ]; then
-            unzip -q in/source-tarball.zip -d work/src
-            tb=$(find work/src -name 'transmission*.tar.*' | head -n1)
-            if [ -n "$tb" ]; then
-              base=$(basename "$tb")   # e.g. transmission-4.2.0.tar.xz
-              stem=${base%.tar.*}      # transmission-4.2.0
-              ext=${base#"$stem"}      # .tar.xz
-              cp "$tb" "dist/${stem}-nightly.$(date -u +%Y%m%d)${ext}"
-            fi
+          unzip -q in/source-tarball.zip -d work/src
+          tarballs=()
+          mapfile -t tarballs < <(find work/src -name 'transmission*.tar.*' -type f)
+          if [ "${#tarballs[@]}" -ne 1 ]; then
+            echo "::error::expected one source tarball; found ${#tarballs[@]}"
+            exit 1
+          fi
+          tb=${tarballs[0]}
+          base=$(basename "$tb")   # e.g. transmission-4.2.0.tar.xz
+          stem=${base%.tar.*}      # transmission-4.2.0
+          ext=${base#"$stem"}      # .tar.xz
+          cp "$tb" "dist/${stem}-nightly.$(date -u +%Y%m%d)${ext}"
+          assets=()
+          mapfile -t assets < <(find dist -mindepth 1 -maxdepth 1 -type f)
+          if [ "${#assets[@]}" -ne 5 ]; then
+            echo "::error::expected five release assets; found ${#assets[@]}"
+            exit 1
           fi
           echo 'Staged assets:'
           ls -l dist
-          [ -n "$(ls -A dist)" ] || { echo '::error::no assets staged'; exit 1; }
 
       - name: Publish / refresh the rolling nightly pre-release
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -146,6 +146,21 @@ jobs:
             gh release create nightly --repo "$repo" --draft --title 'Nightly build' --target "$sha"
           fi
           gh release upload nightly dist/* --repo "$repo" --clobber
+          # Keep one dated source asset so the release page has one current tarball.
+          source_asset=$(find dist -maxdepth 1 -type f -name 'transmission*-nightly.*.tar.*' -printf '%f\n')
+          release_id=$(gh release view nightly --repo "$repo" --json databaseId --jq .databaseId)
+          old_source_ids=()
+          mapfile -t old_source_ids < <(
+            gh api --paginate --slurp "repos/$repo/releases/$release_id/assets?per_page=100" |
+              jq -r --arg keep "$source_asset" '
+                .[][]
+                | select(.name != $keep)
+                | select(.name | test("^transmission.*-nightly\\.[0-9]{8}\\.tar\\."))
+                | .id'
+          )
+          for asset_id in "${old_source_ids[@]}"; do
+            gh api --method DELETE "repos/$repo/releases/assets/$asset_id"
+          done
           # GitHub's generated source archives resolve through the release tag.
           if gh api "repos/$repo/git/ref/tags/nightly" >/dev/null 2>&1; then
             gh api --method PATCH "repos/$repo/git/refs/tags/nightly" \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -72,9 +72,9 @@ jobs:
             gh api "repos/${{ github.repository }}/actions/artifacts/$id/zip" > "in/$1.zip"
           }
           dl binaries-macos-xcodebuild-universal
-          dl binaries-windows-x64-msi
-          dl binaries-windows-arm64-msi
-          dl binaries-windows-x86-msi
+          dl binaries-windows-x64-windows-2022-msi
+          dl binaries-windows-arm64-windows-11-arm-msi
+          dl binaries-windows-x86-windows-2022-msi
           dl source-tarball
 
       - name: Stage clean release assets
@@ -90,8 +90,10 @@ jobs:
             fi
           fi
           # Windows: pull the .msi out of each artifact
-          for arch in x64 arm64 x86; do
-            z="in/binaries-windows-$arch-msi.zip"
+          for pair in x64:windows-2022 arm64:windows-11-arm x86:windows-2022; do
+            arch=${pair%%:*}
+            runner=${pair#*:}
+            z="in/binaries-windows-$arch-$runner-msi.zip"
             [ -f "$z" ] || continue
             unzip -q "$z" -d "work/win-$arch"
             msi=$(find "work/win-$arch" -name '*.msi' | head -n1)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -142,9 +142,16 @@ jobs:
             printf 'Prefer the stable downloads at https://retransmission.org/download unless you specifically want to test main.\n\n'
             printf 'Latest build: %s -- %s UTC\n' "$sha" "$(date -u '+%Y-%m-%d %H:%M')"
           } > "$notes"
-          if gh release view nightly --repo "$repo" >/dev/null 2>&1; then
-            gh release edit nightly --repo "$repo" --prerelease --notes-file "$notes"
-          else
-            gh release create nightly --repo "$repo" --prerelease --title 'Nightly build' --notes-file "$notes" --target "$sha"
+          if ! gh release view nightly --repo "$repo" >/dev/null 2>&1; then
+            gh release create nightly --repo "$repo" --draft --title 'Nightly build' --target "$sha"
           fi
           gh release upload nightly dist/* --repo "$repo" --clobber
+          # GitHub's generated source archives resolve through the release tag.
+          if gh api "repos/$repo/git/ref/tags/nightly" >/dev/null 2>&1; then
+            gh api --method PATCH "repos/$repo/git/refs/tags/nightly" \
+              -f sha="$sha" -F force=true >/dev/null
+          else
+            gh api --method POST "repos/$repo/git/refs" \
+              -f ref='refs/tags/nightly' -f sha="$sha" >/dev/null
+          fi
+          gh release edit nightly --repo "$repo" --draft=false --prerelease --notes-file "$notes"


### PR DESCRIPTION
Add GH Actions scaffolding to make nightly builds available on https://retransmission.org/ .