### PR TITLE
fix: don't require quarks to be utf8

### DIFF
--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -12,7 +12,6 @@
 #include <vector>
 
 #include "libtransmission/quark.h"
-#include "libtransmission/string-utils.h"
 #include "libtransmission/tr-assert.h"
 
 using namespace std::literals;
@@ -781,17 +780,16 @@ std::optional<tr_quark> tr_quark_lookup(std::string_view key)
     return {};
 }
 
-tr_quark tr_quark_new(std::string_view str)
+tr_quark tr_quark_new(std::string_view const str)
 {
-    auto const utf8 = tr_strv_to_utf8_string(str);
-    if (auto const prior = tr_quark_lookup(utf8); prior) {
+    if (auto const prior = tr_quark_lookup(str)) {
         return *prior;
     }
 
     auto const ret = TR_N_KEYS + std::size(my_runtime);
-    auto const len = std::size(utf8);
+    auto const len = std::size(str);
     auto* perma = new char[len + 1];
-    std::copy_n(std::begin(utf8), len, perma);
+    std::copy_n(std::begin(str), len, perma);
     perma[len] = '\0';
     my_runtime.emplace_back(perma);
     return ret;

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -766,6 +766,8 @@ enum // NOLINT(performance-enum-size)
  * Get the string view that corresponds to the specified quark.
  *
  * Note: this view is guaranteed to be zero-terminated at view[std::size(view)]
+ *
+ * Note: the returned string is not guaranteed to be utf8
  */
 [[nodiscard]] std::string_view tr_quark_get_string_view(tr_quark quark);
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1027,7 +1027,7 @@ namespace make_torrent_field_helpers
                 return { tr_torrent::labels_t{}, Error::INVALID_PARAMS, "labels cannot contain comma (,) character"s };
             }
 
-            labels.emplace_back(label);
+            labels.emplace_back(tr_strv_to_utf8_string(label));
         }
     }
 

--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -33,6 +33,7 @@
 
 #include "libtransmission/error.h"
 #include "libtransmission/quark.h"
+#include "libtransmission/string-utils.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/utils.h"
 #include "libtransmission/variant.h"
@@ -295,6 +296,14 @@ template<typename WriterT>
 struct JsonWriter {
     WriterT& writer;
 
+    using StringWriteFunc = bool (WriterT::*)(typename WriterT::Ch const*, rapidjson::SizeType, bool);
+
+    void WriteString(StringWriteFunc const func, std::string_view sv) const
+    {
+        auto const utf8 = tr_strv_to_utf8_string(sv);
+        (writer.*func)(std::data(utf8), std::size(utf8), false);
+    }
+
     void operator()(std::monostate /*unused*/) const
     {
     }
@@ -321,14 +330,7 @@ struct JsonWriter {
 
     void operator()(std::string_view const val) const
     {
-        // workaround for this issue: in Writer::String() at
-        // rapidjson/writer.h:205: `RAPIDJSON_ASSERT(str != 0);`
-        // that fails when val.data() is nullptr when val.empty()
-        if (std::empty(val)) {
-            writer.String("", 0U);
-        } else {
-            writer.String(std::data(val), std::size(val));
-        }
+        WriteString(&WriterT::String, val);
     }
 
     void operator()(tr_variant::Vector const& val) const
@@ -344,7 +346,7 @@ struct JsonWriter {
     {
         writer.StartObject();
         for (auto const& [key, child] : sorted_entries(val)) {
-            writer.Key(std::data(key), std::size(key));
+            WriteString(&WriterT::Key, key);
             child->visit(*this);
         }
         writer.EndObject();


### PR DESCRIPTION
## Description

fix: Don't unconditionally convert quark strings to utf8.

Found another bug while testing the `transmission-show --scrape` regression discussed earlier today. This is an unreleased regression from 6c92d06 that unconditionally converted strings to utf8 in `tr_quark_new()`. This breaks the BitTorrent v2 dicts, which use arbitrary binary data as keys in the merkle trees. Every torrent that round-tripped through `tr_quark` lost those keys to U+FFFD and were corrupted.
    
This commit moves utf8-cleaning out of the quark code and into the consumers that require utf8-clean strings: JSON serialization and labels.

*edit:* marking as no-notes since bug never made it into production

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.