### PR TITLE
ci: another attempt to get us under cache.

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Finalize ccache
         uses: ./.github/actions/finalize-ccache
 
-  sanitizer-tests-macos:
+  sanitizer-tests-macos-26:
     runs-on: macos-26
     needs: [ what-to-make ]
     if: ${{ needs.what-to-make.outputs.make-tests == 'true' }}
@@ -576,7 +576,7 @@ jobs:
           extra-arg: -Wno-unused-command-line-argument
           msvc-env: true
 
-  macos-xcodebuild-universal:
+  macos-xcodebuild-universal-git-26:
     runs-on: macos-26
     needs: [ what-to-make ]
     if: ${{ needs.what-to-make.outputs.make-cli == 'true' ||
@@ -605,19 +605,7 @@ jobs:
           name: binaries-${{ github.job }}
           path: pfx/Build/Products/**/Transmission.app*
 
-  macos-cmake-universal:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [
-          # This is the last and the only macOS Intel runner that GitHub Actions supports.
-          # Xref https://github.com/actions/runner-images/issues/13046
-          macos-15-intel,
-
-          # Tahoe preview. Added Sept 2025.
-          # Xref https://github.com/actions/runner-images/pull/13007
-          macos-26
-        ]
+  macos-cmake-intel-git-15:
     needs: [what-to-make]
     if: ${{ needs.what-to-make.outputs.make-cli == 'true' ||
             needs.what-to-make.outputs.make-daemon == 'true' ||
@@ -626,7 +614,9 @@ jobs:
             needs.what-to-make.outputs.make-qt == 'true' ||
             needs.what-to-make.outputs.make-tests == 'true' ||
             needs.what-to-make.outputs.make-utils == 'true' }}
-    runs-on: ${{ matrix.os }}
+    # The last and only macOS Intel runner GitHub Actions supports.
+    # Xref https://github.com/actions/runner-images/issues/13046
+    runs-on: macos-15-intel
     steps:
       - name: Show Configuration
         run: |
@@ -645,8 +635,6 @@ jobs:
           enable-qt: ${{ needs.what-to-make.outputs.make-qt == 'true' && 'qt6' || 'false' }}
       - name: Setup ccache
         uses: ./.github/actions/setup-ccache
-        with:
-          key-suffix: ${{ matrix.os }}
       - name: Configure
         run: |
           cmake \
@@ -690,7 +678,7 @@ jobs:
         run: cmake --install obj --config RelWithDebInfo --strip
       - uses: actions/upload-artifact@v6
         with:
-          name: binaries-${{ matrix.os }}-cmake-universal
+          name: binaries-${{ github.job }}
           path: pfx/**/*
       - name: Finalize ccache
         uses: ./.github/actions/finalize-ccache
@@ -935,10 +923,10 @@ jobs:
           name: source-tarball
           path: obj/transmission*.tar.*
 
-  macos:
+  macos-cmake-arm64-tar-26:
     # This job covers source tarballs and bundled dependencies on Tahoe
     # (runner notes: https://github.com/actions/runner-images/pull/13007).
-    # macos-cmake-universal covers Intel with system dependencies; the
+    # macos-cmake-intel-git-15 covers Intel with system dependencies; the
     # Intel/tarball/bundled combination is intentionally omitted.
     needs: [make-source-tarball, what-to-make]
     if: ${{ needs.what-to-make.outputs.make-cli == 'true' ||
@@ -1550,6 +1538,8 @@ jobs:
         with:
           usesh: true
           mem: 12288
+          # Caching the image costs more Actions quota than the setup time it saves.
+          disable-cache: true
           prepare: |
             set -ex
             uname -a
@@ -1611,9 +1601,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # WITH_CRYPTO=AUTO resolves to OpenSSL on Linux, so every other Linux
+        # job already covers that backend; only the alternatives need a cell.
         crypto:
-          - cmake: openssl
-            apt: libssl-dev
           - cmake: wolfssl
             apt: libwolfssl-dev
           - cmake: mbedtls
@@ -1722,6 +1712,8 @@ jobs:
         with:
           usesh: true
           mem: 12288
+          # Caching the image costs more Actions quota than the setup time it saves.
+          disable-cache: true
           prepare: |
             set -ex
             uname -a
@@ -1801,6 +1793,8 @@ jobs:
         with:
           usesh: true
           mem: 12288
+          # Caching the image costs more Actions quota than the setup time it saves.
+          disable-cache: true
           prepare: |
             set -ex
             uname -a
@@ -1875,7 +1869,7 @@ jobs:
     # by main. Families that stop being produced age out through the
     # provider's 7-day unused-entry eviction.
     # Runs only on pushes to main: PR runs from forks get a read-only token.
-    needs: [ android, clang-tidy-linux, clang-tidy-windows, crypto, cxx23, debian, fedora, freebsd, macos, macos-cmake-universal, netbsd, openbsd, sanitizer-tests-linux, sanitizer-tests-macos, sanitizer-tests-windows, ubuntu-24-04-arm64, utp-disabled, windows ]
+    needs: [ android, clang-tidy-linux, clang-tidy-windows, crypto, cxx23, debian, fedora, freebsd, macos-cmake-arm64-tar-26, macos-cmake-intel-git-15, netbsd, openbsd, sanitizer-tests-linux, sanitizer-tests-macos-26, sanitizer-tests-windows, ubuntu-24-04-arm64, utp-disabled, windows ]
     if: ${{ always() && github.event_name == 'push' }}
     runs-on: ubuntu-slim
     env:
@@ -1886,11 +1880,10 @@ jobs:
         # ccache/ctcache key, so keep just the newest snapshot per
         # (ref, family). Selector 2: ccache and win-deps keys lacking the
         # current CACHE_SCHEMA can never be restored again. Selector 3: the
-        # content-addressed families (win-deps, vcpkg, and vmactions' VM
-        # images, whose freebsd/openbsd/netbsd prefixes are that action's
-        # own naming) are byte-identical per key+version, and every branch
-        # can restore main's copy through the base-branch fallback, so
-        # branch copies are redundant once main holds the key.
+        # content-addressed families (win-deps, vcpkg) are byte-identical per
+        # key+version, and every branch can restore main's copy through the
+        # base-branch fallback, so branch copies are redundant once main
+        # holds the key.
         run: |
           set -euo pipefail
           inventory="$RUNNER_TEMP/caches.json"
@@ -1907,7 +1900,7 @@ jobs:
                 ($inventory[]
                  | select((.key | test("^(ccache|win-deps)-")) and ((.key | contains($schema)) | not)).id),
                 ($inventory
-                 | map(select((.key | test("^(win-deps|vcpkg)-")) or (.key | test("^(freebsd|openbsd|netbsd)-"))))
+                 | map(select(.key | test("^(win-deps|vcpkg)-")))
                  | group_by([.key, .version])[]
                  | select(any(.[]; .ref == "refs/heads/main"))
                  | .[] | select(.ref != "refs/heads/main").id)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -74,7 +74,7 @@ jobs:
             echo "downloading $1 (id=${ids[0]})"
             gh api "repos/${{ github.repository }}/actions/artifacts/${ids[0]}/zip" > "in/$1.zip"
           }
-          dl binaries-macos-xcodebuild-universal
+          dl binaries-macos-xcodebuild-universal-git-26
           dl binaries-windows-x64-windows-2022-msi
           dl binaries-windows-arm64-windows-11-arm-msi
           dl binaries-windows-x86-windows-2022-msi
@@ -85,7 +85,7 @@ jobs:
           set -euo pipefail
           mkdir -p dist work
           # macOS: repackage the .app in a clean zip (Transmission.app at the root)
-          unzip -q in/binaries-macos-xcodebuild-universal.zip -d work/macos
+          unzip -q in/binaries-macos-xcodebuild-universal-git-26.zip -d work/macos
           apps=()
           mapfile -t apps < <(find work/macos -name Transmission.app -type d)
           if [ "${#apps[@]}" -ne 1 ]; then

--- a/.github/workflows/pr-new-label-expiry.yml
+++ b/.github/workflows/pr-new-label-expiry.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   expire-label:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/github-script@v9
         with:

--- a/.github/workflows/pr-new-label.yml
+++ b/.github/workflows/pr-new-label.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   add-label:
     if: github.event_name == 'pull_request_target'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/github-script@v9
         with:
@@ -54,7 +54,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request_review' &&
       github.event.review.state == 'approved'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/github-script@v9
         with:


### PR DESCRIPTION
## Description

Yes, we're still hitting the 10 GiB cache limit. Try harder to avoid that.

- Stop caching the BSD images
- Drop a redundant openssl job
- Drop a redundant macOS job
- Rename the remaining macOS jobs for clarity
- Incidental cleanup: use `ubuntu-slim` instead of `ubuntu-default` for the `new` label jobs.

Another Claude special. I've reviewed and the changes make sense, but TBH this is all trial and error. It's hard to know how well or poorly things will work until they land in `main` and go through a cache rebuild.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
