### PR TITLE
ci: fixups

### DIFF
--- a/.github/CACHE_POLICY.md
+++ b/.github/CACHE_POLICY.md
@@ -36,6 +36,12 @@ copies are deleted once main holds the same key and version; every branch
 can restore main's copy through the base-branch fallback. Gradle's caches
 are excluded: gradle/actions manages its own rotation.
 
+Windows dependency keys also carry `CACHE_SCHEMA`, which is what lets the
+janitor retire them. Content addressing alone retires an entry only when
+its own inputs change, so a change to the key *format* strands the
+previous generation: nothing produces the old key again, and no newer
+sibling supersedes it.
+
 ## Repository maintenance
 
 After all cache producers finish, the janitor (`prune-caches`) removes

--- a/.github/actions/prepare-deps-win32/action.yml
+++ b/.github/actions/prepare-deps-win32/action.yml
@@ -25,9 +25,15 @@ runs:
       id: cache-key
       shell: pwsh
       run: |
+        if (-not $Env:CACHE_SCHEMA) {
+            Write-Output '::error::CACHE_SCHEMA is unset; define it in the workflow env'
+            exit 1
+        }
         try {
             $DepsHash = & (Join-Path $Env:REPO_ROOT release windows main.ps1) -Mode DepsHash -BuildArch ${{ inputs.arch }} -BuildPart ${{ inputs.type }}
-            "hash=${DepsHash}" | Out-File $Env:GITHUB_OUTPUT -Append
+            # The janitor retires old generations by matching "-$CACHE_SCHEMA-",
+            # so the schema needs a dash on either side of it.
+            "key=win-deps-${{ inputs.arch }}-${{ inputs.type }}-${Env:CACHE_SCHEMA}-${DepsHash}" | Out-File $Env:GITHUB_OUTPUT -Append
         } catch {
             Write-Error ("{1}{0}{2}{0}{3}" -f [Environment]::NewLine, $_.ToString(), $_.InvocationInfo.PositionMessage, $_.ScriptStackTrace) -ErrorAction Continue
             exit 1
@@ -37,7 +43,7 @@ runs:
       id: restore-cache
       with:
         path: ${{ env.DEPS_PREFIX }}
-        key: win-deps-${{ inputs.arch }}-${{ inputs.type }}-${{ steps.cache-key.outputs.hash }}
+        key: ${{ steps.cache-key.outputs.key }}
     - name: Build Dependencies
       if: steps.restore-cache.outputs.cache-hit != 'true'
       shell: pwsh
@@ -58,4 +64,4 @@ runs:
       id: cache
       with:
         path: ${{ env.DEPS_PREFIX }}
-        key: win-deps-${{ inputs.arch }}-${{ inputs.type }}-${{ steps.cache-key.outputs.hash }}
+        key: ${{ steps.cache-key.outputs.key }}

--- a/.github/actions/setup-ccache/action.yml
+++ b/.github/actions/setup-ccache/action.yml
@@ -48,6 +48,13 @@ runs:
         key: ccache-${{ env.CCACHE_KEY }}-
         restore-keys: |
           ccache-${{ env.CCACHE_KEY }}-
+    - name: Zero the restored statistics
+      # ccache keeps its counters inside CCACHE_DIR, so a restored snapshot
+      # arrives carrying its whole lineage's totals. The ccache-action
+      # branch below zeroes them itself.
+      if: ${{ inputs.in-container == 'true' }}
+      shell: bash
+      run: ccache --zero-stats
     - if: ${{ inputs.in-container != 'true' }}
       uses: hendrikmuhs/ccache-action@v1.2.23
       with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,8 +20,8 @@ env:
   # See .github/CACHE_POLICY.md for cache classes, lifecycle, and budget.
   CACHE_LIMIT_GIB: '10'
   CACHE_WARNING_GIB: '9'
-  # Bumping CACHE_SCHEMA re-keys every ccache family; the janitor deletes
-  # keys that do not carry the current value.
+  # Bumping CACHE_SCHEMA re-keys every ccache and win-deps family; the
+  # janitor deletes keys that do not carry the current value.
   CACHE_SCHEMA: cache-v2
   CCACHE_COMPRESSLEVEL: '5'
   CCACHE_DIR: ${{ github.workspace }}/.ccache
@@ -1871,8 +1871,8 @@ jobs:
       - name: Prune redundant cache entries
         # Selector 1: a "-<run id>" suffix is the only per-run part of a
         # ccache/ctcache key, so keep just the newest snapshot per
-        # (ref, family). Selector 2: ccache keys lacking the current
-        # CACHE_SCHEMA can never be restored again. Selector 3: the
+        # (ref, family). Selector 2: ccache and win-deps keys lacking the
+        # current CACHE_SCHEMA can never be restored again. Selector 3: the
         # content-addressed families (win-deps, vcpkg, and vmactions' VM
         # images, whose freebsd/openbsd/netbsd prefixes are that action's
         # own naming) are byte-identical per key+version, and every branch
@@ -1892,7 +1892,7 @@ jobs:
                  | group_by([.ref, (.key | sub("-[0-9]+$"; ""))])[]
                  | sort_by(.created_at) | .[:-1][].id),
                 ($inventory[]
-                 | select((.key | startswith("ccache-")) and ((.key | contains($schema)) | not)).id),
+                 | select((.key | test("^(ccache|win-deps)-")) and ((.key | contains($schema)) | not)).id),
                 ($inventory
                  | map(select((.key | test("^(win-deps|vcpkg)-")) or (.key | test("^(freebsd|openbsd|netbsd)-"))))
                  | group_by([.key, .version])[]

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -282,6 +282,8 @@ jobs:
         uses: ./.github/actions/setup-vs-env-win32
         with:
           arch: x64
+      - name: Setup ccache
+        uses: ./.github/actions/setup-ccache
       - name: Configure
         env:
           # MSVC AddressSanitizer is address-only (no leak/undefined sanitizers).
@@ -297,6 +299,11 @@ jobs:
             '-S .'
             '-B obj'
             '-G Ninja'
+            '-DCMAKE_C_COMPILER_LAUNCHER=ccache'
+            '-DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
+            # ccache cannot cache /Zi; store debug info in the objects (/Z7) instead
+            '-DCMAKE_POLICY_DEFAULT_CMP0141=NEW'
+            '-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded'
             # RelWithDebInfo avoids Debug's /RTC1, which is incompatible with ASan.
             '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
             "-DCMAKE_PREFIX_PATH=`"$Env:DEPS_PREFIX`""
@@ -348,6 +355,10 @@ jobs:
           enable-asan: true
           extra-asan-options: allocator_may_return_null=0
           timeout: 600
+      - name: Finalize ccache
+        uses: ./.github/actions/finalize-ccache
+        with:
+          trim-age: 3d
 
   clang-tidy-linux:
     runs-on: ${{ matrix.runner }}
@@ -798,9 +809,6 @@ jobs:
             ipo: 'OFF'
             runner: windows-11-arm
     runs-on: ${{ matrix.runner }}
-    env:
-      # /Z7 debug info compresses well; the default zstd level overflows the cache cap
-      CCACHE_COMPRESSLEVEL: '8'
     steps:
       - name: Show Configuration
         run: |


### PR DESCRIPTION
fixups to #143.

- Turn on ccache for windows sanitzer tests
- Ensure old schemas get pruned when we change cache naming schemas
- Use the default cache compression level of 5 everywhere