### PR TITLE
refactor: remove unused API tr_variantDictAdd()

### DIFF
--- a/libtransmission/variant.cc
+++ b/libtransmission/variant.cc
@@ -259,23 +259,6 @@ bool tr_variantDictFindDict(tr_variant* const var, tr_quark key, tr_variant** se
 
 // ---
 
-tr_variant* tr_variantDictAdd(tr_variant* const var, tr_quark key)
-{
-    TR_ASSERT(var != nullptr);
-    TR_ASSERT(var->holds_alternative<tr_variant::Map>());
-
-    if (auto* const map = var != nullptr ? var->get_if<tr_variant::MapIndex>() : nullptr; map != nullptr) {
-        return &(*map)[key];
-    }
-
-    return {};
-}
-
-tr_variant* tr_variantDictAddStrView(tr_variant* const var, tr_quark const key, std::string_view const val)
-{
-    return dict_set(var, key, tr_variant::unmanaged_string(val));
-}
-
 tr_variant* tr_variantDictAddDict(tr_variant* const var, tr_quark key, size_t n_reserve)
 {
     return dict_set(var, key, tr_variant::make_map(n_reserve));

--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -568,9 +568,7 @@ bool save(std::string_view filename, Settings const& settings);
 // Deprecated C API. Do not use.
 bool tr_variantDictFindDict(tr_variant* var, tr_quark key, tr_variant** setme_value);
 bool tr_variantDictFindList(tr_variant* var, tr_quark key, tr_variant** setme);
-tr_variant* tr_variantDictAdd(tr_variant* var, tr_quark key);
 tr_variant* tr_variantDictAddDict(tr_variant* var, tr_quark key, size_t n_reserve);
-tr_variant* tr_variantDictAddStrView(tr_variant* var, tr_quark key, std::string_view value);
 tr_variant* tr_variantDictFind(tr_variant* var, tr_quark key);
 tr_variant* tr_variantListChild(tr_variant* var, size_t pos);
 void tr_variantMergeDicts(tr_variant* tgt, tr_variant const* src);


### PR DESCRIPTION
## Description

refactor: remove unused API tr_variantDictAddStrView()

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
