### PR TITLE
refactor: use `std::to_array` in converters code

### DIFF
--- a/libtransmission-app/converters.cc
+++ b/libtransmission-app/converters.cc
@@ -32,7 +32,15 @@ template<typename T>
 inline constexpr bool HasTmGmtoffV = requires(T t) { t.tm_gmtoff; };
 
 template<typename T, size_t N>
-using Lookup = std::array<std::pair<std::string_view, T>, N>;
+using LookupTable = std::array<std::pair<std::string_view, T>, N>;
+
+// NOLINTBEGIN(modernize-avoid-c-arrays)
+template<typename T, size_t N>
+consteval LookupTable<std::remove_cv_t<T>, N> to_lookup(std::pair<std::string_view, T> (&&a)[N])
+{
+    return std::to_array(std::move(a));
+}
+// NOLINTEND(modernize-avoid-c-arrays)
 
 // ---
 
@@ -105,7 +113,7 @@ struct TrYearMonthDay {
     return std::chrono::sys_days{ std::chrono::days{ days_from_civil(ymd.year, ymd.month, ymd.day) } };
 }
 
-auto constexpr ShowKeys = std::array<std::pair<std::string_view, ShowMode>, ShowModeCount>{ {
+auto constexpr ShowKeys = to_lookup<ShowMode>({
     { "show_active", ShowMode::ShowActive },
     { "show_all", ShowMode::ShowAll },
     { "show_downloading", ShowMode::ShowDownloading },
@@ -114,7 +122,7 @@ auto constexpr ShowKeys = std::array<std::pair<std::string_view, ShowMode>, Show
     { "show_paused", ShowMode::ShowPaused },
     { "show_seeding", ShowMode::ShowSeeding },
     { "show_verifying", ShowMode::ShowVerifying },
-} };
+});
 
 bool to_show_mode(tr_variant const& src, ShowMode* tgt)
 {
@@ -147,7 +155,7 @@ tr_variant from_show_mode(ShowMode const& src)
 
 // ---
 
-auto constexpr SortKeys = std::array<std::pair<std::string_view, SortMode>, SortModeCount>{ {
+auto constexpr SortKeys = to_lookup<SortMode>({
     { "sort_by_activity", SortMode::SortByActivity },
     { "sort_by_age", SortMode::SortByAge },
     { "sort_by_eta", SortMode::SortByEta },
@@ -158,7 +166,7 @@ auto constexpr SortKeys = std::array<std::pair<std::string_view, SortMode>, Sort
     { "sort_by_ratio", SortMode::SortByRatio },
     { "sort_by_size", SortMode::SortBySize },
     { "sort_by_state", SortMode::SortByState },
-} };
+});
 
 bool to_sort_mode(tr_variant const& src, SortMode* tgt)
 {
@@ -191,12 +199,12 @@ tr_variant from_sort_mode(SortMode const& src)
 
 // ---
 
-auto constexpr StatsKeys = std::array<std::pair<std::string_view, StatsMode>, StatsModeCount>{ {
+auto constexpr StatsKeys = to_lookup<StatsMode>({
     { "session_ratio", StatsMode::SessionRatio },
     { "session_transfer", StatsMode::SessionTransfer },
     { "total_ratio", StatsMode::TotalRatio },
     { "total_transfer", StatsMode::TotalTransfer },
-} };
+});
 
 bool to_stats_mode(tr_variant const& src, StatsMode* tgt)
 {

--- a/libtransmission-app/converters.cc
+++ b/libtransmission-app/converters.cc
@@ -9,6 +9,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 
 #include <fmt/chrono.h>

--- a/libtransmission-app/converters.cc
+++ b/libtransmission-app/converters.cc
@@ -123,6 +123,7 @@ auto constexpr ShowKeys = to_lookup<ShowMode>({
     { "show_seeding", ShowMode::ShowSeeding },
     { "show_verifying", ShowMode::ShowVerifying },
 });
+static_assert(ShowKeys.size() == ShowModeCount);
 
 bool to_show_mode(tr_variant const& src, ShowMode* tgt)
 {
@@ -167,6 +168,7 @@ auto constexpr SortKeys = to_lookup<SortMode>({
     { "sort_by_size", SortMode::SortBySize },
     { "sort_by_state", SortMode::SortByState },
 });
+static_assert(SortKeys.size() == SortModeCount);
 
 bool to_sort_mode(tr_variant const& src, SortMode* tgt)
 {
@@ -205,6 +207,7 @@ auto constexpr StatsKeys = to_lookup<StatsMode>({
     { "total_ratio", StatsMode::TotalRatio },
     { "total_transfer", StatsMode::TotalTransfer },
 });
+static_assert(StatsKeys.size() == StatsModeCount);
 
 bool to_stats_mode(tr_variant const& src, StatsMode* tgt)
 {

--- a/libtransmission/converters.cc
+++ b/libtransmission/converters.cc
@@ -356,6 +356,7 @@ auto constexpr PreferredTransportKeys = to_lookup<tr_preferred_transport>({
     { "utp", tr_preferred_transport::UTP },
     { "tcp", tr_preferred_transport::TCP },
 });
+static_assert(PreferredTransportKeys.size() == PreferredTransportCount);
 
 bool to_preferred_transport(tr_variant const& src, small::max_size_vector<tr_preferred_transport, PreferredTransportCount>* tgt)
 {

--- a/libtransmission/converters.cc
+++ b/libtransmission/converters.cc
@@ -80,6 +80,14 @@ namespace
 template<typename T, size_t N>
 using LookupTable = std::array<std::pair<std::string_view, T>, N>;
 
+// NOLINTBEGIN(modernize-avoid-c-arrays)
+template<typename T, size_t N>
+consteval LookupTable<std::remove_cv_t<T>, N> to_lookup(std::pair<std::string_view, T> (&&a)[N])
+{
+    return std::to_array(std::move(a));
+}
+// NOLINTEND(modernize-avoid-c-arrays)
+
 template<typename T, size_t N>
 [[nodiscard]] tr_variant from_enum_or_integral_with_lookup(LookupTable<T, N> const& rows, T const src)
 {
@@ -166,11 +174,11 @@ tr_variant from_double(double const& val)
 
 // ---
 
-auto constexpr EncryptionKeys = LookupTable<tr_encryption_mode, 3U>{ {
+auto constexpr EncryptionKeys = to_lookup<tr_encryption_mode>({
     { "required", TR_ENCRYPTION_REQUIRED },
     { "preferred", TR_ENCRYPTION_PREFERRED },
     { "allowed", TR_CLEAR_PREFERRED },
-} };
+});
 
 bool to_encryption_mode(tr_variant const& src, tr_encryption_mode* tgt)
 {
@@ -184,7 +192,7 @@ tr_variant from_encryption_mode(tr_encryption_mode const& val)
 
 // ---
 
-auto constexpr LogKeys = LookupTable<tr_log_level, 7U>{ {
+auto constexpr LogKeys = to_lookup<tr_log_level>({
     { "critical", TR_LOG_CRITICAL },
     { "debug", TR_LOG_DEBUG },
     { "error", TR_LOG_ERROR },
@@ -192,7 +200,7 @@ auto constexpr LogKeys = LookupTable<tr_log_level, 7U>{ {
     { "off", TR_LOG_OFF },
     { "trace", TR_LOG_TRACE },
     { "warn", TR_LOG_WARN },
-} };
+});
 
 bool to_log_level(tr_variant const& src, tr_log_level* tgt)
 {
@@ -324,13 +332,13 @@ tr_variant from_port(tr_port const& val)
 
 // ---
 
-auto constexpr PreallocationKeys = LookupTable<tr_file_preallocation, 5U>{ {
+auto constexpr PreallocationKeys = to_lookup<tr_file_preallocation>({
     { "off", tr_file_preallocation::None },
     { "none", tr_file_preallocation::None },
     { "fast", tr_file_preallocation::Sparse },
     { "sparse", tr_file_preallocation::Sparse },
     { "full", tr_file_preallocation::Full },
-} };
+});
 
 bool to_preallocation_mode(tr_variant const& src, tr_file_preallocation* tgt)
 {
@@ -344,10 +352,10 @@ tr_variant from_preallocation_mode(tr_file_preallocation const& val)
 
 // ---
 
-auto constexpr PreferredTransportKeys = LookupTable<tr_preferred_transport, PreferredTransportCount>{ {
+auto constexpr PreferredTransportKeys = to_lookup<tr_preferred_transport>({
     { "utp", tr_preferred_transport::UTP },
     { "tcp", tr_preferred_transport::TCP },
-} };
+});
 
 bool to_preferred_transport(tr_variant const& src, small::max_size_vector<tr_preferred_transport, PreferredTransportCount>* tgt)
 {
@@ -419,7 +427,7 @@ tr_variant from_string(std::string const& val)
 // RFCs 2474, 3246, 4594 & 8622
 // Service class names are defined in RFC 4594, RFC 5865, and RFC 8622.
 // Not all platforms have these IPTOS_ definitions, so hardcode them here
-auto constexpr DiffServKeys = LookupTable<int, 28U>{ {
+auto constexpr DiffServKeys = to_lookup<int>({
     { "cs0", 0x00 }, // IPTOS_CLASS_CS0
     { "le", 0x04 },
     { "cs1", 0x20 }, // IPTOS_CLASS_CS1
@@ -451,7 +459,7 @@ auto constexpr DiffServKeys = LookupTable<int, 28U>{ {
     { "reliable", 0x04 }, // IPTOS_RELIABILITY
     { "throughput", 0x08 }, // IPTOS_THROUGHPUT
     { "lowdelay", 0x10 }, // IPTOS_LOWDELAY
-} };
+});
 
 bool to_diffserv_t(tr_variant const& src, tr_diffserv_t* tgt)
 {
@@ -471,10 +479,10 @@ tr_variant from_diffserv_t(tr_diffserv_t const& val)
 
 // ---
 
-auto constexpr VerifyModeKeys = LookupTable<tr_verify_added_mode, 2U>{ {
+auto constexpr VerifyModeKeys = to_lookup<tr_verify_added_mode>({
     { "fast", TR_VERIFY_ADDED_FAST },
     { "full", TR_VERIFY_ADDED_FULL },
-} };
+});
 
 bool to_verify_added_mode(tr_variant const& src, tr_verify_added_mode* tgt)
 {

--- a/tests/libtransmission-app/converter-tests.cc
+++ b/tests/libtransmission-app/converter-tests.cc
@@ -68,7 +68,7 @@ void testModeRoundtrip(std::array<std::pair<std::string_view, T>, N> const& item
 
 TEST_F(ConverterTest, showModeStringsRoundtrip)
 {
-    auto constexpr Items = std::array<std::pair<std::string_view, tr::app::ShowMode>, tr::app::ShowModeCount>{ {
+    auto constexpr Items = std::to_array<std::pair<std::string_view, tr::app::ShowMode>>({
         { "show_active", tr::app::ShowMode::ShowActive },
         { "show_all", tr::app::ShowMode::ShowAll },
         { "show_downloading", tr::app::ShowMode::ShowDownloading },
@@ -77,14 +77,14 @@ TEST_F(ConverterTest, showModeStringsRoundtrip)
         { "show_paused", tr::app::ShowMode::ShowPaused },
         { "show_seeding", tr::app::ShowMode::ShowSeeding },
         { "show_verifying", tr::app::ShowMode::ShowVerifying },
-    } };
+    });
 
     testModeRoundtrip(Items);
 }
 
 TEST_F(ConverterTest, sortModeStringsRoundtrip)
 {
-    auto constexpr Items = std::array<std::pair<std::string_view, tr::app::SortMode>, tr::app::SortModeCount>{ {
+    auto constexpr Items = std::to_array<std::pair<std::string_view, tr::app::SortMode>>({
         { "sort_by_activity", tr::app::SortMode::SortByActivity },
         { "sort_by_age", tr::app::SortMode::SortByAge },
         { "sort_by_eta", tr::app::SortMode::SortByEta },
@@ -95,19 +95,19 @@ TEST_F(ConverterTest, sortModeStringsRoundtrip)
         { "sort_by_ratio", tr::app::SortMode::SortByRatio },
         { "sort_by_size", tr::app::SortMode::SortBySize },
         { "sort_by_state", tr::app::SortMode::SortByState },
-    } };
+    });
 
     testModeRoundtrip(Items);
 }
 
 TEST_F(ConverterTest, statsModeStringsRoundtrip)
 {
-    auto constexpr Items = std::array<std::pair<std::string_view, tr::app::StatsMode>, tr::app::StatsModeCount>{ {
+    auto constexpr Items = std::to_array<std::pair<std::string_view, tr::app::StatsMode>>({
         { "total_ratio", tr::app::StatsMode::TotalRatio },
         { "total_transfer", tr::app::StatsMode::TotalTransfer },
         { "session_ratio", tr::app::StatsMode::SessionRatio },
         { "session_transfer", tr::app::StatsMode::SessionTransfer },
-    } };
+    });
 
     testModeRoundtrip(Items);
 }

--- a/tests/libtransmission-app/converter-tests.cc
+++ b/tests/libtransmission-app/converter-tests.cc
@@ -78,6 +78,7 @@ TEST_F(ConverterTest, showModeStringsRoundtrip)
         { "show_seeding", tr::app::ShowMode::ShowSeeding },
         { "show_verifying", tr::app::ShowMode::ShowVerifying },
     });
+    static_assert(Items.size() == tr::app::ShowModeCount);
 
     testModeRoundtrip(Items);
 }
@@ -96,6 +97,7 @@ TEST_F(ConverterTest, sortModeStringsRoundtrip)
         { "sort_by_size", tr::app::SortMode::SortBySize },
         { "sort_by_state", tr::app::SortMode::SortByState },
     });
+    static_assert(Items.size() == tr::app::SortModeCount);
 
     testModeRoundtrip(Items);
 }
@@ -108,6 +110,7 @@ TEST_F(ConverterTest, statsModeStringsRoundtrip)
         { "session_ratio", tr::app::StatsMode::SessionRatio },
         { "session_transfer", tr::app::StatsMode::SessionTransfer },
     });
+    static_assert(Items.size() == tr::app::StatsModeCount);
 
     testModeRoundtrip(Items);
 }


### PR DESCRIPTION
Purely code cleanup. No change in behaviour.

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
