### PR TITLE
refactor: remove unused includes

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -15,7 +15,6 @@
 
 #include <libtransmission/transmission.h>
 
-#include <libtransmission/env.h>
 #include <libtransmission/error.h>
 #include <libtransmission/file.h>
 #include <libtransmission/macros.h>

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -26,7 +26,6 @@
 #include "Utils.h"
 
 #include <libtransmission/transmission.h>
-#include <libtransmission/api-compat.h>
 #include <libtransmission/log.h>
 #include <libtransmission/macros.h>
 #include <libtransmission/quark.h>

--- a/gtk/DetailsDialog.h
+++ b/gtk/DetailsDialog.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <libtransmission/transmission.h>
+#include <libtransmission/types.h>
 
 #include <glibmm/refptr.h>
 #include <gtkmm/builder.h>

--- a/gtk/Dialogs.h
+++ b/gtk/Dialogs.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <libtransmission/transmission.h>
+#include <libtransmission/types.h>
 
 #include <glibmm/refptr.h>
 #include <gtkmm/window.h>

--- a/gtk/FileList.h
+++ b/gtk/FileList.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <libtransmission/transmission.h>
+#include <libtransmission/types.h>
 
 #include <glibmm/refptr.h>
 #include <glibmm/ustring.h>

--- a/gtk/Notify.h
+++ b/gtk/Notify.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <libtransmission/transmission.h>
+#include <libtransmission/types.h>
 
 #include <glibmm/refptr.h>
 

--- a/gtk/RelocateDialog.h
+++ b/gtk/RelocateDialog.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <libtransmission/transmission.h>
+#include <libtransmission/types.h>
 
 #include <glibmm/refptr.h>
 #include <gtkmm/builder.h>

--- a/gtk/TorrentCellRenderer.cc
+++ b/gtk/TorrentCellRenderer.cc
@@ -9,7 +9,7 @@
 #include "Percents.h"
 #include "Torrent.h"
 
-#include <libtransmission/transmission.h>
+#include <libtransmission/types.h>
 #include <libtransmission/utils.h> /* tr_truncd() */
 
 #include <cairomm/context.h>

--- a/gtk/TorrentSorter.cc
+++ b/gtk/TorrentSorter.cc
@@ -11,8 +11,8 @@
 
 #include <libtransmission-app/display-modes.h>
 
-#include <libtransmission/transmission.h>
 #include <libtransmission/macros.h>
+#include <libtransmission/types.h>
 #include <libtransmission/utils.h>
 
 #include <small/map.hpp>

--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -24,7 +24,6 @@
 #include "libtransmission/net.h"
 #include "libtransmission/peer-mgr.h" // tr_pex
 #include "libtransmission/types.h" // tr_peer_id_t
-#include "libtransmission/utils.h"
 
 struct tr_url_parsed_t;
 

--- a/libtransmission/converters.h
+++ b/libtransmission/converters.h
@@ -11,7 +11,6 @@
 #include <concepts>
 #include <cstddef>
 #include <cstdint>
-#include <ctime>
 #include <iterator>
 #include <optional>
 #include <string>

--- a/libtransmission/crypto-utils-ccrypto.cc
+++ b/libtransmission/crypto-utils-ccrypto.cc
@@ -4,7 +4,6 @@
 // License text can be found in the licenses/ folder.
 
 #include <memory>
-#include <type_traits>
 
 #include <CommonCrypto/CommonDigest.h>
 #include <CommonCrypto/CommonRandom.h>

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -4,7 +4,6 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
-#include <cstddef>
 #include <cstdint>
 #include <iterator>
 #include <vector>

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -7,7 +7,6 @@
 #include <cctype> // for isalpha()
 #include <cstring>
 #include <iterator> // for std::back_inserter
-#include <optional>
 #include <string>
 #include <string_view>
 

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <cctype> // for isalpha()
 #include <cstring>
-#include <ctime>
 #include <iterator> // for std::back_inserter
 #include <optional>
 #include <string>

--- a/libtransmission/file.cc
+++ b/libtransmission/file.cc
@@ -5,9 +5,10 @@
 
 #include <chrono>
 #include <filesystem>
-#include <system_error>
+#include <ranges>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <vector>
 
 #ifndef _WIN32

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -9,7 +9,6 @@
 #include <ctime> // time_t
 #include <functional>
 #include <optional>
-#include <ranges>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/libtransmission/handshake.cc
+++ b/libtransmission/handshake.cc
@@ -3,7 +3,6 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <algorithm>
 #include <array>
 #include <cerrno> // ECONNREFUSED, ETIMEDOUT
 #include <cstddef>

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -25,7 +25,6 @@
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-strbuf.h" // tr_pathbuf
 #include "libtransmission/types.h"
-#include "libtransmission/utils.h"
 
 using namespace std::literals;
 

--- a/libtransmission/ip-cache.cc
+++ b/libtransmission/ip-cache.cc
@@ -27,6 +27,7 @@
 #include "libtransmission/log.h"
 #include "libtransmission/string-utils.h"
 #include "libtransmission/tr-assert.h"
+#include "libtransmission/utils.h"
 #include "libtransmission/web.h"
 
 namespace

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -68,7 +68,6 @@ using tr_socket_t = int;
 
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/types.h"
-#include "libtransmission/utils.h" // for tr_compare_3way()
 
 enum tr_address_type : uint8_t { TR_AF_INET = 0, TR_AF_INET6, NUM_TR_AF_INET_TYPES };
 

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -9,7 +9,6 @@
 #error only libtransmission should #include this header.
 #endif
 
-#include <algorithm>
 #include <cstddef> // size_t
 #include <cstdint> // uintX_t
 #include <deque>

--- a/libtransmission/peer-mgr-wishlist.cc
+++ b/libtransmission/peer-mgr-wishlist.cc
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <functional>
 #include <ranges>
-#include <utility>
 #include <vector>
 
 #include <small/vector.hpp>

--- a/libtransmission/peer-mgr-wishlist.cc
+++ b/libtransmission/peer-mgr-wishlist.cc
@@ -4,7 +4,6 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm> // std::adjacent_find, std::sort
-#include <array>
 #include <cstddef>
 #include <functional>
 #include <ranges>

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -19,7 +19,6 @@
 #include <ranges>
 #include <string>
 #include <string_view>
-#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -4,7 +4,6 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm> // std::min
-#include <array>
 #include <cstdint>
 #include <cstring>
 #include <ctime>

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -9,7 +9,6 @@
 #error only libtransmission should #include this header.
 #endif
 
-#include <array>
 #include <cstddef> // size_t
 #include <memory>
 #include <string>

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -24,7 +24,6 @@
 
 class tr_rpc_address;
 struct tr_session;
-struct tr_variant;
 
 namespace tr
 {

--- a/libtransmission/session-alt-speeds.h
+++ b/libtransmission/session-alt-speeds.h
@@ -9,7 +9,6 @@
 #error only libtransmission should #include this header.
 #endif
 
-#include <array>
 #include <bitset>
 #include <cstddef> // size_t
 #include <ctime> // for time_t

--- a/libtransmission/session-alt-speeds.h
+++ b/libtransmission/session-alt-speeds.h
@@ -20,8 +20,6 @@
 #include "libtransmission/types.h" // for TR_SCHED_ALL
 #include "libtransmission/values.h"
 
-struct tr_variant;
-
 /** Manages alternate speed limits and a scheduler to auto-toggle them. */
 class tr_session_alt_speeds
 {

--- a/libtransmission/session-settings.h
+++ b/libtransmission/session-settings.h
@@ -12,7 +12,6 @@
 #include <optional>
 #include <string>
 #include <tuple>
-#include <type_traits>
 #include <vector>
 
 #include <small/vector.hpp>

--- a/libtransmission/session-settings.h
+++ b/libtransmission/session-settings.h
@@ -13,7 +13,6 @@
 #include <string>
 #include <tuple>
 #include <type_traits>
-#include <utility>
 #include <vector>
 
 #include <small/vector.hpp>

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -31,7 +31,6 @@
 
 #include "libtransmission/transmission.h"
 
-#include "libtransmission/api-compat.h"
 #include "libtransmission/bandwidth.h"
 #include "libtransmission/blocklist-download.h"
 #include "libtransmission/blocklist.h"

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -22,7 +22,6 @@
 #include <span>
 #include <string>
 #include <string_view>
-#include <tuple>
 #include <utility> // for std::pair
 #include <vector>
 

--- a/libtransmission/stats.cc
+++ b/libtransmission/stats.cc
@@ -5,7 +5,6 @@
 
 #include <initializer_list>
 #include <optional>
-#include <utility>
 
 #include <fmt/format.h>
 

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -8,7 +8,6 @@
 #include <algorithm> // std::sort()
 #include <cstddef>
 #include <cstdint> // uint64_t
-#include <functional>
 #include <iterator>
 #include <optional>
 #include <ranges>

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -11,6 +11,7 @@
 #include <functional>
 #include <iterator>
 #include <optional>
+#include <ranges>
 #include <span>
 #include <string>
 #include <string_view>

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -28,7 +28,6 @@
 #include "libtransmission/bitfield.h"
 #include "libtransmission/block-info.h"
 #include "libtransmission/completion.h"
-#include "libtransmission/crypto-utils.h"
 #include "libtransmission/file-piece-map.h"
 #include "libtransmission/interned-string.h"
 #include "libtransmission/log.h"

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -13,7 +13,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <ctime>
-#include <functional>
 #include <optional>
 #include <span>
 #include <string>

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -10,7 +10,6 @@
 
 // --- Basic Types
 
-#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <ctime>

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -8,6 +8,7 @@
 #include <cfloat> // DBL_DIG
 #include <charconv> // std::from_chars()
 #include <chrono>
+#include <concepts>
 #include <cstdint> // SIZE_MAX
 #include <cstdlib> // getenv()
 #include <ctime>
@@ -22,7 +23,6 @@
 #include <string>
 #include <string_view>
 #include <system_error>
-#include <type_traits>
 #include <utility> // std::cmp_equal
 #include <vector>
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -41,7 +41,6 @@
 
 #include <fast_float/fast_float.h>
 
-#include "libtransmission/env.h"
 #include "libtransmission/mime-types.h"
 #include "libtransmission/string-utils.h"
 #include "libtransmission/tr-assert.h"

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -5,13 +5,13 @@
 
 #pragma once
 
+#include <concepts>
 #include <cstdint> // uint8_t, uint32_t, uint64_t
 #include <ctime> // time_t
 #include <locale>
 #include <optional>
 #include <string>
 #include <string_view>
-#include <type_traits>
 #include <vector>
 
 /**

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -8,7 +8,6 @@
 #include <algorithm> // std::move()
 #include <cstddef> // size_t
 #include <cstdint> // int64_t
-#include <functional> // std::invoke
 #include <limits>
 #include <optional>
 #include <string>

--- a/libtransmission/watchdir-base.h
+++ b/libtransmission/watchdir-base.h
@@ -9,7 +9,6 @@
 #error only the wathcdir module should #include this header.
 #endif
 
-#include <algorithm>
 #include <chrono>
 #include <cstddef> // for size_t
 #include <map>

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -12,7 +12,6 @@
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint> // for uint64_t
-#include <ctime>
 #include <functional> // for std::less()
 #include <list>
 #include <map>

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -8,7 +8,6 @@
 #include <chrono>
 #include <cstddef> // size_t
 #include <cstdint> // uint64_t
-#include <ctime> // time_t
 #include <functional>
 #include <map>
 #include <memory>

--- a/macosx/BaseFileNameCellView.mm
+++ b/macosx/BaseFileNameCellView.mm
@@ -2,8 +2,6 @@
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
-#include <libtransmission/transmission.h>
-
 #import "BaseFileNameCellView.h"
 #import "FileListNode.h"
 #import "Torrent.h"

--- a/macosx/InfoActivityViewController.mm
+++ b/macosx/InfoActivityViewController.mm
@@ -2,7 +2,6 @@
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
-#include <libtransmission/transmission.h>
 #include <libtransmission/utils.h> //tr_getRatio()
 
 #import "InfoActivityViewController.h"

--- a/macosx/InfoPeersViewController.mm
+++ b/macosx/InfoPeersViewController.mm
@@ -2,7 +2,7 @@
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
-#include <libtransmission/transmission.h>
+#include <libtransmission/types.h>
 
 #import "InfoPeersViewController.h"
 #import "NSStringAdditions.h"

--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -2,10 +2,10 @@
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
-#include <libtransmission/transmission.h>
 #include <libtransmission/log.h>
 #include <libtransmission/file.h>
 #include <libtransmission/string-utils.h>
+#include <libtransmission/types.h>
 
 #import "MessageWindowController.h"
 #import "Controller.h"

--- a/macosx/NSStringAdditions.mm
+++ b/macosx/NSStringAdditions.mm
@@ -2,7 +2,7 @@
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
-#include <libtransmission/transmission.h>
+#include <libtransmission/types.h>
 #include <libtransmission/utils.h>
 
 #import "NSStringAdditions.h"

--- a/macosx/PiecesView.mm
+++ b/macosx/PiecesView.mm
@@ -2,8 +2,6 @@
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
-#include <libtransmission/transmission.h>
-
 #import "PiecesView.h"
 #import "Torrent.h"
 #import "InfoWindowController.h"

--- a/macosx/TorrentGroup.mm
+++ b/macosx/TorrentGroup.mm
@@ -2,7 +2,6 @@
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
-#include <libtransmission/transmission.h>
 #include <libtransmission/utils.h> // tr_getRatio()
 
 #import "TorrentGroup.h"

--- a/macosx/TrackerCell.mm
+++ b/macosx/TrackerCell.mm
@@ -2,7 +2,6 @@
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
-#include <libtransmission/transmission.h>
 #include <libtransmission/web-utils.h> //tr_addressIsIP()
 
 #import "CocoaCompatibility.h"

--- a/macosx/TrackerNode.h
+++ b/macosx/TrackerNode.h
@@ -4,7 +4,7 @@
 
 #import <Foundation/Foundation.h>
 
-#include <libtransmission/transmission.h>
+#include <libtransmission/types.h>
 
 @class Torrent;
 

--- a/macosx/main.mm
+++ b/macosx/main.mm
@@ -8,8 +8,6 @@
 #import <AppKit/AppKit.h>
 #endif
 
-#include <libtransmission/transmission.h>
-
 #include <libtransmission/utils.h>
 
 int main(int argc, char** argv)

--- a/qt/AboutDialog.cc
+++ b/qt/AboutDialog.cc
@@ -8,7 +8,6 @@
 #include <QMessageBox>
 #include <QPushButton>
 
-#include <libtransmission/transmission.h>
 #include <libtransmission/macros.h>
 #include <libtransmission/version.h>
 

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -28,9 +28,8 @@
 #include <QAccessible>
 #endif
 
-#include <libtransmission/transmission.h>
-
 #include <libtransmission/macros.h>
+#include <libtransmission/quark.h>
 #include <libtransmission/values.h>
 
 #include "AccessibleSqueezeLabel.h"

--- a/qt/Application.h
+++ b/qt/Application.h
@@ -19,7 +19,6 @@
 #include <QWeakPointer>
 
 #include <libtransmission/quark.h>
-#include <libtransmission/variant.h>
 
 #include <libtransmission-app/favicon-cache.h>
 

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -31,8 +31,9 @@
 #include <QStyle>
 #include <QTreeWidgetItem>
 
-#include <libtransmission/transmission.h>
 #include <libtransmission/announce-list.h>
+#include <libtransmission/quark.h>
+#include <libtransmission/types.h>
 #include <libtransmission/utils.h> // tr_getRatio()
 
 #include "BaseDialog.h"

--- a/qt/FileTreeItem.cc
+++ b/qt/FileTreeItem.cc
@@ -10,7 +10,7 @@
 
 #include <small/set.hpp>
 
-#include <libtransmission/transmission.h> // priorities
+#include <libtransmission/types.h> // priorities
 
 #include "FileTreeItem.h"
 #include "FileTreeModel.h"

--- a/qt/FileTreeModel.cc
+++ b/qt/FileTreeModel.cc
@@ -13,7 +13,7 @@
 
 #include <small/map.hpp>
 
-#include <libtransmission/transmission.h> // priorities
+#include <libtransmission/types.h> // priorities
 
 #include <QAbstractItemModel>
 #include <QMutableListIterator>

--- a/qt/FileTreeView.cc
+++ b/qt/FileTreeView.cc
@@ -14,7 +14,7 @@
 #include <QResizeEvent>
 #include <QSortFilterProxyModel>
 
-#include <libtransmission/transmission.h> // priorities
+#include <libtransmission/types.h> // priorities
 
 #include "FileTreeDelegate.h"
 #include "FileTreeItem.h"

--- a/qt/Formatter.cc
+++ b/qt/Formatter.cc
@@ -3,14 +3,21 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <libtransmission/values.h>
-
 #include "Formatter.h"
 
 #include <algorithm>
 
+#include <libtransmission/utils.h>
+#include <libtransmission/values.h>
+
 using namespace std::literals;
 using namespace tr::Values;
+
+// static
+QString Formatter::percent_to_string(double const x)
+{
+    return QString::fromStdString(tr_strpercent(x));
+}
 
 QString Formatter::memory_to_string(int64_t const bytes)
 {

--- a/qt/Formatter.h
+++ b/qt/Formatter.h
@@ -11,8 +11,6 @@
 #include <QCoreApplication> // Q_DECLARE_TR_FUNCTIONS
 #include <QString>
 
-#include <libtransmission/utils.h>
-
 #include "Speed.h"
 
 class Formatter
@@ -23,16 +21,9 @@ public:
     Formatter() = delete;
 
     [[nodiscard]] static QString memory_to_string(int64_t bytes);
-
-    [[nodiscard]] static auto percent_to_string(double x)
-    {
-        return QString::fromStdString(tr_strpercent(x));
-    }
-
+    [[nodiscard]] static QString percent_to_string(double x);
     [[nodiscard]] static QString ratio_to_string(double ratio);
-
     [[nodiscard]] static QString storage_to_string(int64_t bytes);
     [[nodiscard]] static QString storage_to_string(uint64_t bytes);
-
     [[nodiscard]] static QString time_to_string(int seconds);
 };

--- a/qt/FreeSpaceLabel.h
+++ b/qt/FreeSpaceLabel.h
@@ -11,8 +11,6 @@
 
 class Session;
 
-struct tr_variant;
-
 class FreeSpaceLabel : public QLabel
 {
     Q_OBJECT

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -20,7 +20,7 @@
 #include <QtGui>
 
 #include "libtransmission/macros.h"
-#include "libtransmission/transmission.h"
+#include "libtransmission/magnet-metainfo.h"
 #include "libtransmission/version.h"
 
 #include "AboutDialog.h"

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -40,8 +40,6 @@ class TorrentDelegate;
 class TorrentDelegateMin;
 class TorrentModel;
 
-struct tr_variant;
-
 class MainWindow : public QMainWindow
 {
     Q_OBJECT

--- a/qt/MakeDialog.cc
+++ b/qt/MakeDialog.cc
@@ -19,9 +19,9 @@
 #include <QString>
 #include <QTimer>
 
+#include <libtransmission/announce-list.h>
 #include <libtransmission/error.h>
 #include <libtransmission/makemeta.h>
-#include <libtransmission/transmission.h>
 
 #include "ColumnResizer.h"
 #include "Formatter.h"

--- a/qt/OptionsDialog.h
+++ b/qt/OptionsDialog.h
@@ -19,8 +19,6 @@
 #include "Typedefs.h" // file_indices_t
 #include "ui_OptionsDialog.h"
 
-#include <libtransmission/transmission.h>
-
 #include <libtransmission/torrent-metainfo.h>
 
 class Prefs;

--- a/qt/OptionsDialog.h
+++ b/qt/OptionsDialog.h
@@ -26,8 +26,6 @@
 class Prefs;
 class Session;
 
-struct tr_variant;
-
 class OptionsDialog : public BaseDialog
 {
     Q_OBJECT

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -24,7 +24,8 @@
 #include <QTime>
 #include <QTimeEdit>
 
-#include <libtransmission/transmission.h>
+#include <libtransmission/quark.h>
+#include <libtransmission/types.h>
 
 #include "ColumnResizer.h"
 #include "Formatter.h"

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -11,7 +11,6 @@
 #include <map>
 #include <optional>
 #include <string>
-#include <string_view>
 #include <type_traits>
 #include <vector>
 

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -10,8 +10,9 @@
 #include <QApplication>
 #include <QString>
 
-#include <libtransmission/transmission.h>
 #include <libtransmission/quark.h>
+#include <libtransmission/types.h>
+#include <libtransmission/variant.h>
 
 #include "Application.h"
 #include "IconCache.h"

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -12,8 +12,6 @@
 #include <string_view>
 #include <vector>
 
-#include <libtransmission/transmission.h>
-
 #include <libtransmission/quark.h>
 #include <libtransmission/variant.h>
 

--- a/qt/Typedefs.h
+++ b/qt/Typedefs.h
@@ -3,7 +3,7 @@
 #include <set>
 #include <unordered_set>
 
-#include <libtransmission/transmission.h>
+#include <libtransmission/types.h>
 
 using torrent_ids_t = std::unordered_set<tr_torrent_id_t>;
 

--- a/qt/Utils.cc
+++ b/qt/Utils.cc
@@ -24,8 +24,6 @@
 #include <QSpinBox>
 #include <QStyle>
 
-#include <libtransmission/transmission.h>
-
 #include "Utils.h"
 
 #include "QtCompat.h"

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -31,7 +31,6 @@
 #include <libtransmission/quark.h>
 #include <libtransmission/torrent-ctor.h>
 #include <libtransmission/torrent.h>
-#include <libtransmission/utils.h>
 #include <libtransmission/variant.h>
 
 using namespace std::literals;

--- a/tests/libtransmission/utils-test.cc
+++ b/tests/libtransmission/utils-test.cc
@@ -18,7 +18,6 @@
 
 #include <libtransmission/transmission.h>
 
-#include <libtransmission/env.h>
 #include <libtransmission/utils.h>
 
 #include "test-fixtures.h"

--- a/utils/create.cc
+++ b/utils/create.cc
@@ -17,8 +17,6 @@
 
 #include <fmt/format.h>
 
-#include <libtransmission/transmission.h>
-
 #include <libtransmission/announce-list.h>
 #include <libtransmission/error.h>
 #include <libtransmission/file.h>
@@ -27,6 +25,7 @@
 #include <libtransmission/makemeta.h>
 #include <libtransmission/torrent-files.h>
 #include <libtransmission/tr-getopt.h>
+#include <libtransmission/types.h>
 #include <libtransmission/utils.h>
 #include <libtransmission/values.h>
 #include <libtransmission/version.h>

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -6,8 +6,8 @@
 #include <algorithm>
 #include <array>
 #include <cctype> // isspace
-#include <cmath> // floor
 #include <chrono>
+#include <cmath> // floor
 #include <cstdint> // int64_t
 #include <cstdio>
 #include <cstdlib>
@@ -17,6 +17,7 @@
 #include <limits>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <set>
 #include <string>
 #include <string_view>

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -28,9 +28,8 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
-#include <libtransmission/transmission.h>
-
 #include <libtransmission/api-compat.h>
+#include <libtransmission/constants.h>
 #include <libtransmission/crypto-utils.h>
 #include <libtransmission/env.h>
 #include <libtransmission/file-utils.h>
@@ -41,6 +40,7 @@
 #include <libtransmission/string-utils.h>
 #include <libtransmission/tr-assert.h>
 #include <libtransmission/tr-getopt.h>
+#include <libtransmission/types.h>
 #include <libtransmission/utils.h>
 #include <libtransmission/values.h>
 #include <libtransmission/variant.h>


### PR DESCRIPTION
Manual cleanup: remove some unused `#include` calls.

No behavior changes; just some janitorial #include cleanup

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
