### PR TITLE
refactor: remove dead code in the Qt client

### DIFF
--- a/qt/DetailsDialog.h
+++ b/qt/DetailsDialog.h
@@ -17,7 +17,6 @@
 #include "Typedefs.h"
 
 #include "ui_DetailsDialog.h"
-#include "ui_TrackersDialog.h"
 
 class QResizeEvent;
 class QTreeWidgetItem;
@@ -137,7 +136,6 @@ private:
     TorrentModel const& model_;
 
     Ui::DetailsDialog ui_ = {};
-    Ui::TrackersDialog trackers_ui_ = {};
 
     torrent_ids_t ids_;
     QTimer model_timer_;

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -868,12 +868,6 @@ void MainWindow::refreshIcons()
 ***
 **/
 
-// NOLINTNEXTLINE(readability-make-member-function-const)
-void MainWindow::clearSelection()
-{
-    ui_.action_DeselectAll->trigger();
-}
-
 torrent_ids_t MainWindow::getSelectedTorrents(bool with_metadata_only) const
 {
     torrent_ids_t ids;

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -15,7 +15,6 @@
 #include <QStringList>
 #include <QSystemTrayIcon>
 #include <QTimer>
-#include <QWidgetList>
 
 #include "Filters.h"
 #include "Prefs.h"
@@ -167,7 +166,6 @@ private:
     QAction* ulimit_on_action_ = {};
     QAction* ratio_off_action_ = {};
     QAction* ratio_on_action_ = {};
-    QWidgetList hidden_;
     QWidget* filter_bar_ = {};
     QAction* alt_speed_action_ = {};
     QString error_message_;

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -128,7 +128,6 @@ private:
     QMenu* createStatsModeMenu();
     void initStatusBar();
 
-    void clearSelection();
     void addTorrentFromClipboard();
     void addTorrent(AddData const& add_me, bool show_options);
 

--- a/qt/MainWindow.ui
+++ b/qt/MainWindow.ui
@@ -585,14 +585,6 @@
     <string>Sort by Stat&amp;e</string>
    </property>
   </action>
-  <action name="action_SortByTracker">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Sort by T&amp;racker</string>
-   </property>
-  </action>
   <action name="action_Statistics">
    <property name="checkable">
     <bool>false</bool>

--- a/qt/MainWindow.ui
+++ b/qt/MainWindow.ui
@@ -593,14 +593,6 @@
     <string>Sort by T&amp;racker</string>
    </property>
   </action>
-  <action name="action_ShowMessageLog">
-   <property name="checkable">
-    <bool>false</bool>
-   </property>
-   <property name="text">
-    <string>Message &amp;Log</string>
-   </property>
-  </action>
   <action name="action_Statistics">
    <property name="checkable">
     <bool>false</bool>

--- a/qt/MainWindow.ui
+++ b/qt/MainWindow.ui
@@ -633,30 +633,6 @@
     <string>Re&amp;verse Sort Order</string>
    </property>
   </action>
-  <action name="action_FilterByName">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>&amp;Name</string>
-   </property>
-  </action>
-  <action name="action_FilterByFiles">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>&amp;Files</string>
-   </property>
-  </action>
-  <action name="action_FilterByTracker">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>&amp;Tracker</string>
-   </property>
-  </action>
   <action name="action_TotalRatio">
    <property name="checkable">
     <bool>true</bool>

--- a/qt/PrefsDialog.h
+++ b/qt/PrefsDialog.h
@@ -16,7 +16,6 @@
 #include "Session.h"
 #include "ui_PrefsDialog.h"
 
-class QHttp;
 class QMessageBox;
 class QString;
 
@@ -105,7 +104,5 @@ private:
     QWidgetList block_widgets_;
     QWidgetList unsupported_when_remote_;
 
-    int blocklist_http_tag_ = {};
-    QHttp* blocklist_http_ = {};
     QMessageBox* blocklist_dialog_ = {};
 };

--- a/qt/PrefsDialog.h
+++ b/qt/PrefsDialog.h
@@ -98,8 +98,6 @@ private:
     QWidgetList web_widgets_;
     QWidgetList web_auth_widgets_;
     QWidgetList web_whitelist_widgets_;
-    QWidgetList proxy_widgets_;
-    QWidgetList proxy_auth_widgets_;
     QWidgetList sched_widgets_;
     QWidgetList block_widgets_;
     QWidgetList unsupported_when_remote_;

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -204,7 +204,6 @@ private:
 
     Tag torrentSetImpl(tr_variant::Map params);
     void sessionSet(tr_quark key, tr_variant val);
-    void pumpRequests();
     void sendTorrentRequest(tr_quark method, torrent_ids_t const& torrent_ids);
     void refreshTorrents(torrent_ids_t const& ids, TorrentProperties props);
 

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -17,7 +17,6 @@
 
 #include <QObject>
 #include <QString>
-#include <QStringList>
 #include <QNetworkReply>
 #include <QTimer>
 
@@ -215,7 +214,6 @@ private:
     int64_t blocklist_size_ = -1;
     std::array<bool, NUM_PORT_TEST_IP_PROTOCOL> port_test_pending_ = {};
     tr_session* session_ = {};
-    QStringList idle_json_;
     tr_session_stats stats_ = EmptyStats;
     tr_session_stats cumulative_stats_ = EmptyStats;
     QString session_version_;

--- a/qt/Speed.h
+++ b/qt/Speed.h
@@ -48,11 +48,6 @@ public:
         return tr("%1 %2").arg(to_qstring()).arg(DownloadSymbol);
     }
 
-    [[nodiscard]] constexpr auto operator+(Speed const& other) const noexcept
-    {
-        return Speed{ base_quantity() + other.base_quantity(), Speed::Units::Byps };
-    }
-
     [[nodiscard]] static auto display_name(Speed::Units const units)
     {
         auto const speed_unit_sv = Speed::units().display_name(units);

--- a/qt/SqueezeLabel.cc
+++ b/qt/SqueezeLabel.cc
@@ -50,11 +50,6 @@
 
 #include "SqueezeLabel.h"
 
-SqueezeLabel::SqueezeLabel(QString const& text, QWidget* parent)
-    : QLabel{ text, parent }
-{
-}
-
 SqueezeLabel::SqueezeLabel(QWidget* parent)
     : QLabel{ parent }
 {

--- a/qt/SqueezeLabel.h
+++ b/qt/SqueezeLabel.h
@@ -49,7 +49,6 @@ class SqueezeLabel : public QLabel
 
 public:
     explicit SqueezeLabel(QWidget* parent = nullptr);
-    explicit SqueezeLabel(QString const& text, QWidget* parent = nullptr);
     ~SqueezeLabel() override = default;
     SqueezeLabel(SqueezeLabel&&) = delete;
     SqueezeLabel(SqueezeLabel const&) = delete;

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -191,7 +191,6 @@ Torrent::fields_t Torrent::update(tr_quark const* keys, tr_variant const* const*
             HANDLE_KEY(honors_session_limits, honors_session_limits, HONORS_SESSION_LIMITS)
             HANDLE_KEY(is_finished, is_finished, IS_FINISHED)
             HANDLE_KEY(is_private, is_private, IS_PRIVATE)
-            HANDLE_KEY(is_stalled, is_stalled, IS_STALLED)
             HANDLE_KEY(labels, labels, LABELS)
             HANDLE_KEY(left_until_done, left_until_done, LEFT_UNTIL_DONE)
             HANDLE_KEY(manual_announce_time, manual_announce_time, MANUAL_ANNOUNCE_TIME)

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -73,9 +73,7 @@ struct TrackerStat {
     bool last_announce_succeeded = {};
     bool last_announce_timed_out = {};
     bool last_scrape_succeeded = {};
-    bool last_scrape_timed_out = {};
     int announce_state = {};
-    int download_count = {};
     int id = {};
     int last_announce_peer_count = {};
     int last_announce_start_time = {};
@@ -99,7 +97,6 @@ struct TrackerStat {
     static constexpr auto Fields = std::make_tuple(
         Field<&TrackerStat::announce>{ TR_KEY_announce },
         Field<&TrackerStat::announce_state>{ TR_KEY_announce_state },
-        Field<&TrackerStat::download_count>{ TR_KEY_download_count },
         Field<&TrackerStat::has_announced>{ TR_KEY_has_announced },
         Field<&TrackerStat::has_scraped>{ TR_KEY_has_scraped },
         Field<&TrackerStat::id>{ TR_KEY_id },
@@ -114,7 +111,6 @@ struct TrackerStat {
         Field<&TrackerStat::last_scrape_start_time>{ TR_KEY_last_scrape_start_time },
         Field<&TrackerStat::last_scrape_succeeded>{ TR_KEY_last_scrape_succeeded },
         Field<&TrackerStat::last_scrape_time>{ TR_KEY_last_scrape_time },
-        Field<&TrackerStat::last_scrape_timed_out>{ TR_KEY_last_scrape_timed_out },
         Field<&TrackerStat::leecher_count>{ TR_KEY_leecher_count },
         Field<&TrackerStat::next_announce_time>{ TR_KEY_next_announce_time },
         Field<&TrackerStat::next_scrape_time>{ TR_KEY_next_scrape_time },

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -35,14 +35,7 @@ class QPixmap;
 class Prefs;
 
 struct Peer {
-    bool client_is_choked = {};
-    bool client_is_interested = {};
-    bool is_downloading_from = {};
     bool is_encrypted = {};
-    bool is_incoming = {};
-    bool is_uploading_to = {};
-    bool peer_is_choked = {};
-    bool peer_is_interested = {};
     size_t active_reqs_to_client = {};
     size_t active_reqs_to_peer = {};
     QString address;
@@ -60,16 +53,9 @@ struct Peer {
         Field<&Peer::active_reqs_to_client>{ TR_KEY_active_reqs_to_client },
         Field<&Peer::active_reqs_to_peer>{ TR_KEY_active_reqs_to_peer },
         Field<&Peer::address>{ TR_KEY_address },
-        Field<&Peer::client_is_choked>{ TR_KEY_client_is_choked },
-        Field<&Peer::client_is_interested>{ TR_KEY_client_is_interested },
         Field<&Peer::client_name>{ TR_KEY_client_name },
         Field<&Peer::flags>{ TR_KEY_flag_str },
-        Field<&Peer::is_downloading_from>{ TR_KEY_is_downloading_from },
         Field<&Peer::is_encrypted>{ TR_KEY_is_encrypted },
-        Field<&Peer::is_incoming>{ TR_KEY_is_incoming },
-        Field<&Peer::is_uploading_to>{ TR_KEY_is_uploading_to },
-        Field<&Peer::peer_is_choked>{ TR_KEY_peer_is_choked },
-        Field<&Peer::peer_is_interested>{ TR_KEY_peer_is_interested },
         Field<&Peer::port>{ TR_KEY_port },
         Field<&Peer::progress>{ TR_KEY_progress },
         Field<&Peer::rate_to_client>{ TR_KEY_rate_to_client },

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -595,7 +595,6 @@ public:
         HAVE_UNCHECKED,
         HAVE_VERIFIED,
         HONORS_SESSION_LIMITS,
-        ICON,
         IS_FINISHED,
         IS_PRIVATE,
         LABELS,

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -418,11 +418,6 @@ public:
         return peers_getting_from_us_;
     }
 
-    [[nodiscard]] constexpr auto isUploading() const noexcept
-    {
-        return peersWeAreUploadingTo() > 0;
-    }
-
     [[nodiscard]] constexpr auto connectedPeers() const noexcept
     {
         return peers_connected_;

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -535,11 +535,6 @@ public:
         return queue_position_;
     }
 
-    [[nodiscard]] auto constexpr isStalled() const noexcept
-    {
-        return is_stalled_;
-    }
-
     QString activityString() const;
 
     [[nodiscard]] auto constexpr getActivity() const noexcept
@@ -631,7 +626,6 @@ public:
         ICON,
         IS_FINISHED,
         IS_PRIVATE,
-        IS_STALLED,
         LABELS,
         LEFT_UNTIL_DONE,
         MANUAL_ANNOUNCE_TIME,
@@ -679,7 +673,6 @@ private:
     bool honors_session_limits_ = {};
     bool is_finished_ = {};
     bool is_private_ = {};
-    bool is_stalled_ = {};
     bool upload_limited_ = {};
 
     tr_stat::Error error_ = tr_stat::Error::Ok;

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -398,11 +398,6 @@ public:
         return date_created_;
     }
 
-    [[nodiscard]] constexpr auto dateEdited() const noexcept
-    {
-        return edit_date_;
-    }
-
     [[nodiscard]] constexpr auto manualAnnounceTime() const noexcept
     {
         return manual_announce_time_;

--- a/qt/TrackerModelFilter.h
+++ b/qt/TrackerModelFilter.h
@@ -21,11 +21,6 @@ public:
 
     void setShowBackupTrackers(bool b);
 
-    [[nodiscard]] constexpr auto showBackupTrackers() const noexcept
-    {
-        return show_backups_;
-    }
-
 protected:
     // QSortFilterProxyModel
     [[nodiscard]] bool filterAcceptsRow(int source_row, QModelIndex const& source_parent) const override;

--- a/qt/UserMetaType.h
+++ b/qt/UserMetaType.h
@@ -11,14 +11,11 @@
 
 using ShowMode = tr::app::ShowMode;
 Q_DECLARE_METATYPE(ShowMode)
-inline auto constexpr DefaultShowMode = tr::app::DefaultShowMode;
 inline auto constexpr ShowModeCount = tr::app::ShowModeCount;
 
 using SortMode = tr::app::SortMode;
 Q_DECLARE_METATYPE(SortMode)
-inline auto constexpr DefaultSortMode = tr::app::DefaultSortMode;
 
 using StatsMode = tr::app::StatsMode;
 Q_DECLARE_METATYPE(StatsMode)
-inline auto constexpr DefaultStatsMode = tr::app::DefaultStatsMode;
 inline auto constexpr StatsModeCount = tr::app::StatsModeCount;


### PR DESCRIPTION
Remove unused code in the Qt client.

AI disclosure: dead code found by Opus 5. Each instance confirmed and removed manually by ckerr.