### PR TITLE
refactor: order `#include` calls based on toolkit stack dependency order

### DIFF
--- a/gtk/.clang-format
+++ b/gtk/.clang-format
@@ -3,30 +3,44 @@ BasedOnStyle: InheritParentConfig
 
 IncludeBlocks: Regroup
 IncludeCategories:
-  - Regex: '^<libtransmission-app/'
+  - Regex: '^[<"]libtransmission-app/'
     Priority: 3
-  - Regex: '^<libtransmission/transmission.h>'
+  - Regex: '^[<"]libtransmission/'
     Priority: 4
-    SortPriority: 3
-  - Regex: '^<libtransmission/'
-    Priority: 4
-    SortPriority: 4
-  - Regex: '^<(cairo|gdk|gio|glib|gtk|pango)mm([-./]|config)'
+  - Regex: '^<(gtk|gdk)mm([-./]|config)'
     Priority: 5
-  - Regex: '^<sigc\+\+([-./]|config)'
+  - Regex: '^<pangomm([-./]|config)'
     Priority: 6
-  - Regex: '^<(fmt|small|woke)/'
-    Priority: 6
-  - Regex: '^<(cairo|gdk|gio|glib|gtk|pango)[-./]'
+  - Regex: '^<cairomm([-./]|config)'
+    Priority: 7
+  - Regex: '^<giomm([-./]|config)'
     Priority: 8
-  - Regex: '^<(libappindicator|libayatana-appindicator)/'
+  - Regex: '^<glibmm([-./]|config)'
     Priority: 9
-  - Regex: '^<(winsock2|ws2tcpip)\.h>'
+  - Regex: '^<sigc\+\+([-./]|config)'
     Priority: 10
-  - Regex: '^<(arpa|sys)/'
+  - Regex: '^<(fmt|small|woke)/'
     Priority: 11
   - Regex: '^<[a-z_]+>'
-    Priority: 7
+    Priority: 12
+  - Regex: '^<(libappindicator|libayatana-appindicator)/'
+    Priority: 13
+  - Regex: '^<gtk[-./]'
+    Priority: 14
+  - Regex: '^<gdk[-./]'
+    Priority: 15
+  - Regex: '^<pango[-./]'
+    Priority: 16
+  - Regex: '^<cairo[-./]'
+    Priority: 17
+  - Regex: '^<gio[-./]'
+    Priority: 18
+  - Regex: '^<glib[-./]'
+    Priority: 19
+  - Regex: '^<(winsock2|ws2tcpip)\.h>'
+    Priority: 20
+  - Regex: '^<(arpa|sys)/'
+    Priority: 21
   - Regex: '.*'
     Priority: 2
 SortIncludes:

--- a/gtk/Actions.cc
+++ b/gtk/Actions.cc
@@ -13,6 +13,7 @@
 #include <libtransmission/quark.h>
 
 #include <giomm/simpleaction.h>
+
 #include <glibmm/i18n.h>
 #include <glibmm/variant.h>
 
@@ -22,12 +23,13 @@
 #include <unordered_map>
 
 #if GTKMM_CHECK_VERSION(4, 0, 0)
-#include <giomm/liststore.h>
-#include <giomm/menuattributeiter.h>
-#include <giomm/menulinkiter.h>
 #include <gtkmm/shortcut.h>
 #include <gtkmm/shortcutaction.h>
 #include <gtkmm/shortcuttrigger.h>
+
+#include <giomm/liststore.h>
+#include <giomm/menuattributeiter.h>
+#include <giomm/menulinkiter.h>
 
 #include <stack>
 #include <utility>

--- a/gtk/Actions.h
+++ b/gtk/Actions.h
@@ -8,13 +8,15 @@
 #include "GtkCompat.h"
 #include "Utils.h"
 
+#include <gtkmm/builder.h>
+
 #include <giomm/listmodel.h>
 #include <giomm/menumodel.h>
 #include <giomm/simpleactiongroup.h>
+
 #include <glibmm/object.h>
 #include <glibmm/refptr.h>
 #include <glibmm/ustring.h>
-#include <gtkmm/builder.h>
 
 class Session;
 

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -25,23 +25,16 @@
 #include "Torrent.h"
 #include "Utils.h"
 
-#include <libtransmission/transmission.h>
+#include <libtransmission/api-compat.h>
 #include <libtransmission/log.h>
 #include <libtransmission/macros.h>
 #include <libtransmission/quark.h>
 #include <libtransmission/rpcimpl.h>
+#include <libtransmission/transmission.h>
 #include <libtransmission/utils.h>
 #include <libtransmission/version.h>
 
 #include <gdkmm/display.h>
-#include <giomm/appinfo.h>
-#include <giomm/error.h>
-#include <giomm/menu.h>
-#include <glibmm/i18n.h>
-#include <glibmm/main.h>
-#include <glibmm/miscutils.h>
-#include <glibmm/value.h>
-#include <glibmm/vectorutils.h>
 #include <gtkmm/aboutdialog.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/button.h>
@@ -53,6 +46,16 @@
 #include <gtkmm/messagedialog.h>
 #include <gtkmm/stylecontext.h>
 #include <gtkmm/window.h>
+
+#include <giomm/appinfo.h>
+#include <giomm/error.h>
+#include <giomm/menu.h>
+
+#include <glibmm/i18n.h>
+#include <glibmm/main.h>
+#include <glibmm/miscutils.h>
+#include <glibmm/value.h>
+#include <glibmm/vectorutils.h>
 
 #include <small/set.hpp>
 #include <woke/woke.hpp>

--- a/gtk/Application.h
+++ b/gtk/Application.h
@@ -4,10 +4,12 @@
 
 #pragma once
 
+#include <gtkmm/application.h>
+
 #include <giomm/file.h>
+
 #include <glibmm/refptr.h>
 #include <glibmm/ustring.h>
-#include <gtkmm/application.h>
 
 #include <memory>
 #include <string>

--- a/gtk/DetailsDialog.cc
+++ b/gtk/DetailsDialog.cc
@@ -21,11 +21,6 @@
 #include <libtransmission/web-utils.h>
 
 #include <gdkmm/pixbuf.h>
-#include <glibmm/i18n.h>
-#include <glibmm/main.h>
-#include <glibmm/markup.h>
-#include <glibmm/quark.h>
-#include <glibmm/ustring.h>
 #include <gtkmm/adjustment.h>
 #include <gtkmm/button.h>
 #include <gtkmm/cellrendererpixbuf.h>
@@ -48,6 +43,12 @@
 #include <gtkmm/treemodelsort.h>
 #include <gtkmm/treerowreference.h>
 #include <gtkmm/treeview.h>
+
+#include <glibmm/i18n.h>
+#include <glibmm/main.h>
+#include <glibmm/markup.h>
+#include <glibmm/quark.h>
+#include <glibmm/ustring.h>
 
 #include <fmt/chrono.h>
 #include <fmt/format.h>

--- a/gtk/DetailsDialog.h
+++ b/gtk/DetailsDialog.h
@@ -7,10 +7,11 @@
 
 #include <libtransmission/types.h>
 
-#include <glibmm/refptr.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/dialog.h>
 #include <gtkmm/window.h>
+
+#include <glibmm/refptr.h>
 
 #include <memory>
 #include <vector>

--- a/gtk/Dialogs.cc
+++ b/gtk/Dialogs.cc
@@ -8,9 +8,10 @@
 #include "Session.h"
 #include "Utils.h"
 
+#include <gtkmm/messagedialog.h>
+
 #include <glibmm/i18n.h>
 #include <glibmm/ustring.h>
-#include <gtkmm/messagedialog.h>
 
 #include <fmt/format.h>
 

--- a/gtk/Dialogs.h
+++ b/gtk/Dialogs.h
@@ -6,8 +6,9 @@
 
 #include <libtransmission/types.h>
 
-#include <glibmm/refptr.h>
 #include <gtkmm/window.h>
+
+#include <glibmm/refptr.h>
 
 #include <vector>
 

--- a/gtk/FaviconCache.cc
+++ b/gtk/FaviconCache.cc
@@ -8,7 +8,9 @@
 #include <libtransmission/macros.h>
 
 #include <gdkmm/pixbuf.h>
+
 #include <giomm/memoryinputstream.h>
+
 #include <glibmm/error.h>
 #include <glibmm/main.h>
 #include <glibmm/miscutils.h>

--- a/gtk/FileList.cc
+++ b/gtk/FileList.cc
@@ -16,13 +16,6 @@
 #include <libtransmission/string-utils.h>
 #include <libtransmission/utils.h>
 
-#include <giomm/icon.h>
-#include <glibmm/fileutils.h>
-#include <glibmm/i18n.h>
-#include <glibmm/main.h>
-#include <glibmm/markup.h>
-#include <glibmm/miscutils.h>
-#include <glibmm/nodetree.h>
 #include <gtkmm/cellrendererpixbuf.h>
 #include <gtkmm/cellrendererprogress.h>
 #include <gtkmm/cellrenderertext.h>
@@ -33,6 +26,15 @@
 #include <gtkmm/treeselection.h>
 #include <gtkmm/treestore.h>
 #include <gtkmm/treeview.h>
+
+#include <giomm/icon.h>
+
+#include <glibmm/fileutils.h>
+#include <glibmm/i18n.h>
+#include <glibmm/main.h>
+#include <glibmm/markup.h>
+#include <glibmm/miscutils.h>
+#include <glibmm/nodetree.h>
 
 #include <fmt/format.h>
 

--- a/gtk/FileList.h
+++ b/gtk/FileList.h
@@ -7,10 +7,11 @@
 
 #include <libtransmission/types.h>
 
-#include <glibmm/refptr.h>
-#include <glibmm/ustring.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/scrolledwindow.h>
+
+#include <glibmm/refptr.h>
+#include <glibmm/ustring.h>
 
 #include <memory>
 

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -19,10 +19,6 @@
 #include <libtransmission/macros.h>
 
 #include <gdkmm/pixbuf.h>
-#include <glibmm/i18n.h>
-#include <glibmm/main.h>
-#include <glibmm/unicode.h>
-#include <glibmm/ustring.h>
 #include <gtkmm/cellrendererpixbuf.h>
 #include <gtkmm/cellrenderertext.h>
 #include <gtkmm/combobox.h>
@@ -34,6 +30,11 @@
 #include <gtkmm/treemodelfilter.h>
 #include <gtkmm/treerowreference.h>
 #include <gtkmm/treestore.h>
+
+#include <glibmm/i18n.h>
+#include <glibmm/main.h>
+#include <glibmm/unicode.h>
+#include <glibmm/ustring.h>
 
 #if GTKMM_CHECK_VERSION(4, 0, 0)
 #include <gtkmm/filterlistmodel.h>

--- a/gtk/FilterBar.h
+++ b/gtk/FilterBar.h
@@ -7,12 +7,14 @@
 
 #include "GtkCompat.h"
 
-#include <giomm/listmodel.h>
-#include <glibmm/extraclassinit.h>
-#include <glibmm/refptr.h>
 #include <gtkmm/box.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/treemodel.h>
+
+#include <giomm/listmodel.h>
+
+#include <glibmm/extraclassinit.h>
+#include <glibmm/refptr.h>
 
 #include <memory>
 

--- a/gtk/FreeSpaceLabel.h
+++ b/gtk/FreeSpaceLabel.h
@@ -3,9 +3,10 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <glibmm/refptr.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/label.h>
+
+#include <glibmm/refptr.h>
 
 #include <memory>
 #include <string_view>

--- a/gtk/GtkCompat.h
+++ b/gtk/GtkCompat.h
@@ -5,10 +5,13 @@
 
 #pragma once
 
-#include <cairommconfig.h>
-#include <glibmmconfig.h>
 #include <gtkmmconfig.h>
+
 #include <pangommconfig.h>
+
+#include <cairommconfig.h>
+
+#include <glibmmconfig.h>
 
 #include <cstddef>
 

--- a/gtk/IconCache.h
+++ b/gtk/IconCache.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <giomm/icon.h>
+
 #include <glibmm/refptr.h>
 
 #include <string_view>

--- a/gtk/ListModelAdapter.h
+++ b/gtk/ListModelAdapter.h
@@ -7,12 +7,14 @@
 
 #include "GtkCompat.h"
 
+#include <gtkmm/treemodel.h>
+#include <gtkmm/treemodelcolumn.h>
+
 #include <giomm/listmodel.h>
+
 #include <glibmm/object.h>
 #include <glibmm/refptr.h>
 #include <glibmm/value.h>
-#include <gtkmm/treemodel.h>
-#include <gtkmm/treemodelcolumn.h>
 
 #include <cstdint>
 #include <optional>

--- a/gtk/MainWindow.cc
+++ b/gtk/MainWindow.cc
@@ -25,16 +25,6 @@
 
 #include <gdkmm/cursor.h>
 #include <gdkmm/rectangle.h>
-#include <giomm/menu.h>
-#include <giomm/menuitem.h>
-#include <giomm/menumodel.h>
-#include <giomm/simpleaction.h>
-#include <giomm/simpleactiongroup.h>
-#include <glibmm/i18n.h>
-#include <glibmm/main.h>
-#include <glibmm/miscutils.h>
-#include <glibmm/ustring.h>
-#include <glibmm/variant.h>
 #include <gtkmm/image.h>
 #include <gtkmm/label.h>
 #include <gtkmm/menubutton.h>
@@ -44,6 +34,18 @@
 #include <gtkmm/treeview.h>
 #include <gtkmm/widget.h>
 #include <gtkmm/window.h>
+
+#include <giomm/menu.h>
+#include <giomm/menuitem.h>
+#include <giomm/menumodel.h>
+#include <giomm/simpleaction.h>
+#include <giomm/simpleactiongroup.h>
+
+#include <glibmm/i18n.h>
+#include <glibmm/main.h>
+#include <glibmm/miscutils.h>
+#include <glibmm/ustring.h>
+#include <glibmm/variant.h>
 
 #if GTKMM_CHECK_VERSION(4, 0, 0)
 #include <gtkmm/listitemfactory.h>

--- a/gtk/MainWindow.h
+++ b/gtk/MainWindow.h
@@ -4,11 +4,13 @@
 
 #pragma once
 
-#include <giomm/actiongroup.h>
-#include <glibmm/refptr.h>
 #include <gtkmm/application.h>
 #include <gtkmm/applicationwindow.h>
 #include <gtkmm/builder.h>
+
+#include <giomm/actiongroup.h>
+
+#include <glibmm/refptr.h>
 
 #include <memory>
 

--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -11,20 +11,11 @@
 #include "Session.h"
 #include "Utils.h"
 
-#include <libtransmission/transmission.h>
 #include <libtransmission/error.h>
 #include <libtransmission/makemeta.h>
+#include <libtransmission/transmission.h>
 #include <libtransmission/values.h>
 
-#include <giomm/file.h>
-#include <glibmm/convert.h>
-#include <glibmm/fileutils.h>
-#include <glibmm/i18n.h>
-#include <glibmm/main.h>
-#include <glibmm/miscutils.h>
-#include <glibmm/ustring.h>
-#include <glibmm/value.h>
-#include <glibmm/vectorutils.h>
 #include <gtkmm/adjustment.h>
 #include <gtkmm/checkbutton.h>
 #include <gtkmm/entry.h>
@@ -33,6 +24,17 @@
 #include <gtkmm/scale.h>
 #include <gtkmm/textbuffer.h>
 #include <gtkmm/textview.h>
+
+#include <giomm/file.h>
+
+#include <glibmm/convert.h>
+#include <glibmm/fileutils.h>
+#include <glibmm/i18n.h>
+#include <glibmm/main.h>
+#include <glibmm/miscutils.h>
+#include <glibmm/ustring.h>
+#include <glibmm/value.h>
+#include <glibmm/vectorutils.h>
 
 #if GTKMM_CHECK_VERSION(4, 0, 0)
 #include <gtkmm/droptarget.h>

--- a/gtk/MakeDialog.h
+++ b/gtk/MakeDialog.h
@@ -5,10 +5,11 @@
 
 #pragma once
 
-#include <glibmm/refptr.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/dialog.h>
 #include <gtkmm/window.h>
+
+#include <glibmm/refptr.h>
 
 #include <memory>
 

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -14,14 +14,6 @@
 
 #include <libtransmission/log.h>
 
-#include <giomm/simpleaction.h>
-#include <glibmm/convert.h>
-#include <glibmm/datetime.h>
-#include <glibmm/i18n.h>
-#include <glibmm/main.h>
-#include <glibmm/miscutils.h>
-#include <glibmm/ustring.h>
-#include <glibmm/variant.h>
 #include <gtkmm/cellrenderertext.h>
 #include <gtkmm/combobox.h>
 #include <gtkmm/filechoosernative.h>
@@ -32,6 +24,16 @@
 #include <gtkmm/treemodelfilter.h>
 #include <gtkmm/treemodelsort.h>
 #include <gtkmm/treeview.h>
+
+#include <giomm/simpleaction.h>
+
+#include <glibmm/convert.h>
+#include <glibmm/datetime.h>
+#include <glibmm/i18n.h>
+#include <glibmm/main.h>
+#include <glibmm/miscutils.h>
+#include <glibmm/ustring.h>
+#include <glibmm/variant.h>
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>

--- a/gtk/MessageLogWindow.h
+++ b/gtk/MessageLogWindow.h
@@ -5,9 +5,10 @@
 
 #pragma once
 
-#include <glibmm/refptr.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/window.h>
+
+#include <glibmm/refptr.h>
 
 #include <memory>
 

--- a/gtk/Notify.cc
+++ b/gtk/Notify.cc
@@ -15,6 +15,7 @@
 
 #include <giomm/asyncresult.h>
 #include <giomm/dbusproxy.h>
+
 #include <glibmm/error.h>
 #include <glibmm/i18n.h>
 #include <glibmm/miscutils.h>

--- a/gtk/OptionsDialog.cc
+++ b/gtk/OptionsDialog.cc
@@ -14,14 +14,16 @@
 #include "Session.h"
 #include "Utils.h"
 
-#include <libtransmission/transmission.h>
 #include <libtransmission/file.h> /* tr_sys_path_is_same() */
+#include <libtransmission/transmission.h>
 
-#include <giomm/file.h>
-#include <glibmm/i18n.h>
 #include <gtkmm/checkbutton.h>
 #include <gtkmm/combobox.h>
 #include <gtkmm/filefilter.h>
+
+#include <giomm/file.h>
+
+#include <glibmm/i18n.h>
 
 #include <memory>
 #include <utility>

--- a/gtk/OptionsDialog.h
+++ b/gtk/OptionsDialog.h
@@ -5,12 +5,13 @@
 
 #pragma once
 
-#include <glibmm/refptr.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/dialog.h>
 #include <gtkmm/entry.h>
 #include <gtkmm/filechoosernative.h>
 #include <gtkmm/window.h>
+
+#include <glibmm/refptr.h>
 
 #include <memory>
 

--- a/gtk/PathButton.cc
+++ b/gtk/PathButton.cc
@@ -8,13 +8,6 @@
 #include "GtkCompat.h"
 #include "Utils.h"
 
-#include <giomm/file.h>
-#include <giomm/icon.h>
-#include <glibmm/error.h>
-#include <glibmm/i18n.h>
-#include <glibmm/property.h>
-#include <glibmm/refptr.h>
-#include <glibmm/ustring.h>
 #include <gtkmm/box.h>
 #include <gtkmm/button.h>
 #include <gtkmm/dialog.h>
@@ -24,6 +17,15 @@
 #include <gtkmm/label.h>
 #include <gtkmm/popover.h>
 #include <gtkmm/separator.h>
+
+#include <giomm/file.h>
+#include <giomm/icon.h>
+
+#include <glibmm/error.h>
+#include <glibmm/i18n.h>
+#include <glibmm/property.h>
+#include <glibmm/refptr.h>
+#include <glibmm/ustring.h>
 
 #include <sigc++/signal.h>
 

--- a/gtk/PathButton.h
+++ b/gtk/PathButton.h
@@ -7,11 +7,12 @@
 
 #include "GtkCompat.h"
 
-#include <glibmm/refptr.h>
-#include <glibmm/ustring.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/button.h>
 #include <gtkmm/filefilter.h>
+
+#include <glibmm/refptr.h>
+#include <glibmm/ustring.h>
 
 #include <memory>
 #include <string>

--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -9,8 +9,8 @@
 
 #include <libtransmission-app/display-modes.h>
 
-#include <libtransmission/transmission.h>
 #include <libtransmission/converters.h>
+#include <libtransmission/transmission.h>
 #include <libtransmission/variant.h>
 
 #include <glibmm/miscutils.h>

--- a/gtk/Prefs.h
+++ b/gtk/Prefs.h
@@ -6,9 +6,9 @@
 
 #include <libtransmission-app/converters.h>
 
-#include <libtransmission/transmission.h>
 #include <libtransmission/converters.h>
 #include <libtransmission/quark.h>
+#include <libtransmission/transmission.h>
 #include <libtransmission/variant.h>
 
 #include <glibmm/miscutils.h>

--- a/gtk/PrefsDialog.cc
+++ b/gtk/PrefsDialog.cc
@@ -16,11 +16,6 @@
 #include <libtransmission/transmission.h>
 #include <libtransmission/web-utils.h>
 
-#include <glibmm/date.h>
-#include <glibmm/i18n.h>
-#include <glibmm/main.h>
-#include <glibmm/timer.h>
-#include <glibmm/ustring.h>
 #include <gtkmm/adjustment.h>
 #include <gtkmm/box.h>
 #include <gtkmm/button.h>
@@ -35,6 +30,12 @@
 #include <gtkmm/textview.h>
 #include <gtkmm/treemodelcolumn.h>
 #include <gtkmm/widget.h>
+
+#include <glibmm/date.h>
+#include <glibmm/i18n.h>
+#include <glibmm/main.h>
+#include <glibmm/timer.h>
+#include <glibmm/ustring.h>
 
 #if GTKMM_CHECK_VERSION(4, 0, 0)
 #include <gtkmm/eventcontrollerfocus.h>

--- a/gtk/PrefsDialog.h
+++ b/gtk/PrefsDialog.h
@@ -5,10 +5,11 @@
 
 #pragma once
 
-#include <glibmm/refptr.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/dialog.h>
 #include <gtkmm/window.h>
+
+#include <glibmm/refptr.h>
 
 #include <memory>
 

--- a/gtk/RelocateDialog.cc
+++ b/gtk/RelocateDialog.cc
@@ -10,11 +10,12 @@
 #include "Session.h"
 #include "Utils.h"
 
+#include <gtkmm/checkbutton.h>
+#include <gtkmm/messagedialog.h>
+
 #include <glibmm/i18n.h>
 #include <glibmm/main.h>
 #include <glibmm/ustring.h>
-#include <gtkmm/checkbutton.h>
-#include <gtkmm/messagedialog.h>
 
 #include <fmt/format.h>
 

--- a/gtk/RelocateDialog.h
+++ b/gtk/RelocateDialog.h
@@ -7,10 +7,11 @@
 
 #include <libtransmission/types.h>
 
-#include <glibmm/refptr.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/dialog.h>
 #include <gtkmm/window.h>
+
+#include <glibmm/refptr.h>
 
 #include <memory>
 #include <vector>

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -14,13 +14,13 @@
 #include "TorrentSorter.h"
 #include "Utils.h"
 
-#include <libtransmission/transmission.h>
 #include <libtransmission/env.h>
 #include <libtransmission/log.h>
 #include <libtransmission/macros.h>
 #include <libtransmission/rpcimpl.h>
 #include <libtransmission/string-utils.h>
 #include <libtransmission/torrent-metainfo.h>
+#include <libtransmission/transmission.h>
 #include <libtransmission/utils.h> // tr_time()
 #include <libtransmission/variant.h>
 #include <libtransmission/web-utils.h> // tr_urlIsValid()
@@ -29,6 +29,7 @@
 #include <giomm/fileinfo.h>
 #include <giomm/filemonitor.h>
 #include <giomm/liststore.h>
+
 #include <glibmm/error.h>
 #include <glibmm/fileutils.h>
 #include <glibmm/i18n.h>

--- a/gtk/Session.h
+++ b/gtk/Session.h
@@ -10,17 +10,19 @@
 
 #include <libtransmission-app/favicon-cache.h>
 
-#include <libtransmission/transmission.h>
 #include <libtransmission/converters.h>
+#include <libtransmission/transmission.h>
 #include <libtransmission/variant.h>
 
 #include <gdkmm/pixbuf.h>
+#include <gtkmm/treemodel.h>
+
 #include <giomm/file.h>
 #include <giomm/listmodel.h>
+
 #include <glibmm/object.h>
 #include <glibmm/refptr.h>
 #include <glibmm/ustring.h>
-#include <gtkmm/treemodel.h>
 
 #include <cstddef>
 #include <cstdint>

--- a/gtk/StatsDialog.cc
+++ b/gtk/StatsDialog.cc
@@ -10,11 +10,12 @@
 #include "Session.h"
 #include "Utils.h"
 
+#include <gtkmm/label.h>
+#include <gtkmm/messagedialog.h>
+
 #include <glibmm/i18n.h>
 #include <glibmm/main.h>
 #include <glibmm/ustring.h>
-#include <gtkmm/label.h>
-#include <gtkmm/messagedialog.h>
 
 #include <fmt/format.h>
 

--- a/gtk/StatsDialog.h
+++ b/gtk/StatsDialog.h
@@ -5,10 +5,11 @@
 
 #pragma once
 
-#include <glibmm/refptr.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/dialog.h>
 #include <gtkmm/window.h>
+
+#include <glibmm/refptr.h>
 
 #include <memory>
 

--- a/gtk/SystemTrayIcon.cc
+++ b/gtk/SystemTrayIcon.cc
@@ -10,18 +10,20 @@
 #include "Session.h"
 #include "Utils.h"
 
-#include <libtransmission/transmission.h>
 #include <libtransmission/macros.h>
+#include <libtransmission/transmission.h>
 #include <libtransmission/utils.h>
 
 #include <glibmm/i18n.h>
 #include <glibmm/ustring.h>
 
 #if !GTKMM_CHECK_VERSION(4, 0, 0)
-#include <giomm/menu.h>
-#include <glibmm/miscutils.h>
 #include <gtkmm/icontheme.h>
 #include <gtkmm/menu.h>
+
+#include <giomm/menu.h>
+
+#include <glibmm/miscutils.h>
 #if !defined(HAVE_APPINDICATOR)
 #include <gtkmm/statusicon.h>
 #endif

--- a/gtk/SystemTrayIcon.h
+++ b/gtk/SystemTrayIcon.h
@@ -5,8 +5,9 @@
 
 #pragma once
 
-#include <glibmm/refptr.h>
 #include <gtkmm/window.h>
+
+#include <glibmm/refptr.h>
 
 #include <memory>
 

--- a/gtk/Torrent.cc
+++ b/gtk/Torrent.cc
@@ -10,8 +10,8 @@
 #include "Percents.h"
 #include "Utils.h"
 
-#include <libtransmission/transmission.h>
 #include <libtransmission/macros.h>
+#include <libtransmission/transmission.h>
 #include <libtransmission/utils.h>
 #include <libtransmission/values.h>
 

--- a/gtk/Torrent.h
+++ b/gtk/Torrent.h
@@ -10,12 +10,14 @@
 #include <libtransmission/transmission.h>
 #include <libtransmission/values.h>
 
+#include <gtkmm/treemodelcolumn.h>
+
 #include <giomm/icon.h>
+
 #include <glibmm/extraclassinit.h>
 #include <glibmm/object.h>
 #include <glibmm/refptr.h>
 #include <glibmm/ustring.h>
-#include <gtkmm/treemodelcolumn.h>
 
 #include <algorithm>
 #include <bitset>

--- a/gtk/TorrentCellRenderer.cc
+++ b/gtk/TorrentCellRenderer.cc
@@ -12,19 +12,22 @@
 #include <libtransmission/types.h>
 #include <libtransmission/utils.h> /* tr_truncd() */
 
-#include <cairomm/context.h>
-#include <cairomm/refptr.h>
-#include <cairomm/surface.h>
 #include <gdkmm/rectangle.h>
 #include <gdkmm/rgba.h>
-#include <giomm/icon.h>
-#include <glibmm.h>
-#include <glibmm/i18n.h>
-#include <glibmm/property.h>
 #include <gtkmm/cellrendererpixbuf.h>
 #include <gtkmm/cellrendererprogress.h>
 #include <gtkmm/cellrenderertext.h>
 #include <gtkmm/requisition.h>
+
+#include <cairomm/context.h>
+#include <cairomm/refptr.h>
+#include <cairomm/surface.h>
+
+#include <giomm/icon.h>
+
+#include <glibmm.h>
+#include <glibmm/i18n.h>
+#include <glibmm/property.h>
 
 #if GTKMM_CHECK_VERSION(4, 0, 0)
 #include <gtkmm/snapshot.h>

--- a/gtk/TorrentCellRenderer.h
+++ b/gtk/TorrentCellRenderer.h
@@ -7,8 +7,9 @@
 
 #include "GtkCompat.h"
 
-#include <glibmm/propertyproxy.h>
 #include <gtkmm/cellrenderer.h>
+
+#include <glibmm/propertyproxy.h>
 
 #include <memory>
 

--- a/gtk/TorrentFilter.cc
+++ b/gtk/TorrentFilter.cc
@@ -8,8 +8,8 @@
 #include "FilterBase.hh"
 #include "Utils.h"
 
-#include <libtransmission/transmission.h>
 #include <libtransmission/macros.h>
+#include <libtransmission/transmission.h>
 
 #include <algorithm>
 #include <array>

--- a/gtk/Utils.cc
+++ b/gtk/Utils.cc
@@ -9,31 +9,33 @@
 #include "PrefsDialog.h"
 #include "Session.h"
 
-#include <libtransmission/transmission.h> /* TR_RATIO_NA, TR_RATIO_INF */
 #include <libtransmission/error.h>
 #include <libtransmission/macros.h>
 #include <libtransmission/string-utils.h>
 #include <libtransmission/torrent-metainfo.h>
 #include <libtransmission/tr-strbuf.h>
+#include <libtransmission/transmission.h> /* TR_RATIO_NA, TR_RATIO_INF */
 #include <libtransmission/utils.h> /* tr_strratio() */
 #include <libtransmission/values.h>
 #include <libtransmission/version.h> /* SHORT_VERSION_STRING */
 #include <libtransmission/web-utils.h>
 
 #include <gdkmm/display.h>
-#include <giomm/appinfo.h>
-#include <giomm/asyncresult.h>
-#include <giomm/file.h>
-#include <glibmm/convert.h>
-#include <glibmm/error.h>
-#include <glibmm/i18n.h>
-#include <glibmm/quark.h>
-#include <glibmm/spawn.h>
 #include <gtkmm/cellrenderertext.h>
 #include <gtkmm/liststore.h>
 #include <gtkmm/messagedialog.h>
 #include <gtkmm/treemodel.h>
 #include <gtkmm/treemodelcolumn.h>
+
+#include <giomm/appinfo.h>
+#include <giomm/asyncresult.h>
+#include <giomm/file.h>
+
+#include <glibmm/convert.h>
+#include <glibmm/error.h>
+#include <glibmm/i18n.h>
+#include <glibmm/quark.h>
+#include <glibmm/spawn.h>
 
 #if GTKMM_CHECK_VERSION(4, 0, 0)
 #include <gdkmm/clipboard.h>
@@ -53,8 +55,9 @@
 #include <stdexcept>
 #include <utility>
 
-#include <gdk/gdk.h>
 #include <gtk/gtk.h>
+
+#include <gdk/gdk.h>
 
 #if GTK_CHECK_VERSION(4, 0, 0) && defined(GDK_WINDOWING_X11)
 #include <optional>

--- a/gtk/Utils.h
+++ b/gtk/Utils.h
@@ -10,10 +10,6 @@
 #include <libtransmission/transmission.h>
 #include <libtransmission/values.h>
 
-#include <glibmm/objectbase.h>
-#include <glibmm/refptr.h>
-#include <glibmm/signalproxy.h>
-#include <glibmm/ustring.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/combobox.h>
 #include <gtkmm/entry.h>
@@ -21,6 +17,11 @@
 #include <gtkmm/treeview.h>
 #include <gtkmm/widget.h>
 #include <gtkmm/window.h>
+
+#include <glibmm/objectbase.h>
+#include <glibmm/refptr.h>
+#include <glibmm/signalproxy.h>
+#include <glibmm/ustring.h>
 
 #if GTKMM_CHECK_VERSION(4, 0, 0)
 #include <gtkmm/listview.h>

--- a/gtk/main.cc
+++ b/gtk/main.cc
@@ -11,13 +11,16 @@
 
 #include <libtransmission-app/app.h>
 
-#include <libtransmission/transmission.h>
 #include <libtransmission/macros.h>
+#include <libtransmission/transmission.h>
 #include <libtransmission/utils.h>
 #include <libtransmission/version.h>
 
+#include <gtkmm.h>
+
 #include <giomm/file.h>
 #include <giomm/init.h>
+
 #include <glibmm/i18n.h>
 #include <glibmm/init.h>
 #include <glibmm/miscutils.h>
@@ -27,7 +30,6 @@
 #include <glibmm/optiongroup.h>
 #include <glibmm/ustring.h>
 #include <glibmm/wrap.h>
-#include <gtkmm.h>
 
 #include <fmt/format.h>
 

--- a/qt/.clang-format
+++ b/qt/.clang-format
@@ -1,0 +1,67 @@
+---
+BasedOnStyle: InheritParentConfig
+
+IncludeBlocks: Regroup
+IncludeCategories:
+  # The Windows SDK headers form one block (a single Priority) whose order within the
+  # block is pinned by SortPriority: the SDK does not include its own prerequisites,
+  # so winsock2.h and windows.h have to precede the headers that use their macros.
+  # Every SortPriority below is lower than any other category's Priority, which is
+  # what keeps this block ahead of the rest.
+  - Regex: '^<winsock2\.h>'
+    Priority: 1
+    SortPriority: 1
+  - Regex: '^<windows\.h>'
+    Priority: 1
+    SortPriority: 2
+  - Regex: '^<(objbase|shellapi|ws2tcpip)\.h>'
+    Priority: 1
+    SortPriority: 3
+  # CaseSensitive keeps this off the unqualified Qt headers below: these regexes are
+  # matched case-insensitively by default, and the first match wins.
+  - Regex: '^<[a-z_]+>'
+    Priority: 4
+    CaseSensitive: true
+  - Regex: '^<(fmt|sigslot|small|woke)/'
+    Priority: 5
+  # The Qt stack, lowest layer first: each tier only depends on the ones above it.
+  # QtCore -> QtGui -> QtWidgets is the spine; QtNetwork and QtDBus sit on QtCore
+  # alone, and the ActiveQt/WinExtras modules are Windows-only leaves.
+  - Regex: '^<QtCore/'
+    Priority: 6
+  - Regex: '^<QtGui/'
+    Priority: 7
+  # QAction and QActionGroup moved from QtWidgets (Qt5) to QtGui (Qt6), so they stay
+  # unqualified; group them with QtGui, where they live in the Qt version we build
+  # against by default.
+  - Regex: '^<QAction(Group)?>'
+    Priority: 7
+  - Regex: '^<QtWidgets/'
+    Priority: 8
+  - Regex: '^<QtSvg/'
+    Priority: 9
+  - Regex: '^<QtNetwork/'
+    Priority: 10
+  - Regex: '^<QtDBus/'
+    Priority: 11
+  - Regex: '^<Qt(AxContainer|AxServer|WinExtras)/'
+    Priority: 12
+  - Regex: '^[<"]libtransmission/'
+    Priority: 13
+  - Regex: '^[<"]libtransmission-app/'
+    Priority: 14
+  - Regex: '.*'
+    Priority: 16
+SortIncludes:
+  Enabled: true
+  IgnoreCase: true
+
+# Workaround. Needed until we adopt a version that includes https://github.com/llvm/llvm-project/pull/192283
+BreakAfterOpenBracketFunction: true
+BreakAfterOpenBracketIf: true
+BreakAfterOpenBracketLoop: true
+BreakAfterOpenBracketSwitch: true
+BreakBeforeCloseBracketFunction: false
+BreakBeforeCloseBracketIf: false
+BreakBeforeCloseBracketLoop: false
+BreakBeforeCloseBracketSwitch: false

--- a/qt/AboutDialog.cc
+++ b/qt/AboutDialog.cc
@@ -3,15 +3,18 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <QApplication>
-#include <QIcon>
-#include <QMessageBox>
-#include <QPushButton>
+#include "AboutDialog.h"
+
+#include <QtGui/QIcon>
+
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QPushButton>
 
 #include <libtransmission/macros.h>
+#include <libtransmission/transmission.h>
 #include <libtransmission/version.h>
 
-#include "AboutDialog.h"
 #include "LicenseDialog.h"
 #include "Session.h"
 #include "Utils.h"

--- a/qt/AboutDialog.h
+++ b/qt/AboutDialog.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <QPointer>
+#include <QtCore/QPointer>
 
 #include "BaseDialog.h"
 #include "ui_AboutDialog.h"

--- a/qt/AccessibleSqueezeLabel.cc
+++ b/qt/AccessibleSqueezeLabel.cc
@@ -7,7 +7,7 @@
 
 #if QT_CONFIG(accessibility)
 
-#include <QMetaProperty>
+#include <QtCore/QMetaProperty>
 
 #include "AccessibleSqueezeLabel.h"
 #include "SqueezeLabel.h"

--- a/qt/AccessibleSqueezeLabel.h
+++ b/qt/AccessibleSqueezeLabel.h
@@ -9,7 +9,7 @@
 
 #if QT_CONFIG(accessibility)
 
-#include <QAccessibleWidget>
+#include <QtWidgets/QAccessibleWidget>
 
 class SqueezeLabel;
 

--- a/qt/AddData.cc
+++ b/qt/AddData.cc
@@ -3,17 +3,17 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <QDir>
-#include <QFile>
-#include <QFileInfo>
+#include "AddData.h"
 
-#include <libtransmission/transmission.h>
+#include <QtCore/QDir>
+#include <QtCore/QFile>
+#include <QtCore/QFileInfo>
 
 #include <libtransmission/error.h>
 #include <libtransmission/torrent-metainfo.h>
+#include <libtransmission/transmission.h>
 #include <libtransmission/web-utils.h>
 
-#include "AddData.h"
 #include "Utils.h"
 
 namespace

--- a/qt/AddData.h
+++ b/qt/AddData.h
@@ -7,9 +7,9 @@
 
 #include <optional>
 
-#include <QByteArray>
-#include <QString>
-#include <QUrl>
+#include <QtCore/QByteArray>
+#include <QtCore/QString>
+#include <QtCore/QUrl>
 
 class AddData
 {

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -11,21 +11,23 @@
 #include <utility>
 #include <vector>
 
-#include <QIcon>
-#include <QLibraryInfo>
-#include <QMessageBox>
-#include <QProcess>
-#include <QRect>
-#include <QSystemTrayIcon>
+#include <QtCore/QLibraryInfo>
+#include <QtCore/QProcess>
+#include <QtCore/QRect>
+
+#include <QtGui/QIcon>
+
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QSystemTrayIcon>
 
 #ifdef QT_DBUS_LIB
-#include <QDBusConnection>
-#include <QDBusMessage>
-#include <QDBusReply>
+#include <QtDBus/QDBusConnection>
+#include <QtDBus/QDBusMessage>
+#include <QtDBus/QDBusReply>
 #endif
 
 #if QT_CONFIG(accessibility)
-#include <QAccessible>
+#include <QtGui/QAccessible>
 #endif
 
 #include <libtransmission/macros.h>

--- a/qt/Application.h
+++ b/qt/Application.h
@@ -10,13 +10,15 @@
 #include <optional>
 #include <unordered_set>
 
-#include <QApplication>
-#include <QPixmap>
-#include <QPointer>
-#include <QRegularExpression>
-#include <QTimer>
-#include <QTranslator>
-#include <QWeakPointer>
+#include <QtCore/QPointer>
+#include <QtCore/QRegularExpression>
+#include <QtCore/QTimer>
+#include <QtCore/QTranslator>
+#include <QtCore/QWeakPointer>
+
+#include <QtGui/QPixmap>
+
+#include <QtWidgets/QApplication>
 
 #include <libtransmission/quark.h>
 

--- a/qt/BaseDialog.h
+++ b/qt/BaseDialog.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <QDialog>
+#include <QtWidgets/QDialog>
 
 class BaseDialog : public QDialog
 {

--- a/qt/ColumnResizer.cc
+++ b/qt/ColumnResizer.cc
@@ -3,10 +3,11 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <QEvent>
-#include <QGridLayout>
-
 #include "ColumnResizer.h"
+
+#include <QtCore/QEvent>
+
+#include <QtWidgets/QGridLayout>
 
 namespace
 {

--- a/qt/ColumnResizer.h
+++ b/qt/ColumnResizer.h
@@ -7,8 +7,8 @@
 
 #include <set>
 
-#include <QObject>
-#include <QTimer>
+#include <QtCore/QObject>
+#include <QtCore/QTimer>
 
 class QGridLayout;
 

--- a/qt/ComInteropHelper.cc
+++ b/qt/ComInteropHelper.cc
@@ -3,16 +3,18 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "ComInteropHelper.h"
+
 #include <windows.h>
 #include <objbase.h>
 
-#include <QAxFactory>
-#include <QString>
-#include <QVariant>
+#include <QtCore/QString>
+#include <QtCore/QVariant>
+
+#include <QtAxServer/QAxFactory>
 
 #include "libtransmission/macros.h"
 
-#include "ComInteropHelper.h"
 #include "InteropObject.h"
 
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)

--- a/qt/ComInteropHelper.h
+++ b/qt/ComInteropHelper.h
@@ -7,7 +7,7 @@
 
 #include <memory>
 
-#include <QAxObject>
+#include <QtAxContainer/QAxObject>
 
 class QObject;
 class QString;

--- a/qt/DBusInteropHelper.cc
+++ b/qt/DBusInteropHelper.cc
@@ -3,16 +3,18 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <QDBusConnection>
-#include <QDBusMessage>
-#include <QDBusReply>
-#include <QString>
-#include <QVariant>
-#include <QtDebug>
+#include "DBusInteropHelper.h"
+
+#include <QtCore/QString>
+#include <QtCore/QtDebug>
+#include <QtCore/QVariant>
+
+#include <QtDBus/QDBusConnection>
+#include <QtDBus/QDBusMessage>
+#include <QtDBus/QDBusReply>
 
 #include "libtransmission/macros.h"
 
-#include "DBusInteropHelper.h"
 #include "InteropObject.h"
 
 bool DBusInteropHelper::isConnected() const

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -3,33 +3,38 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "DetailsDialog.h"
+
 #include <algorithm>
 #include <cassert>
 #include <cstring>
 #include <ctime>
 #include <map>
-#include <set>
 #include <ranges>
+#include <set>
 #include <utility>
 
-#include <QDateTime>
-#include <QDesktopServices>
-#include <QEvent>
-#include <QFont>
-#include <QFontMetrics>
-#include <QHeaderView>
-#include <QHostAddress>
-#include <QInputDialog>
-#include <QItemSelectionModel>
-#include <QLabel>
-#include <QList>
-#include <QMessageBox>
-#include <QResizeEvent>
-#include <QRegularExpression>
-#include <QStringList>
-#include <QString>
-#include <QStyle>
-#include <QTreeWidgetItem>
+#include <QtCore/QDateTime>
+#include <QtCore/QEvent>
+#include <QtCore/QItemSelectionModel>
+#include <QtCore/QList>
+#include <QtCore/QRegularExpression>
+#include <QtCore/QString>
+#include <QtCore/QStringList>
+
+#include <QtGui/QDesktopServices>
+#include <QtGui/QFont>
+#include <QtGui/QFontMetrics>
+#include <QtGui/QResizeEvent>
+
+#include <QtWidgets/QHeaderView>
+#include <QtWidgets/QInputDialog>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QStyle>
+#include <QtWidgets/QTreeWidgetItem>
+
+#include <QtNetwork/QHostAddress>
 
 #include <libtransmission/announce-list.h>
 #include <libtransmission/quark.h>
@@ -38,7 +43,6 @@
 
 #include "BaseDialog.h"
 #include "ColumnResizer.h"
-#include "DetailsDialog.h"
 #include "Formatter.h"
 #include "IconCache.h"
 #include "NativeIcon.h"
@@ -51,9 +55,8 @@
 #include "TrackerDelegate.h"
 #include "TrackerModel.h"
 #include "TrackerModelFilter.h"
-#include "Utils.h"
-
 #include "ui_TrackersDialog.h"
+#include "Utils.h"
 
 class Prefs;
 class Session;

--- a/qt/DetailsDialog.h
+++ b/qt/DetailsDialog.h
@@ -9,13 +9,12 @@
 #include <memory>
 #include <unordered_set>
 
-#include <QString>
-#include <QTimer>
+#include <QtCore/QString>
+#include <QtCore/QTimer>
 
 #include "BaseDialog.h"
 #include "Session.h"
 #include "Typedefs.h"
-
 #include "ui_DetailsDialog.h"
 
 class QResizeEvent;

--- a/qt/FaviconCache.cc
+++ b/qt/FaviconCache.cc
@@ -4,11 +4,13 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <libtransmission-app/favicon-cache.h>
+#include <QtCore/QStandardPaths>
 
-#include <QApplication>
-#include <QPixmap>
-#include <QStandardPaths>
+#include <QtGui/QPixmap>
+
+#include <QtWidgets/QApplication>
+
+#include <libtransmission-app/favicon-cache.h>
 
 #include "Utils.h"
 

--- a/qt/FileTreeDelegate.cc
+++ b/qt/FileTreeDelegate.cc
@@ -3,10 +3,12 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <QApplication>
-#include <QPainter>
-
 #include "FileTreeDelegate.h"
+
+#include <QtGui/QPainter>
+
+#include <QtWidgets/QApplication>
+
 #include "FileTreeModel.h"
 #include "StyleHelper.h"
 

--- a/qt/FileTreeDelegate.h
+++ b/qt/FileTreeDelegate.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <QItemDelegate>
+#include <QtWidgets/QItemDelegate>
 
 class FileTreeDelegate : public QItemDelegate
 {

--- a/qt/FileTreeItem.cc
+++ b/qt/FileTreeItem.cc
@@ -3,16 +3,17 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "FileTreeItem.h"
+
 #include <algorithm>
 #include <cassert>
-#include <utility>
 #include <ranges>
+#include <utility>
 
 #include <small/set.hpp>
 
 #include <libtransmission/types.h> // priorities
 
-#include "FileTreeItem.h"
 #include "FileTreeModel.h"
 #include "Formatter.h"
 #include "IconCache.h"

--- a/qt/FileTreeItem.h
+++ b/qt/FileTreeItem.h
@@ -10,14 +10,14 @@
 #include <utility>
 #include <vector>
 
-#include <QCoreApplication>
-#include <QString>
-#include <QVariant>
-
-#include "Utils.h" // for std::hash<QString>
-#include "Typedefs.h"
+#include <QtCore/QCoreApplication>
+#include <QtCore/QString>
+#include <QtCore/QVariant>
 
 #include "libtransmission/macros.h"
+
+#include "Typedefs.h"
+#include "Utils.h" // for std::hash<QString>
 
 class FileTreeItem
 {

--- a/qt/FileTreeModel.cc
+++ b/qt/FileTreeModel.cc
@@ -3,6 +3,8 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "FileTreeModel.h"
+
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
@@ -13,13 +15,12 @@
 
 #include <small/map.hpp>
 
+#include <QtCore/QAbstractItemModel>
+#include <QtCore/QMutableListIterator>
+
 #include <libtransmission/types.h> // priorities
 
-#include <QAbstractItemModel>
-#include <QMutableListIterator>
-
 #include "FileTreeItem.h"
-#include "FileTreeModel.h"
 #include "QtCompat.h"
 
 namespace

--- a/qt/FileTreeModel.h
+++ b/qt/FileTreeModel.h
@@ -10,7 +10,7 @@
 #include <memory>
 #include <set>
 
-#include <QAbstractItemModel>
+#include <QtCore/QAbstractItemModel>
 
 #include "Typedefs.h" // file_indices_t
 

--- a/qt/FileTreeView.cc
+++ b/qt/FileTreeView.cc
@@ -3,23 +3,26 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "FileTreeView.h"
+
 #include <algorithm>
 #include <cassert>
 #include <queue>
 #include <ranges>
 #include <set>
 
-#include <QHeaderView>
-#include <QMenu>
-#include <QResizeEvent>
-#include <QSortFilterProxyModel>
+#include <QtCore/QSortFilterProxyModel>
+
+#include <QtGui/QResizeEvent>
+
+#include <QtWidgets/QHeaderView>
+#include <QtWidgets/QMenu>
 
 #include <libtransmission/types.h> // priorities
 
 #include "FileTreeDelegate.h"
 #include "FileTreeItem.h"
 #include "FileTreeModel.h"
-#include "FileTreeView.h"
 #include "Formatter.h"
 #include "Utils.h"
 

--- a/qt/FileTreeView.h
+++ b/qt/FileTreeView.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <QTreeView>
+#include <QtWidgets/QTreeView>
 
 #include "Torrent.h" // FileList
 #include "Typedefs.h" // file_indices_t

--- a/qt/FilterBar.cc
+++ b/qt/FilterBar.cc
@@ -9,10 +9,11 @@
 #include <unordered_map>
 #include <utility>
 
-#include <QHBoxLayout>
-#include <QLabel>
-#include <QLineEdit>
-#include <QStandardItemModel>
+#include <QtGui/QStandardItemModel>
+
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QLineEdit>
 
 #include "Application.h"
 #include "FilterBarComboBox.h"

--- a/qt/FilterBar.h
+++ b/qt/FilterBar.h
@@ -9,10 +9,12 @@
 
 #include <small/map.hpp>
 
-#include <QLineEdit>
-#include <QStandardItemModel>
-#include <QTimer>
-#include <QWidget>
+#include <QtCore/QTimer>
+
+#include <QtGui/QStandardItemModel>
+
+#include <QtWidgets/QLineEdit>
+#include <QtWidgets/QWidget>
 
 #include "Prefs.h"
 #include "Torrent.h"

--- a/qt/FilterBarComboBox.cc
+++ b/qt/FilterBarComboBox.cc
@@ -3,16 +3,19 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "FilterBarComboBox.h"
+
 #include <algorithm>
 
-#include <QApplication>
-#include <QComboBox>
-#include <QPen>
-#include <QRect>
-#include <QStyle>
-#include <QStylePainter>
+#include <QtCore/QRect>
 
-#include "FilterBarComboBox.h"
+#include <QtGui/QPen>
+
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QStyle>
+#include <QtWidgets/QStylePainter>
+
 #include "StyleHelper.h"
 #include "Utils.h"
 

--- a/qt/FilterBarComboBox.h
+++ b/qt/FilterBarComboBox.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <QComboBox>
+#include <QtWidgets/QComboBox>
 
 class FilterBarComboBox : public QComboBox
 {

--- a/qt/FilterBarComboBoxDelegate.cc
+++ b/qt/FilterBarComboBoxDelegate.cc
@@ -3,13 +3,15 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <QAbstractItemView>
-#include <QComboBox>
-#include <QStandardItemModel>
-#include <QStyle>
+#include "FilterBarComboBoxDelegate.h"
+
+#include <QtGui/QStandardItemModel>
+
+#include <QtWidgets/QAbstractItemView>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QStyle>
 
 #include "FilterBarComboBox.h"
-#include "FilterBarComboBoxDelegate.h"
 #include "StyleHelper.h"
 #include "Utils.h"
 

--- a/qt/FilterBarComboBoxDelegate.h
+++ b/qt/FilterBarComboBoxDelegate.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <QItemDelegate>
+#include <QtWidgets/QItemDelegate>
 
 class QAbstractItemModel;
 class QComboBox;

--- a/qt/Filters.h
+++ b/qt/Filters.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include "UserMetaType.h"
 #include "Torrent.h"
+#include "UserMetaType.h"
 
 // The Torrent properties that can affect ShowMode filtering.
 // When one of these changes, it's time to refilter.

--- a/qt/Formatter.h
+++ b/qt/Formatter.h
@@ -8,8 +8,8 @@
 #include <array>
 #include <cstdint> // int64_t
 
-#include <QCoreApplication> // Q_DECLARE_TR_FUNCTIONS
-#include <QString>
+#include <QtCore/QCoreApplication> // Q_DECLARE_TR_FUNCTIONS
+#include <QtCore/QString>
 
 #include "Speed.h"
 

--- a/qt/FreeSpaceLabel.cc
+++ b/qt/FreeSpaceLabel.cc
@@ -3,13 +3,16 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "FreeSpaceLabel.h"
+
 #include <cstdint>
 
-#include <QDir>
-#include <QLabel>
-#include <QPointer>
-#include <QString>
-#include <QWidget>
+#include <QtCore/QDir>
+#include <QtCore/QPointer>
+#include <QtCore/QString>
+
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QWidget>
 
 #include <libtransmission/converters.h>
 #include <libtransmission/quark.h>
@@ -17,7 +20,6 @@
 #include <libtransmission/variant.h>
 
 #include "Formatter.h"
-#include "FreeSpaceLabel.h"
 #include "Session.h"
 #include "VariantHelpers.h"
 

--- a/qt/FreeSpaceLabel.h
+++ b/qt/FreeSpaceLabel.h
@@ -5,9 +5,10 @@
 
 #pragma once
 
-#include <QLabel>
-#include <QString>
-#include <QTimer>
+#include <QtCore/QString>
+#include <QtCore/QTimer>
+
+#include <QtWidgets/QLabel>
 
 class Session;
 

--- a/qt/IconCache.cc
+++ b/qt/IconCache.cc
@@ -10,23 +10,25 @@
 #include <shellapi.h>
 #endif
 
-#include <QApplication>
-#include <QFile>
-#include <QFileIconProvider>
-#include <QFileInfo>
-#include <QIcon>
-#include <QMimeDatabase>
-#include <QObject>
-#include <QPainter>
-#include <QPixmap>
-#include <QStyle>
+#include <QtCore/QFile>
+#include <QtCore/QFileInfo>
+#include <QtCore/QMimeDatabase>
+#include <QtCore/QObject>
+
+#include <QtGui/QIcon>
+#include <QtGui/QPainter>
+#include <QtGui/QPixmap>
+
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QFileIconProvider>
+#include <QtWidgets/QStyle>
 
 #ifdef _WIN32
-#include <QPixmapCache>
+#include <QtGui/QPixmapCache>
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-#include <QImage>
+#include <QtGui/QImage>
 #else
-#include <QtWin>
+#include <QtWinExtras/QtWin>
 #endif
 
 #include "QtCompat.h"

--- a/qt/IconCache.h
+++ b/qt/IconCache.h
@@ -12,10 +12,12 @@
 #include <optional>
 #include <unordered_map>
 
-#include <QFileIconProvider>
-#include <QIcon>
-#include <QString>
-#include <QStyle>
+#include <QtCore/QString>
+
+#include <QtGui/QIcon>
+
+#include <QtWidgets/QFileIconProvider>
+#include <QtWidgets/QStyle>
 
 #include "Utils.h" // std::hash<QString>()
 

--- a/qt/IconToolButton.cc
+++ b/qt/IconToolButton.cc
@@ -3,12 +3,12 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <QStyle>
-#include <QStyleOption>
-#include <QStyleOptionToolButton>
-#include <QStylePainter>
-
 #include "IconToolButton.h"
+
+#include <QtWidgets/QStyle>
+#include <QtWidgets/QStyleOption>
+#include <QtWidgets/QStyleOptionToolButton>
+#include <QtWidgets/QStylePainter>
 
 IconToolButton::IconToolButton(QWidget* parent)
     : QToolButton{ parent }

--- a/qt/IconToolButton.h
+++ b/qt/IconToolButton.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <QToolButton>
+#include <QtWidgets/QToolButton>
 
 class IconToolButton : public QToolButton
 {

--- a/qt/InteropHelper.cc
+++ b/qt/InteropHelper.cc
@@ -3,9 +3,9 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <QVariant>
-
 #include "InteropHelper.h"
+
+#include <QtCore/QVariant>
 
 bool InteropHelper::isConnected() const
 {

--- a/qt/InteropObject.cc
+++ b/qt/InteropObject.cc
@@ -3,9 +3,10 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "InteropObject.h"
+
 #include "AddData.h"
 #include "Application.h"
-#include "InteropObject.h"
 
 InteropObject::InteropObject(QObject* parent)
     : QObject{ parent }

--- a/qt/InteropObject.h
+++ b/qt/InteropObject.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <QObject>
+#include <QtCore/QObject>
 
 #include "libtransmission/macros.h"
 

--- a/qt/LicenseDialog.cc
+++ b/qt/LicenseDialog.cc
@@ -3,10 +3,11 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <QWidget>
+#include "LicenseDialog.h"
+
+#include <QtWidgets/QWidget>
 
 #include "BaseDialog.h"
-#include "LicenseDialog.h"
 
 LicenseDialog::LicenseDialog(QWidget* parent)
     : BaseDialog{ parent }

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -3,6 +3,8 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "MainWindow.h"
+
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -10,14 +12,20 @@
 #include <ranges>
 #include <utility>
 
-#include <QCheckBox>
-#include <QFileDialog>
-#include <QIcon>
-#include <QLabel>
-#include <QMessageBox>
-#include <QPainter>
-#include <QProxyStyle>
-#include <QtGui>
+#include <QtCore/QMimeData>
+#include <QtCore/QProcess> // openSelect() on Windows and macOS
+
+#include <QActionGroup> // unqualified: QtWidgets on Qt5, QtGui on Qt6
+#include <QtGui/QClipboard>
+#include <QtGui/QDesktopServices>
+#include <QtGui/QIcon>
+#include <QtGui/QPainter>
+
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QFileDialog>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QProxyStyle>
 
 #include "libtransmission/macros.h"
 #include "libtransmission/magnet-metainfo.h"
@@ -30,7 +38,6 @@
 #include "FilterBar.h"
 #include "Filters.h"
 #include "Formatter.h"
-#include "MainWindow.h"
 #include "MakeDialog.h"
 #include "NativeIcon.h"
 #include "OptionsDialog.h"

--- a/qt/MainWindow.h
+++ b/qt/MainWindow.h
@@ -9,12 +9,14 @@
 #include <ctime>
 #include <memory>
 
-#include <QMainWindow>
-#include <QNetworkReply>
-#include <QPointer>
-#include <QStringList>
-#include <QSystemTrayIcon>
-#include <QTimer>
+#include <QtCore/QPointer>
+#include <QtCore/QStringList>
+#include <QtCore/QTimer>
+
+#include <QtWidgets/QMainWindow>
+#include <QtWidgets/QSystemTrayIcon>
+
+#include <QtNetwork/QNetworkReply>
 
 #include "Filters.h"
 #include "Prefs.h"

--- a/qt/MakeDialog.cc
+++ b/qt/MakeDialog.cc
@@ -11,13 +11,14 @@
 #include <utility>
 #include <vector>
 
-#include <QDialogButtonBox>
-#include <QDir>
-#include <QFileInfo>
-#include <QMimeData>
-#include <QPushButton>
-#include <QString>
-#include <QTimer>
+#include <QtCore/QDir>
+#include <QtCore/QFileInfo>
+#include <QtCore/QMimeData>
+#include <QtCore/QString>
+#include <QtCore/QTimer>
+
+#include <QtWidgets/QDialogButtonBox>
+#include <QtWidgets/QPushButton>
 
 #include <libtransmission/announce-list.h>
 #include <libtransmission/error.h>
@@ -27,9 +28,8 @@
 #include "Formatter.h"
 #include "QtCompat.h"
 #include "Session.h"
-#include "Utils.h"
-
 #include "ui_MakeProgressDialog.h"
+#include "Utils.h"
 
 namespace
 {

--- a/qt/NativeIcon.cc
+++ b/qt/NativeIcon.cc
@@ -4,23 +4,26 @@
 // License text can be found in the licenses/ folder.
 
 #include "NativeIcon.h"
-#include "Utils.h"
 
 #include <optional>
 #include <string_view>
 
-#include <QChar>
-#include <QFontDatabase>
-#include <QOperatingSystemVersion>
-#include <QStyle>
+#include <small/set.hpp>
+
+#include <QtCore/QChar>
+#include <QtCore/QOperatingSystemVersion>
+
 #include <QtGui/QFont>
+#include <QtGui/QFontDatabase>
 #include <QtGui/QGuiApplication> // qApp
 #include <QtGui/QIcon>
 #include <QtGui/QPainter>
 #include <QtGui/QPalette>
 #include <QtGui/QPixmap>
 
-#include <small/set.hpp>
+#include <QtWidgets/QStyle>
+
+#include "Utils.h"
 
 #if defined(Q_OS_MAC)
 extern QPixmap loadSFSymbol(QString symbol_name, int pixel_size);

--- a/qt/NativeIcon.h
+++ b/qt/NativeIcon.h
@@ -5,9 +5,10 @@
 
 #pragma once
 
-#include <QApplication>
-#include <QIcon>
-#include <QStyle>
+#include <QtGui/QIcon>
+
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QStyle>
 
 namespace icons
 {

--- a/qt/NativeIconMac.mm
+++ b/qt/NativeIconMac.mm
@@ -3,13 +3,14 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#import <AppKit/AppKit.h>
+#import <QtGui/QColor>
+#import <QtGui/QImage>
+#import <QtGui/QPalette>
+#import <QtGui/QPixmap>
 
-#import <QApplication>
-#import <QColor>
-#import <QImage>
-#import <QPalette>
-#import <QPixmap>
+#import <QtWidgets/QApplication>
+
+#import <AppKit/AppKit.h>
 
 // Source: https://stackoverflow.com/a/74756071
 // Posted by Bri Bri

--- a/qt/OptionsDialog.cc
+++ b/qt/OptionsDialog.cc
@@ -3,25 +3,26 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "OptionsDialog.h"
+
 #include <algorithm>
 #include <utility>
 
-#include <QComboBox>
-#include <QFileInfo>
-#include <QLineEdit>
-#include <QPushButton>
+#include <QtCore/QFileInfo>
 
-#include <libtransmission/transmission.h>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QLineEdit>
+#include <QtWidgets/QPushButton>
 
 #include <libtransmission/converters.h>
 #include <libtransmission/quark.h>
 #include <libtransmission/torrent-metainfo.h>
+#include <libtransmission/transmission.h>
 #include <libtransmission/variant.h>
 
 #include "AddData.h"
 #include "FileTreeModel.h"
 #include "FreeSpaceLabel.h"
-#include "OptionsDialog.h"
 #include "Prefs.h"
 #include "Session.h"
 #include "Torrent.h"

--- a/qt/OptionsDialog.h
+++ b/qt/OptionsDialog.h
@@ -8,18 +8,19 @@
 #include <optional>
 #include <vector>
 
-#include <QDir>
-#include <QFile>
-#include <QString>
-#include <QTimer>
+#include <QtCore/QDir>
+#include <QtCore/QFile>
+#include <QtCore/QString>
+#include <QtCore/QTimer>
+
+#include <libtransmission/torrent-metainfo.h>
+#include <libtransmission/transmission.h>
 
 #include "AddData.h" // AddData
 #include "BaseDialog.h"
 #include "Torrent.h" // FileList
 #include "Typedefs.h" // file_indices_t
 #include "ui_OptionsDialog.h"
-
-#include <libtransmission/torrent-metainfo.h>
 
 class Prefs;
 class Session;

--- a/qt/PathButton.cc
+++ b/qt/PathButton.cc
@@ -3,18 +3,21 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <QAction>
-#include <QApplication>
-#include <QDir>
-#include <QFileDialog>
-#include <QFileIconProvider>
-#include <QFileInfo>
-#include <QMenu>
-#include <QStyle>
-#include <QStyleOptionToolButton>
-#include <QStylePainter>
-
 #include "PathButton.h"
+
+#include <QtCore/QDir>
+#include <QtCore/QFileInfo>
+
+#include <QAction> // unqualified: QtWidgets on Qt5, QtGui on Qt6
+
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QFileDialog>
+#include <QtWidgets/QFileIconProvider>
+#include <QtWidgets/QMenu>
+#include <QtWidgets/QStyle>
+#include <QtWidgets/QStyleOptionToolButton>
+#include <QtWidgets/QStylePainter>
+
 #include "Utils.h"
 
 PathButton::PathButton(QWidget* parent)

--- a/qt/PathButton.h
+++ b/qt/PathButton.h
@@ -5,8 +5,9 @@
 
 #pragma once
 
-#include <QStringList>
-#include <QToolButton>
+#include <QtCore/QStringList>
+
+#include <QtWidgets/QToolButton>
 
 class QMenu;
 

--- a/qt/Prefs.h
+++ b/qt/Prefs.h
@@ -5,14 +5,14 @@
 
 #pragma once
 
-#include <QObject>
-#include <QString>
+#include <sigslot/signal.hpp>
+
+#include <QtCore/QObject>
+#include <QtCore/QString>
 
 #include <libtransmission/quark.h>
 
 #include <libtransmission-app/prefs.h>
-
-#include <sigslot/signal.hpp>
 
 #include "UserMetaType.h"
 #include "VariantHelpers.h"

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -8,21 +8,22 @@
 #include <cassert>
 #include <optional>
 
-#include <QCheckBox>
-#include <QComboBox>
-#include <QCoreApplication>
-#include <QDialogButtonBox>
-#include <QDoubleSpinBox>
-#include <QHBoxLayout>
-#include <QLabel>
-#include <QLineEdit>
-#include <QMessageBox>
-#include <QPlainTextEdit>
-#include <QPushButton>
-#include <QSignalBlocker>
-#include <QSpinBox>
-#include <QTime>
-#include <QTimeEdit>
+#include <QtCore/QCoreApplication>
+#include <QtCore/QSignalBlocker>
+#include <QtCore/QTime>
+
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QDialogButtonBox>
+#include <QtWidgets/QDoubleSpinBox>
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QLineEdit>
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QPlainTextEdit>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QSpinBox>
+#include <QtWidgets/QTimeEdit>
 
 #include <libtransmission/quark.h>
 #include <libtransmission/types.h>

--- a/qt/QtCompat.h
+++ b/qt/QtCompat.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <QtGlobal>
+#include <QtCore/QtGlobal>
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #define IF_QT6(ThenValue, ElseValue) ThenValue

--- a/qt/RelocateDialog.cc
+++ b/qt/RelocateDialog.cc
@@ -3,16 +3,18 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "RelocateDialog.h"
+
 #include <utility>
 
-#include <QComboBox>
-#include <QDir>
-#include <QLineEdit>
+#include <QtCore/QDir>
+
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QLineEdit>
 
 #include <libtransmission/quark.h>
 
 #include "Prefs.h"
-#include "RelocateDialog.h"
 #include "Session.h"
 #include "Torrent.h"
 #include "TorrentModel.h"

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -3,15 +3,15 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "RpcClient.h"
+
 #include <functional>
 #include <optional>
 #include <string>
 #include <utility>
 
-#include "RpcClient.h"
-
-#include <QCoreApplication>
-#include <QTimer>
+#include <QtCore/QCoreApplication>
+#include <QtCore/QTimer>
 
 #include "Utils.h"
 

--- a/qt/RpcClient.h
+++ b/qt/RpcClient.h
@@ -7,17 +7,18 @@
 
 #include <array>
 
-#include <QObject>
-#include <QNetworkReply> // QNetworkReply::NetworkError
-#include <QString>
-#include <QUrl>
-
 #include <sigslot/signal.hpp>
 
-#include <libtransmission-app/rpc-client.h>
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QUrl>
+
+#include <QtNetwork/QNetworkReply> // QNetworkReply::NetworkError
 
 #include <libtransmission/quark.h>
 #include <libtransmission/variant.h>
+
+#include <libtransmission-app/rpc-client.h>
 
 struct tr_session;
 

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -3,6 +3,8 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "Session.h"
+
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -10,30 +12,29 @@
 #include <string_view>
 #include <utility>
 
-#include <QApplication>
-#include <QByteArray>
-#include <QClipboard>
-#include <QCoreApplication>
-#include <QDebug>
-#include <QDesktopServices>
-#include <QFile>
-#include <QFileInfo>
-#include <QMessageBox>
-#include <QStyle>
-#include <QTextStream>
-#include <QtDebug>
-
 #include <small/vector.hpp>
 
-#include <libtransmission/transmission.h>
+#include <QtCore/QByteArray>
+#include <QtCore/QCoreApplication>
+#include <QtCore/QDebug>
+#include <QtCore/QFile>
+#include <QtCore/QFileInfo>
+#include <QtCore/QtDebug>
+#include <QtCore/QTextStream>
+
+#include <QtGui/QClipboard>
+#include <QtGui/QDesktopServices>
+
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QStyle>
 
 #include <libtransmission/quark.h>
 #include <libtransmission/serializer.h>
 #include <libtransmission/session-id.h>
+#include <libtransmission/transmission.h>
 #include <libtransmission/utils.h>
 #include <libtransmission/variant.h>
-
-#include "Session.h"
 
 #include "AddData.h"
 #include "Filters.h"

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -14,20 +14,22 @@
 #include <type_traits>
 #include <vector>
 
-#include <QObject>
-#include <QString>
-#include <QNetworkReply>
-#include <QTimer>
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QTimer>
+
+#include <QtNetwork/QNetworkReply>
 
 #include <libtransmission/converters.h>
 #include <libtransmission/quark.h>
 #include <libtransmission/types.h>
 #include <libtransmission/variant.h>
 
-#include "Prefs.h"
-#include "RpcClient.h"
 #include <libtransmission-app/rpc-queue.h>
 #include <libtransmission-app/session.h>
+
+#include "Prefs.h"
+#include "RpcClient.h"
 #include "Torrent.h"
 #include "Typedefs.h"
 

--- a/qt/SessionDialog.cc
+++ b/qt/SessionDialog.cc
@@ -3,9 +3,10 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "SessionDialog.h"
+
 #include "Prefs.h"
 #include "Session.h"
-#include "SessionDialog.h"
 
 /***
 ****

--- a/qt/SessionDialog.h
+++ b/qt/SessionDialog.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <QWidgetList>
+#include <QtGui/QWidgetList>
 
 #include "BaseDialog.h"
 #include "ui_SessionDialog.h"

--- a/qt/Speed.h
+++ b/qt/Speed.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include <QCoreApplication> // Q_DECLARE_TR_FUNCTIONS
-#include <QString>
+#include <QtCore/QCoreApplication> // Q_DECLARE_TR_FUNCTIONS
+#include <QtCore/QString>
 
 #include <libtransmission/values.h>
 

--- a/qt/SqueezeLabel.cc
+++ b/qt/SqueezeLabel.cc
@@ -39,13 +39,15 @@
 **
 ****************************************************************************/
 
-#include <QPainter>
-#include <QStyle>
-#include <QStyleOption>
-#include <QTimer>
+#include <QtCore/QTimer>
+
+#include <QtGui/QPainter>
+
+#include <QtWidgets/QStyle>
+#include <QtWidgets/QStyleOption>
 
 #if QT_CONFIG(accessibility)
-#include <QAccessible>
+#include <QtGui/QAccessible>
 #endif
 
 #include "SqueezeLabel.h"

--- a/qt/SqueezeLabel.h
+++ b/qt/SqueezeLabel.h
@@ -41,7 +41,7 @@
 
 #pragma once
 
-#include <QLabel>
+#include <QtWidgets/QLabel>
 
 class SqueezeLabel : public QLabel
 {

--- a/qt/StatsDialog.cc
+++ b/qt/StatsDialog.cc
@@ -3,12 +3,13 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <QTimer>
+#include "StatsDialog.h"
+
+#include <QtCore/QTimer>
 
 #include "ColumnResizer.h"
 #include "Formatter.h"
 #include "Session.h"
-#include "StatsDialog.h"
 
 namespace
 {

--- a/qt/StatsDialog.h
+++ b/qt/StatsDialog.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <QTimer>
+#include <QtCore/QTimer>
 
 #include "BaseDialog.h"
 #include "ui_StatsDialog.h"

--- a/qt/StyleHelper.cc
+++ b/qt/StyleHelper.cc
@@ -3,13 +3,14 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "StyleHelper.h"
+
 #include <algorithm>
 
-#include <QPainter>
-#include <QStaticText>
-#include <QStyleOptionProgressBar>
+#include <QtGui/QPainter>
+#include <QtGui/QStaticText>
 
-#include "StyleHelper.h"
+#include <QtWidgets/QStyleOptionProgressBar>
 
 QIcon::Mode StyleHelper::getIconMode(QStyle::State const& state)
 {

--- a/qt/StyleHelper.h
+++ b/qt/StyleHelper.h
@@ -5,8 +5,9 @@
 
 #pragma once
 
-#include <QIcon>
-#include <QStyle>
+#include <QtGui/QIcon>
+
+#include <QtWidgets/QStyle>
 
 class QPainter;
 class QStyleOptionProgressBar;

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -3,12 +3,15 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <algorithm>
-#include <set>
-#include <ranges>
+#include "Torrent.h"
 
-#include <QApplication>
-#include <QString>
+#include <algorithm>
+#include <ranges>
+#include <set>
+
+#include <QtCore/QString>
+
+#include <QtWidgets/QApplication>
 
 #include <libtransmission/quark.h>
 #include <libtransmission/types.h>
@@ -17,7 +20,6 @@
 #include "Application.h"
 #include "IconCache.h"
 #include "Prefs.h"
-#include "Torrent.h"
 #include "Utils.h"
 #include "VariantHelpers.h"
 

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -15,11 +15,12 @@
 #include <tuple>
 #include <vector>
 
-#include <QIcon>
-#include <QMetaType>
-#include <QObject>
-#include <QString>
-#include <QStringList>
+#include <QtCore/QMetaType>
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QStringList>
+
+#include <QtGui/QIcon>
 
 #include <libtransmission/crypto-utils.h>
 #include <libtransmission/quark.h>

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -3,22 +3,25 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "TorrentDelegate.h"
+
 #include <utility>
 
-#include <QApplication>
-#include <QFont>
-#include <QFontMetrics>
-#include <QIcon>
-#include <QModelIndex>
-#include <QPainter>
-#include <QPixmap>
-#include <QPixmapCache>
-#include <QStyleOptionProgressBar>
+#include <QtCore/QModelIndex>
+
+#include <QtGui/QFont>
+#include <QtGui/QFontMetrics>
+#include <QtGui/QIcon>
+#include <QtGui/QPainter>
+#include <QtGui/QPixmap>
+#include <QtGui/QPixmapCache>
+
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QStyleOptionProgressBar>
 
 #include "Formatter.h"
 #include "StyleHelper.h"
 #include "Torrent.h"
-#include "TorrentDelegate.h"
 #include "TorrentModel.h"
 #include "Utils.h"
 

--- a/qt/TorrentDelegate.h
+++ b/qt/TorrentDelegate.h
@@ -7,7 +7,7 @@
 
 #include <optional>
 
-#include <QStyledItemDelegate>
+#include <QtWidgets/QStyledItemDelegate>
 
 #include "NativeIcon.h"
 

--- a/qt/TorrentDelegateMin.cc
+++ b/qt/TorrentDelegateMin.cc
@@ -3,25 +3,28 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "TorrentDelegateMin.h"
+
 #include <algorithm>
 #include <utility>
 
-#include <QApplication>
-#include <QBrush>
-#include <QFont>
-#include <QFontMetrics>
-#include <QIcon>
-#include <QModelIndex>
-#include <QPainter>
-#include <QPixmap>
-#include <QPixmapCache>
-#include <QStyleOptionProgressBar>
+#include <QtCore/QModelIndex>
+
+#include <QtGui/QBrush>
+#include <QtGui/QFont>
+#include <QtGui/QFontMetrics>
+#include <QtGui/QIcon>
+#include <QtGui/QPainter>
+#include <QtGui/QPixmap>
+#include <QtGui/QPixmapCache>
+
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QStyleOptionProgressBar>
 
 #include <libtransmission/utils.h>
 
 #include "StyleHelper.h"
 #include "Torrent.h"
-#include "TorrentDelegateMin.h"
 #include "TorrentModel.h"
 #include "Utils.h"
 

--- a/qt/TorrentFilter.cc
+++ b/qt/TorrentFilter.cc
@@ -3,6 +3,8 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "TorrentFilter.h"
+
 #include <array>
 #include <compare>
 #include <optional>
@@ -12,7 +14,6 @@
 #include "Filters.h"
 #include "Prefs.h"
 #include "Torrent.h"
-#include "TorrentFilter.h"
 #include "TorrentModel.h"
 #include "Utils.h"
 

--- a/qt/TorrentFilter.h
+++ b/qt/TorrentFilter.h
@@ -7,8 +7,8 @@
 
 #include <array>
 
-#include <QSortFilterProxyModel>
-#include <QTimer>
+#include <QtCore/QSortFilterProxyModel>
+#include <QtCore/QTimer>
 
 #include "Filters.h"
 #include "Prefs.h"

--- a/qt/TorrentModel.cc
+++ b/qt/TorrentModel.cc
@@ -3,6 +3,8 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "TorrentModel.h"
+
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
@@ -13,11 +15,11 @@
 #include <vector>
 
 #include <libtransmission/quark.h>
+#include <libtransmission/transmission.h>
 #include <libtransmission/variant.h>
 
 #include "Torrent.h"
 #include "TorrentDelegate.h"
-#include "TorrentModel.h"
 #include "VariantHelpers.h"
 
 /***

--- a/qt/TorrentModel.h
+++ b/qt/TorrentModel.h
@@ -9,7 +9,7 @@
 #include <utility>
 #include <vector>
 
-#include <QAbstractListModel>
+#include <QtCore/QAbstractListModel>
 
 #include "Torrent.h"
 #include "Typedefs.h"

--- a/qt/TorrentView.cc
+++ b/qt/TorrentView.cc
@@ -3,11 +3,11 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <QApplication>
-#include <QStyleOptionHeader>
-#include <QStylePainter>
-
 #include "TorrentView.h"
+
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QStyleOptionHeader>
+#include <QtWidgets/QStylePainter>
 
 class TorrentView::HeaderWidget : public QWidget
 {

--- a/qt/TorrentView.h
+++ b/qt/TorrentView.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <QListView>
+#include <QtWidgets/QListView>
 
 class TorrentView : public QListView
 {

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -3,11 +3,14 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <QAbstractTextDocumentLayout>
-#include <QApplication>
-#include <QPainter>
-#include <QPixmap>
-#include <QTextDocument>
+#include "TrackerDelegate.h"
+
+#include <QtGui/QAbstractTextDocumentLayout>
+#include <QtGui/QPainter>
+#include <QtGui/QPixmap>
+#include <QtGui/QTextDocument>
+
+#include <QtWidgets/QApplication>
 
 #include <libtransmission/web-utils.h>
 
@@ -15,7 +18,6 @@
 
 #include "Formatter.h"
 #include "Torrent.h"
-#include "TrackerDelegate.h"
 #include "TrackerModel.h"
 #include "Utils.h"
 

--- a/qt/TrackerDelegate.h
+++ b/qt/TrackerDelegate.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <QItemDelegate>
+#include <QtWidgets/QItemDelegate>
 
 class QStyle;
 

--- a/qt/TrackerModel.cc
+++ b/qt/TrackerModel.cc
@@ -3,14 +3,15 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "TrackerModel.h"
+
 #include <algorithm> // std::sort()
 #include <ranges>
 
-#include <QUrl>
+#include <QtCore/QUrl>
 
 #include "Application.h" // Application
 #include "TorrentModel.h"
-#include "TrackerModel.h"
 
 int TrackerModel::rowCount(QModelIndex const& parent) const
 {

--- a/qt/TrackerModel.h
+++ b/qt/TrackerModel.h
@@ -7,7 +7,7 @@
 
 #include <vector>
 
-#include <QAbstractListModel>
+#include <QtCore/QAbstractListModel>
 
 #include "Torrent.h"
 #include "Typedefs.h"

--- a/qt/TrackerModelFilter.cc
+++ b/qt/TrackerModelFilter.cc
@@ -3,8 +3,9 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include "TrackerModel.h"
 #include "TrackerModelFilter.h"
+
+#include "TrackerModel.h"
 
 TrackerModelFilter::TrackerModelFilter(QObject* parent)
     : QSortFilterProxyModel{ parent }

--- a/qt/TrackerModelFilter.h
+++ b/qt/TrackerModelFilter.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <QSortFilterProxyModel>
+#include <QtCore/QSortFilterProxyModel>
 
 class TrackerModelFilter : public QSortFilterProxyModel
 {

--- a/qt/UserMetaType.h
+++ b/qt/UserMetaType.h
@@ -5,9 +5,9 @@
 
 #pragma once
 
-#include <libtransmission-app/display-modes.h>
+#include <QtCore/QMetaType>
 
-#include <QMetaType>
+#include <libtransmission-app/display-modes.h>
 
 using ShowMode = tr::app::ShowMode;
 Q_DECLARE_METATYPE(ShowMode)

--- a/qt/Utils.cc
+++ b/qt/Utils.cc
@@ -3,28 +3,30 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "Utils.h"
+
 #include <string_view>
 
-#include <QAbstractItemView>
-#include <QApplication>
-#include <QColor>
-#include <QCoreApplication>
-#include <QDataStream>
-#include <QFile>
-#include <QFileIconProvider>
-#include <QFileInfo>
-#include <QHeaderView>
-#include <QIcon>
-#include <QInputDialog>
-#include <QMimeDatabase>
-#include <QMimeType>
-#include <QObject>
-#include <QPixmapCache>
-#include <QRect>
-#include <QSpinBox>
-#include <QStyle>
+#include <QtCore/QCoreApplication>
+#include <QtCore/QDataStream>
+#include <QtCore/QFile>
+#include <QtCore/QFileInfo>
+#include <QtCore/QMimeDatabase>
+#include <QtCore/QMimeType>
+#include <QtCore/QObject>
+#include <QtCore/QRect>
 
-#include "Utils.h"
+#include <QtGui/QColor>
+#include <QtGui/QIcon>
+#include <QtGui/QPixmapCache>
+
+#include <QtWidgets/QAbstractItemView>
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QFileIconProvider>
+#include <QtWidgets/QHeaderView>
+#include <QtWidgets/QInputDialog>
+#include <QtWidgets/QSpinBox>
+#include <QtWidgets/QStyle>
 
 #include "QtCompat.h"
 

--- a/qt/Utils.h
+++ b/qt/Utils.h
@@ -8,8 +8,8 @@
 #include <string_view>
 #include <utility>
 
-#include <QPointer>
-#include <QString>
+#include <QtCore/QPointer>
+#include <QtCore/QString>
 
 class QAbstractItemView;
 class QColor;

--- a/qt/VariantHelpers.cc
+++ b/qt/VariantHelpers.cc
@@ -11,8 +11,8 @@
 #include <limits>
 #include <string_view>
 
-#include <QString>
-#include <QUrl>
+#include <QtCore/QString>
+#include <QtCore/QUrl>
 
 #include <libtransmission/converters.h>
 #include <libtransmission/web-utils.h>

--- a/qt/WatchDir.cc
+++ b/qt/WatchDir.cc
@@ -3,18 +3,18 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include "WatchDir.h"
+
 #include <memory>
 
-#include <QDir>
-#include <QFileSystemWatcher>
-#include <QTimer>
-
-#include <libtransmission/transmission.h>
+#include <QtCore/QDir>
+#include <QtCore/QFileSystemWatcher>
+#include <QtCore/QTimer>
 
 #include <libtransmission/torrent-metainfo.h>
+#include <libtransmission/transmission.h>
 
 #include "TorrentModel.h"
-#include "WatchDir.h"
 
 // ---
 

--- a/qt/WatchDir.h
+++ b/qt/WatchDir.h
@@ -8,9 +8,9 @@
 #include <memory>
 #include <set>
 
-#include <QObject>
-#include <QFileSystemWatcher>
-#include <QString>
+#include <QtCore/QFileSystemWatcher>
+#include <QtCore/QObject>
+#include <QtCore/QString>
 
 class TorrentModel;
 


### PR DESCRIPTION
Change the #include call ordering to group by toolkit stack, eg

- glib -> gio -> gtk
- QtCore -> QtGui -> QtWidgets

No behavioral changes.

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
