### PR TITLE
fix: -Wunused-parameter warnings in macOS code

### DIFF
--- a/macosx/QuickLookExtension/PreviewProvider.mm
+++ b/macosx/QuickLookExtension/PreviewProvider.mm
@@ -70,7 +70,7 @@ NSString* generateIconData(UTType* type, NSUInteger width, NSMutableDictionary<N
     QLPreviewReply* reply = [[QLPreviewReply alloc]
         initWithDataOfContentType:UTTypeHTML
                       contentSize:CGSizeMake(1200, 800)
-                dataCreationBlock:^NSData* _Nullable(QLPreviewReply* _Nonnull replyToUpdate, NSError* __autoreleasing _Nullable* _Nullable error) {
+                dataCreationBlock:^NSData* _Nullable(QLPreviewReply* _Nonnull replyToUpdate, NSError* __autoreleasing _Nullable* _Nullable /*error*/) {
                     NSString* previewHTML = [self generateHTMLPreviewFor:request.fileURL andReply:replyToUpdate];
 
                     return [previewHTML dataUsingEncoding:NSUTF8StringEncoding];

--- a/macosx/QuickLookPlugin/GeneratePreviewForURL.mm
+++ b/macosx/QuickLookPlugin/GeneratePreviewForURL.mm
@@ -74,7 +74,7 @@ NSString* generateIconData(NSString* fileExtension, NSUInteger width, NSMutableD
     return [@"cid:" stringByAppendingString:iconFileName];
 }
 
-OSStatus GeneratePreviewForURL(void* /*thisInterface*/, QLPreviewRequestRef preview, CFURLRef url, CFStringRef contentTypeUTI, CFDictionaryRef options)
+OSStatus GeneratePreviewForURL(void* /*thisInterface*/, QLPreviewRequestRef preview, CFURLRef url, CFStringRef /*contentTypeUTI*/, CFDictionaryRef /*options*/)
 {
     // Before proceeding make sure the user didn't cancel the request
     if (QLPreviewRequestIsCancelled(preview)) {
@@ -281,7 +281,7 @@ OSStatus GeneratePreviewForURL(void* /*thisInterface*/, QLPreviewRequestRef prev
     return noErr;
 }
 
-void CancelPreviewGeneration(void* /*thisInterface*/, QLPreviewRequestRef preview)
+void CancelPreviewGeneration(void* /*thisInterface*/, QLPreviewRequestRef /*preview*/)
 {
     // Implement only if supported
 }

--- a/macosx/QuickLookPlugin/GenerateThumbnailForURL.mm
+++ b/macosx/QuickLookPlugin/GenerateThumbnailForURL.mm
@@ -18,13 +18,13 @@ QL_EXTERN_C_END
    This function's job is to create thumbnail for designated file as fast as possible
    ----------------------------------------------------------------------------- */
 
-OSStatus GenerateThumbnailForURL(void* thisInterface, QLThumbnailRequestRef thumbnail, CFURLRef url, CFStringRef contentTypeUTI, CFDictionaryRef options, CGSize maxSize)
+OSStatus GenerateThumbnailForURL(void* /*thisInterface*/, QLThumbnailRequestRef /*thumbnail*/, CFURLRef /*url*/, CFStringRef /*contentTypeUTI*/, CFDictionaryRef /*options*/, CGSize /*maxSize*/)
 {
     // To complete the generator, please implement the function GenerateThumbnailForURL here
     return noErr;
 }
 
-void CancelThumbnailGeneration(void* thisInterface, QLThumbnailRequestRef thumbnail)
+void CancelThumbnailGeneration(void* /*thisInterface*/, QLThumbnailRequestRef /*thumbnail*/)
 {
     // Implement only if supported
 }

--- a/macosx/QuickLookPlugin/main.cc
+++ b/macosx/QuickLookPlugin/main.cc
@@ -204,7 +204,7 @@ ULONG QuickLookGeneratorPluginRelease(void* thisInstance)
 // -----------------------------------------------------------------------------
 //  QuickLookGeneratorPluginFactory
 // -----------------------------------------------------------------------------
-void* QuickLookGeneratorPluginFactory(CFAllocatorRef allocator, CFUUIDRef typeID)
+void* QuickLookGeneratorPluginFactory(CFAllocatorRef /*allocator*/, CFUUIDRef typeID)
 {
     QuickLookGeneratorPluginType* result;
     CFUUIDRef uuid;


### PR DESCRIPTION
## Description

No behavior changes. Minor cleanup to silence some long-standing "warning: unused parameter" warnings in the macosx/ code.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
