### PR TITLE
fix: Qt IconCache.cc cache misses

### DIFF
--- a/qt/IconCache.cc
+++ b/qt/IconCache.cc
@@ -87,7 +87,8 @@ QIcon IconCache::getMimeTypeIcon(QString const& mime_type_name, bool multifile) 
         static auto const MimeDb = QMimeDatabase{};
         auto const type = MimeDb.mimeTypeForName(mime_type_name);
         auto const filename = QStringLiteral("filename.%1").arg(type.preferredSuffix());
-        return guessMimeIcon(filename, file_icon_);
+        icon = guessMimeIcon(filename, file_icon_);
+        return icon;
     }
 
     auto const mime_icon = getMimeTypeIcon(mime_type_name, false);

--- a/qt/IconCache.cc
+++ b/qt/IconCache.cc
@@ -174,24 +174,19 @@ QIcon IconCache::getMimeIcon(QString const& filename) const
         return {};
     }
 
-    QIcon& icon = ext_to_icon_[ext];
-    if (icon.isNull()) // cache miss
-    {
-        QMimeDatabase const mime_db;
-        auto const type = mime_db.mimeTypeForFile(filename, QMimeDatabase::MatchExtension);
-        if (icon.isNull()) {
-            icon = getThemeIcon(type.iconName());
-        }
-
-        if (icon.isNull()) {
-            icon = getThemeIcon(type.genericIconName());
-        }
-
-        if (icon.isNull()) {
-            icon = {};
-        }
+    if (auto const iter = ext_to_icon_.find(ext); iter != ext_to_icon_.end()) {
+        return iter->second;
     }
 
+    QMimeDatabase const mime_db;
+    auto const type = mime_db.mimeTypeForFile(filename, QMimeDatabase::MatchExtension);
+    auto icon = getThemeIcon(type.iconName());
+
+    if (icon.isNull()) {
+        icon = getThemeIcon(type.genericIconName());
+    }
+
+    ext_to_icon_.emplace(ext, icon);
     return icon;
 }
 

--- a/qt/IconCache.h
+++ b/qt/IconCache.h
@@ -65,7 +65,10 @@ private:
     void addAssociatedFileIcon(QFileInfo const& file_info, unsigned int icon_size, QIcon& icon) const;
 #else
     mutable std::unordered_set<QString> suffixes_;
+
+    // A null icon is a cached miss: the theme has no icon for that suffix.
     mutable std::unordered_map<QString, QIcon> ext_to_icon_;
+
     QIcon getMimeIcon(QString const& filename) const;
 #endif
 


### PR DESCRIPTION
## Description

- Fixed a bug that caused single-file torrents' mime-type icons to be re-queried from the mime db every time instead of caching it.
- Fixed a bug that caused torrents' mime-type icons to be re-queried from the mime db every time if there was no matching icon.

Notes:  Improved UI code to use less CPU.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
