### PR TITLE
feat: use the macOS app's magnet icon in the Qt and GTK apps

### DIFF
--- a/gtk/IconCache.cc
+++ b/gtk/IconCache.cc
@@ -10,6 +10,7 @@
 #include "GtkCompat.h"
 
 #include <giomm/contenttype.h>
+#include <giomm/themedicon.h>
 
 #include <functional> // for std::less<>
 #include <map>
@@ -38,5 +39,11 @@ Glib::RefPtr<Gio::Icon> gtr_get_mime_type_icon(std::string_view mime_type)
         cache.try_emplace(std::move(mime_type_str), icon);
     }
 
+    return icon;
+}
+
+Glib::RefPtr<Gio::Icon> gtr_get_magnet_icon()
+{
+    static auto const icon = Gio::ThemedIcon::create("magnet");
     return icon;
 }

--- a/gtk/IconCache.h
+++ b/gtk/IconCache.h
@@ -17,3 +17,5 @@ extern std::string_view const DirectoryMimeType;
 extern std::string_view const UnknownMimeType;
 
 Glib::RefPtr<Gio::Icon> gtr_get_mime_type_icon(std::string_view mime_type);
+
+Glib::RefPtr<Gio::Icon> gtr_get_magnet_icon();

--- a/gtk/Torrent.cc
+++ b/gtk/Torrent.cc
@@ -345,7 +345,7 @@ void Torrent::Impl::notify_property_changes(ChangeFlags changes) const
 
     static auto TR_CONSTEXPR23
         properties_flags = std::array<std::pair<Property, ChangeFlags>, PropertyStore::PropertyCount - 1>({ {
-            { Property::ICON, ChangeFlag::MIME_TYPE },
+            { Property::ICON, ChangeFlag::HAS_METADATA | ChangeFlag::MIME_TYPE },
             { Property::NAME, ChangeFlag::NAME },
             { Property::PERCENT_DONE, ChangeFlag::PERCENT_DONE },
             { Property::SHORT_STATUS,
@@ -391,7 +391,7 @@ void Torrent::Impl::get_value(int column, Glib::ValueBase& value) const
 
 Glib::RefPtr<Gio::Icon> Torrent::Impl::get_icon() const
 {
-    return gtr_get_mime_type_icon(cache_.mime_type);
+    return cache_.has_metadata ? gtr_get_mime_type_icon(cache_.mime_type) : gtr_get_magnet_icon();
 }
 
 Glib::ustring Torrent::Impl::get_short_status_text() const
@@ -540,7 +540,7 @@ void Torrent::Impl::class_init(void* cls, void* /*user_data*/)
     PropertyStore::get().install(
         G_OBJECT_CLASS(cls),
         {
-            { Property::ICON, "icon", "Icon", "Icon based on torrent's likely MIME type", &Torrent::get_icon },
+            { Property::ICON, "icon", "Icon", "Icon for the torrent's likely contents", &Torrent::get_icon },
             { Property::NAME, "name", "Name", "Torrent name / title", &Torrent::get_name },
             { Property::PERCENT_DONE,
               "percent-done",

--- a/gtk/transmission.gresource.xml
+++ b/gtk/transmission.gresource.xml
@@ -2,6 +2,7 @@
 <gresources>
   <gresource prefix="/org/retransmission/transmission">
     <file alias="icons/scalable/actions/lock.svg">../icons/lock.svg</file>
+    <file alias="icons/scalable/actions/magnet.svg">../icons/magnet.svg</file>
     <file alias="icons/scalable/actions/options-symbolic.svg">../icons/options-symbolic.svg</file>
     <file alias="icons/scalable/actions/ratio-symbolic.svg">../icons/ratio-symbolic.svg</file>
     <file alias="icons/scalable/actions/turtle-symbolic.svg">../icons/turtle-silhouette.svg</file>

--- a/icons/SOURCES.md
+++ b/icons/SOURCES.md
@@ -4,6 +4,7 @@
 |---|---|---|---|
 | hamburger-menu.svg | [wikimedia](https://commons.wikimedia.org/wiki/File:Hamburger_icon.svg) | [Timothy Miller](https://tmthymllr.com/) | [SPDX: CC-BY-SA-3.0](https://spdx.org/licenses/CC-BY-SA-3.0.html) |
 | lock.svg | [fxemoji](https://github.com/mozilla/fxemoji/blob/gh-pages/svgs/objects/u1F512-lock.svg) | Mozilla Foundation | [SPDX: CC-BY-4.0](https://spdx.org/licenses/CC-BY-4.0.html) |
+| magnet.svg | [macosx/Images/Images.xcassets/Magnet.imageset](../macosx/Images/Images.xcassets/Magnet.imageset) (redrawn from) | Transmission authors and contributors | [SPDX: MIT](https://spdx.org/licenses/MIT.html) |
 | turtle.svg | [fxemoji](https://github.com/mozilla/fxemoji/blob/gh-pages/svgs/nature/u1F422-turtle.svg) (derived from) | Mozilla Foundation | [SPDX: CC-BY-4.0](https://spdx.org/licenses/CC-BY-4.0.html) |
 | turtle-silhouette.svg | [fxemoji](https://github.com/mozilla/fxemoji/blob/gh-pages/svgs/nature/u1F422-turtle.svg) (derived from) | Mozilla Foundation | [SPDX: CC-BY-4.0](https://spdx.org/licenses/CC-BY-4.0.html) |
 | yin-yang.svg | [forum.transmissionbt](https://forum.transmissionbt.com/viewtopic.php?p=42307#p42307) | [Jakub Steiner](https://jimmac.eu/) | [SPDX: CC-BY-SA-2.5](https://spdx.org/licenses/CC-BY-SA-2.5.html) |

--- a/icons/magnet.svg
+++ b/icons/magnet.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><path fill="#CC1111" d="M2.5 7v10a13.5 13.5 0 0 0 27 0V7h-8.5v10a5 5 0 0 1-10 0V7z"/><path fill="#AAB8C2" d="M2.5 7V4.5A2.5 2.5 0 0 1 5 2h3.5A2.5 2.5 0 0 1 11 4.5V7zm18.5 0V4.5A2.5 2.5 0 0 1 23.5 2H27a2.5 2.5 0 0 1 2.5 2.5V7z"/></svg>

--- a/qt/IconCache.h
+++ b/qt/IconCache.h
@@ -42,6 +42,11 @@ public:
         return file_icon_;
     }
 
+    [[nodiscard]] constexpr auto const& magnetIcon() const noexcept
+    {
+        return magnet_icon_;
+    }
+
     QIcon guessMimeIcon(QString const& filename, QIcon fallback = {}) const;
     QIcon getMimeTypeIcon(QString const& mime_type, bool multifile) const;
 
@@ -51,6 +56,7 @@ protected:
 private:
     QIcon const folder_icon_ = QFileIconProvider().icon(QFileIconProvider::Folder);
     QIcon const file_icon_ = QFileIconProvider().icon(QFileIconProvider::File);
+    QIcon const magnet_icon_ = QIcon{ QStringLiteral(":/icons/magnet.svg") };
 
     mutable std::unordered_map<QString, QIcon> name_to_icon_;
     mutable std::unordered_map<QString, QIcon> name_to_emblem_icon_;

--- a/qt/Torrent.cc
+++ b/qt/Torrent.cc
@@ -139,6 +139,10 @@ std::strong_ordering Torrent::compareETA(Torrent const& that) const
 
 QIcon Torrent::getMimeTypeIcon() const
 {
+    if (file_count_ == 0) {
+        return IconCache::get().magnetIcon();
+    }
+
     if (icon_.isNull()) {
         icon_ = IconCache::get().getMimeTypeIcon(primary_mime_type_, file_count_ > 1);
     }

--- a/qt/application.qrc
+++ b/qt/application.qrc
@@ -4,6 +4,7 @@
       <file alias="alt-limit-on.svg">../icons/turtle.svg</file>
       <file alias="encrypted.svg">../icons/lock.svg</file>
       <file alias="hamburger-menu.svg">../icons/hamburger-menu.svg</file>
+      <file alias="magnet.svg">../icons/magnet.svg</file>
       <file alias="ratio.svg">../icons/yin-yang.svg</file>
       <file alias="transmission.svg">../icons/hicolor_apps_scalable_transmission.svg</file>
   </qresource>


### PR DESCRIPTION
## Description

Notes:  Made the magnet link icon consistent across the macOS, Qt, and GTK clients.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
