### PR TITLE
refactor: `tr_sessionGetAllTorrents()` returns a vector

### DIFF
--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -888,12 +888,10 @@ void Session::load(bool force_paused)
     tr_ctorSetPeerLimit(ctor, TR_FALLBACK, gtr_pref_int_get<size_t>(TR_KEY_peer_limit_per_torrent));
 
     auto* session = impl_->get_session();
-    auto const n_torrents = tr_sessionLoadTorrents(session, ctor);
+    tr_sessionLoadTorrents(session, ctor);
     tr_ctorFree(ctor);
 
-    auto raw_torrents = std::vector<tr_torrent*>{};
-    raw_torrents.resize(n_torrents);
-    tr_sessionGetAllTorrents(session, std::data(raw_torrents), std::size(raw_torrents));
+    auto const raw_torrents = tr_sessionGetAllTorrents(session);
 
     auto torrents = std::vector<Glib::RefPtr<Torrent>>();
     torrents.reserve(raw_torrents.size());

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1462,16 +1462,10 @@ size_t tr_sessionLoadTorrents(tr_session* session, tr_ctor* ctor)
     return n_torrents;
 }
 
-size_t tr_sessionGetAllTorrents(tr_session* session, tr_torrent** buf, size_t buflen)
+std::vector<tr_torrent*> tr_sessionGetAllTorrents(tr_session* session)
 {
-    auto& torrents = session->torrents();
-    auto const n = std::size(torrents);
-
-    if (buflen >= n) {
-        std::copy_n(std::begin(torrents), n, buf);
-    }
-
-    return n;
+    auto const& torrents = session->torrents();
+    return { std::begin(torrents), std::end(torrents) };
 }
 
 // ---

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -442,13 +442,8 @@ size_t tr_sessionLoadTorrents(tr_session* session, tr_ctor* ctor);
 
 /**
  * Get pointers to all the torrents in a session.
- *
- * Iff `buflen` is large enough to hold the torrents pointers,
- * then all of them are copied into `buf`.
- *
- * @return the number of torrents in the session
  */
-size_t tr_sessionGetAllTorrents(tr_session* session, tr_torrent** buf, size_t buflen);
+[[nodiscard]] std::vector<tr_torrent*> tr_sessionGetAllTorrents(tr_session* session);
 
 // ---
 

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -659,14 +659,11 @@ static void removeKeRangerRansomware()
     //load previous transfers
     tr_ctor* ctor = tr_ctorNew(session);
     tr_ctorSetPaused(ctor, TR_FORCE, true); // paused by default; unpause below after checking state history
-    auto const n_torrents = tr_sessionLoadTorrents(session, ctor);
+    tr_sessionLoadTorrents(session, ctor);
     tr_ctorFree(ctor);
 
     // process the loaded torrents
-    auto torrents = std::vector<tr_torrent*>{};
-    torrents.resize(n_torrents);
-    tr_sessionGetAllTorrents(session, std::data(torrents), std::size(torrents));
-    for (auto* tor : torrents) {
+    for (auto* tor : tr_sessionGetAllTorrents(session)) {
         NSString* location = tr_strv_to_utf8_nsstring(tr_torrentGetDownloadDir(tor));
         Torrent* torrent = [[Torrent alloc] initWithTorrentStruct:tor location:location lib:self.fLib];
         [self.fTorrents addObject:torrent];


### PR DESCRIPTION
This replaces a C-style function signature that copied the pointers into a client-provided memory buffer and returned the torrent count.