### PR TITLE
fixup! chore: retransmission.org (#141)

### DIFF
--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -68,6 +68,7 @@ struct tr_torrent;
 #endif
 
 #define MY_NAME TR_PROJ_APPNAME "-daemon"
+#define MY_CONFIG_DIRNAME TR_PROJ_CONFIG_DIRNAME "-daemon"
 
 using namespace std::literals;
 using tr::Watchdir;
@@ -181,7 +182,7 @@ namespace
 
     tr_optind = ind;
 
-    return tr::platform::get_default_config_dir(MyName);
+    return tr::platform::get_default_config_dir(MY_CONFIG_DIRNAME);
 }
 
 auto onFileAdded(tr_session* session, std::string_view dirname, std::string_view basename)

--- a/gtk/Application.cc
+++ b/gtk/Application.cc
@@ -543,7 +543,7 @@ void Application::Impl::on_startup()
 
     /* Add style provider to the window. */
     auto css_provider = Gtk::CssProvider::create();
-    css_provider->load_from_resource(gtr_get_full_resource_path(TR_PROJ_APPNAME "-ui.css"));
+    css_provider->load_from_resource(gtr_get_full_resource_path("transmission-ui.css"));
     Gtk::StyleContext::IF_GTKMM4(add_provider_for_display, add_provider_for_screen)(
         IF_GTKMM4(Gdk::Display::get_default(), Gdk::Screen::get_default()),
         css_provider,
@@ -576,7 +576,7 @@ void Application::Impl::on_startup()
     core_ = Session::create(session);
 
     /* init the ui manager */
-    ui_builder_ = Gtk::Builder::create_from_resource(gtr_get_full_resource_path(TR_PROJ_APPNAME "-ui.xml"));
+    ui_builder_ = Gtk::Builder::create_from_resource(gtr_get_full_resource_path("transmission-ui.xml"));
     auto const actions = gtr_actions_init(ui_builder_, this);
 
     auto const main_menu = gtr_action_get_object<Gio::Menu>("main-window-menu");

--- a/gtk/main.cc
+++ b/gtk/main.cc
@@ -36,7 +36,7 @@
 
 namespace
 {
-auto const* const AppConfigDirName = TR_PROJ_APPNAME;
+auto const* const AppConfigDirName = TR_PROJ_CONFIG_DIRNAME;
 auto const* const AppTranslationDomainName = MY_NAME;
 auto const* const AppName = MY_NAME;
 

--- a/gtk/transmission.gresource.xml
+++ b/gtk/transmission.gresource.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
-  <gresource prefix="/org/retransmission/transmission">
+  <gresource prefix="/org/retransmission/retransmission">
     <file alias="icons/scalable/actions/lock.svg">../icons/lock.svg</file>
     <file alias="icons/scalable/actions/options-symbolic.svg">../icons/options-symbolic.svg</file>
     <file alias="icons/scalable/actions/ratio-symbolic.svg">../icons/ratio-symbolic.svg</file>
     <file alias="icons/scalable/actions/turtle-symbolic.svg">../icons/turtle-silhouette.svg</file>
-    <file alias="icons/scalable/apps/transmission.svg" compressed="true" preprocess="xml-stripblanks">../icons/hicolor_apps_scalable_transmission.svg</file>
+    <file alias="icons/scalable/apps/retransmission.svg" compressed="true" preprocess="xml-stripblanks">../icons/hicolor_apps_scalable_transmission.svg</file>
     <file compressed="true">transmission-ui.css</file>
     <file compressed="true" preprocess="xml-stripblanks">transmission-ui.xml</file>
   </gresource>

--- a/gtk/ui/gtk3/transmission-ui.gresource.xml
+++ b/gtk/ui/gtk3/transmission-ui.gresource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
-  <gresource prefix="/org/retransmission/transmission">
+  <gresource prefix="/org/retransmission/retransmission">
     <file compressed="true" preprocess="xml-stripblanks">AddTrackerDialog.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">DetailsDialog.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">EditTrackersDialog.ui</file>

--- a/gtk/ui/gtk4/transmission-ui.gresource.xml
+++ b/gtk/ui/gtk4/transmission-ui.gresource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
-  <gresource prefix="/org/retransmission/transmission">
+  <gresource prefix="/org/retransmission/retransmission">
     <file compressed="true" preprocess="xml-stripblanks">AddTrackerDialog.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">DetailsDialog.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">EditTrackersDialog.ui</file>

--- a/libtransmission/macros.h
+++ b/libtransmission/macros.h
@@ -44,10 +44,6 @@
 #define TR_PROJ_DOMAIN_TLD "org"
 #define TR_PROJ_DOMAIN_SLD "retransmission"
 
-#define TR_PROJ_APPNAME "retransmission"
-#define TR_PROJ_APPNAME_CAPITALIZED "Retransmission"
-#define TR_PROJ_APPNAME_RDNS TR_PROJ_DOMAIN_APEX_REVERSED "." TR_PROJ_APPNAME
-
 #define TR_PROJ_DOMAIN_APEX TR_PROJ_DOMAIN_SLD "." TR_PROJ_DOMAIN_TLD
 #define TR_PROJ_DOMAIN_APEX_REVERSED TR_PROJ_DOMAIN_TLD "." TR_PROJ_DOMAIN_SLD
 #define TR_PROJ_DOMAIN_DHT "dht." TR_PROJ_DOMAIN_APEX
@@ -55,6 +51,10 @@
 #define TR_PROJ_APPNAME "retransmission"
 #define TR_PROJ_APPNAME_CAPITALIZED "Retransmission"
 #define TR_PROJ_APPNAME_RDNS TR_PROJ_DOMAIN_APEX_REVERSED "." TR_PROJ_APPNAME
+
+// Config dirs keep the old name for compatibility.
+// Everything else uses TR_PROJ_APPNAME.
+#define TR_PROJ_CONFIG_DIRNAME "transmission"
 
 #define TR_PROJ_URL_HOMEPAGE "https://" TR_PROJ_DOMAIN_APEX
 #define TR_PROJ_URL_DONATE TR_PROJ_URL_HOMEPAGE "/donate"

--- a/qt/main.cc
+++ b/qt/main.cc
@@ -238,7 +238,7 @@ int tr_main(int argc, char** argv)
 
     // set the fallback config dir
     if (config_dir.isNull()) {
-        config_dir = QString::fromStdString(tr::platform::get_default_config_dir(TR_PROJ_APPNAME));
+        config_dir = QString::fromStdString(tr::platform::get_default_config_dir(TR_PROJ_CONFIG_DIRNAME));
     }
 
     auto prefs = Prefs{ config_dir };


### PR DESCRIPTION
Fix a nonreleased regression introduced over the weekend by #141. This causes the GTK client to fail to launch :hankey: and breaks the path to `settings.json` by looking for `retransmission` instead of `transmission`.

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
