### PR TITLE
refactor: remove `<fmt/format.h>` from `values.h`

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		9F0B1F332E4D1A0100A1B2C3 /* env.cc in Sources */ = {isa = PBXBuildFile; fileRef = 9F0B1F2B2E4D1A0100A1B2C3 /* env.cc */; };
 		9F0B1F342E4D1A0100A1B2C3 /* file-utils.cc in Sources */ = {isa = PBXBuildFile; fileRef = 9F0B1F2D2E4D1A0100A1B2C3 /* file-utils.cc */; };
 		9F0B1F352E4D1A0100A1B2C3 /* string-utils.cc in Sources */ = {isa = PBXBuildFile; fileRef = 9F0B1F2F2E4D1A0100A1B2C3 /* string-utils.cc */; };
+		9F0B1F372E4D1A0100A1B2C3 /* values.cc in Sources */ = {isa = PBXBuildFile; fileRef = 9F0B1F362E4D1A0100A1B2C3 /* values.cc */; };
 		1BB44E07B1B52E28291B4E32 /* file-piece-map.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BB44E07B1B52E28291B4E30 /* file-piece-map.cc */; };
 		1BB44E07B1B52E28291B4E33 /* file-piece-map.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BB44E07B1B52E28291B4E31 /* file-piece-map.h */; };
 		2856E0656A49F2665D69E760 /* benc.h in Headers */ = {isa = PBXBuildFile; fileRef = 2856E0656A49F2665D69E761 /* benc.h */; };
@@ -1050,6 +1051,7 @@
 		A25964A5106D73A800453B31 /* announcer.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = announcer.h; sourceTree = "<group>"; };
 		A25BFD63167BED3B0039D1AA /* variant-benc.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "variant-benc.cc"; sourceTree = "<group>"; };
 		A25BFD65167BED3B0039D1AA /* variant-json.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "variant-json.cc"; sourceTree = "<group>"; };
+		9F0B1F362E4D1A0100A1B2C3 /* values.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = values.cc; sourceTree = "<group>"; };
 		A25BFD67167BED3B0039D1AA /* variant.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = variant.cc; sourceTree = "<group>"; };
 		A25BFD68167BED3B0039D1AA /* variant.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = variant.h; sourceTree = "<group>"; };
 		A25D2CBA0CF4C7190096A262 /* stats.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = stats.h; sourceTree = "<group>"; };
@@ -2240,6 +2242,7 @@
 				9F0B1F2F2E4D1A0100A1B2C3 /* string-utils.cc */,
 				9F0B1F2E2E4D1A0100A1B2C3 /* string-utils.h */,
 				C843FC8329C51B9400491854 /* string-utils.mm */,
+				9F0B1F362E4D1A0100A1B2C3 /* values.cc */,
 				A25BFD63167BED3B0039D1AA /* variant-benc.cc */,
 				A25BFD65167BED3B0039D1AA /* variant-json.cc */,
 				A25BFD67167BED3B0039D1AA /* variant.cc */,
@@ -3620,6 +3623,7 @@
 				9F0B1F332E4D1A0100A1B2C3 /* env.cc in Sources */,
 				9F0B1F342E4D1A0100A1B2C3 /* file-utils.cc in Sources */,
 				9F0B1F352E4D1A0100A1B2C3 /* string-utils.cc in Sources */,
+				9F0B1F372E4D1A0100A1B2C3 /* values.cc in Sources */,
 				EDBBE7692F0FF05500E90EA1 /* peer-socket-tcp.cc in Sources */,
 				EDBBE76A2F0FF05500E90EA1 /* peer-socket-utp.cc in Sources */,
 				A2AAB65F0DE0CF6200E04DDA /* rpcimpl.cc in Sources */,

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -176,6 +176,8 @@ target_sources(${TR_NAME}
         utils-ev.h
         utils.cc
         utils.h
+        values.cc
+        values.h
         variant-benc.cc
         variant-json.cc
         variant.cc

--- a/libtransmission/converters.h
+++ b/libtransmission/converters.h
@@ -48,6 +48,17 @@ template<typename T>
 // NOLINTBEGIN(readability-identifier-naming)
 // use std-style naming for these traits
 
+// Type trait: is C a std::basic_string?
+// Matches the specialization rather than comparing C against
+// `std::basic_string<typename C::value_type>`: naming that type instantiates the
+// deprecated `std::char_traits<T>` primary template whenever C's elements aren't
+// characters, e.g. for a std::vector<std::string>.
+template<typename C>
+inline constexpr bool is_basic_string_v = false;
+
+template<typename CharT, typename Traits, typename Alloc>
+inline constexpr bool is_basic_string_v<std::basic_string<CharT, Traits, Alloc>> = true;
+
 // Type trait: is C a container with push_back (but not a string)?
 template<typename C, typename = void>
 inline constexpr bool is_push_back_range_v = false;
@@ -59,8 +70,7 @@ inline constexpr bool is_push_back_range_v<
         typename C::value_type,
         decltype(std::begin(std::declval<C const&>())),
         decltype(std::end(std::declval<C const&>())),
-        decltype(std::declval<C&>().push_back(
-            std::declval<typename C::value_type const&>()))>> = !std::is_same_v<C, std::basic_string<typename C::value_type>>;
+        decltype(std::declval<C&>().push_back(std::declval<typename C::value_type const&>()))>> = !is_basic_string_v<C>;
 
 // Type trait: is C a container with insert (like std::set)?
 template<typename C, typename = void>

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1793,26 +1793,15 @@ void add_strings_from_var(std::set<std::string_view>& strings, tr_variant const&
 [[nodiscard]] auto values_get_units()
 {
     using namespace tr::Values;
-
-    auto const make_units_vec = [](auto const& units) {
-        auto units_vec = tr_variant::Vector{};
-        for (size_t i = 0;; ++i) {
-            auto const display_name = units.display_name(i);
-            if (std::empty(display_name)) {
-                break;
-            }
-            units_vec.emplace_back(tr_variant::unmanaged_string(display_name));
-        }
-        return units_vec;
-    };
+    using namespace tr::serializer;
 
     auto units_map = tr_variant::Map{ 6U };
     units_map.try_emplace(TR_KEY_memory_bytes, Memory::units().base());
-    units_map.try_emplace(TR_KEY_memory_units, make_units_vec(Memory::units()));
+    units_map.try_emplace(TR_KEY_memory_units, to_variant(Memory::units().display_names()));
     units_map.try_emplace(TR_KEY_size_bytes, Storage::units().base());
-    units_map.try_emplace(TR_KEY_size_units, make_units_vec(Storage::units()));
+    units_map.try_emplace(TR_KEY_size_units, to_variant(Storage::units().display_names()));
     units_map.try_emplace(TR_KEY_speed_bytes, Speed::units().base());
-    units_map.try_emplace(TR_KEY_speed_units, make_units_vec(Speed::units()));
+    units_map.try_emplace(TR_KEY_speed_units, to_variant(Speed::units().display_names()));
     return tr_variant{ std::move(units_map) };
 }
 

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -47,24 +47,10 @@
 #include "libtransmission/tr-strbuf.h"
 #include "libtransmission/types.h"
 #include "libtransmission/utils.h"
-#include "libtransmission/values.h"
 
 using namespace std::literals;
-using namespace tr::Values;
 
 time_t tr::detail::tr_time::current_time = {};
-
-// ---
-
-namespace tr::Values
-{
-
-// default values; can be overridden by client apps
-Config::Units<MemoryUnits> Config::memory{ Config::Base::Kibi, "B"sv, "KiB"sv, "MiB"sv, "GiB"sv, "TiB"sv };
-Config::Units<SpeedUnits> Config::speed{ Config::Base::Kilo, "B/s"sv, "kB/s"sv, "MB/s"sv, "GB/s"sv, "TB/s"sv };
-Config::Units<StorageUnits> Config::storage{ Config::Base::Kilo, "B"sv, "kB"sv, "MB"sv, "GB"sv, "TB"sv };
-
-} // namespace tr::Values
 
 // ---
 

--- a/libtransmission/values.cc
+++ b/libtransmission/values.cc
@@ -1,0 +1,68 @@
+// This file Copyright © Mnemosaic LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosaic LLC.
+// License text can be found in the licenses/ folder.
+
+#include <algorithm> // std::copy_n(), std::min()
+#include <array>
+#include <cmath> // std::fabs(), std::floor()
+#include <cstddef> // size_t
+#include <cstdint> // uint64_t
+#include <iterator> // std::begin(), std::size()
+#include <string>
+#include <string_view>
+
+#include <fmt/format.h>
+
+#include "libtransmission/values.h"
+
+using namespace std::literals;
+
+namespace tr::Values
+{
+
+// default values; can be overridden by client apps
+Config::Units<MemoryUnits> Config::memory{ Config::Base::Kibi, "B"sv, "KiB"sv, "MiB"sv, "GiB"sv, "TiB"sv };
+Config::Units<SpeedUnits> Config::speed{ Config::Base::Kilo, "B/s"sv, "kB/s"sv, "MB/s"sv, "GB/s"sv, "TB/s"sv };
+Config::Units<StorageUnits> Config::storage{ Config::Base::Kilo, "B"sv, "kB"sv, "MB"sv, "GB"sv, "TB"sv };
+
+void Config::UnitsBase::set_name(size_t idx, std::string_view name)
+{
+    auto& buf = display_names_[idx];
+    auto const n_copied = std::min(std::size(name), std::size(buf) - 1U);
+    *std::copy_n(std::begin(name), n_copied, std::begin(buf)) = '\0';
+}
+
+namespace detail
+{
+
+std::string to_string(uint64_t const quantity, Config::UnitsBase const& units)
+{
+    auto idx = size_t{ 0 };
+    auto val = static_cast<double>(quantity);
+    // Silence a clang-tidy bug that incorrectly reports a fmt problem
+    // NOLINTBEGIN(clang-analyzer-security.ArrayBound)
+    for (;;) {
+        if (std::fabs(val - std::floor(val)) < 0.001 && (val < 999.5 || std::empty(units.display_name(idx + 1)))) {
+            return fmt::format("{:.0Lf} {:s}", val, units.display_name(idx));
+        }
+
+        if (val < 99.995) // 0.98 to 99.99
+        {
+            return fmt::format("{:.2Lf} {:s}", val, units.display_name(idx));
+        }
+
+        if (val < 999.95 || std::empty(units.display_name(idx + 1))) // 100.0 to 999.9
+        {
+            return fmt::format("{:.1Lf} {:s}", val, units.display_name(idx));
+        }
+
+        val /= static_cast<double>(units.base());
+        ++idx;
+    }
+    // NOLINTEND(clang-analyzer-security.ArrayBound)
+}
+
+} // namespace detail
+
+} // namespace tr::Values

--- a/libtransmission/values.cc
+++ b/libtransmission/values.cc
@@ -11,6 +11,7 @@
 #include <iterator> // std::begin(), std::size()
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include <fmt/format.h>
 
@@ -25,6 +26,18 @@ namespace tr::Values
 Config::Units<MemoryUnits> Config::memory{ Config::Base::Kibi, "B"sv, "KiB"sv, "MiB"sv, "GiB"sv, "TiB"sv };
 Config::Units<SpeedUnits> Config::speed{ Config::Base::Kilo, "B/s"sv, "kB/s"sv, "MB/s"sv, "GB/s"sv, "TB/s"sv };
 Config::Units<StorageUnits> Config::storage{ Config::Base::Kilo, "B"sv, "kB"sv, "MB"sv, "GB"sv, "TB"sv };
+
+std::vector<std::string> Config::UnitsBase::display_names() const
+{
+    auto names = std::vector<std::string>{};
+    names.reserve(display_names_.size());
+
+    for (auto const& name : display_names_) {
+        names.emplace_back(std::data(name));
+    }
+
+    return names;
+}
 
 void Config::UnitsBase::set_name(size_t idx, std::string_view name)
 {

--- a/libtransmission/values.h
+++ b/libtransmission/values.h
@@ -7,13 +7,10 @@
 
 #include <array>
 #include <cstddef> // size_t
-#include <cmath> // for std::fabs(), std::floor()
 #include <compare>
 #include <cstdint> // for uint64_t
 #include <string>
 #include <string_view>
-
-#include <fmt/format.h>
 
 namespace tr::Values
 {
@@ -26,17 +23,12 @@ enum class SpeedUnits : uint8_t { Byps, KByps, MByps, GByps, TByps };
 struct Config {
     enum class Base : uint16_t { Kilo = 1000U, Kibi = 1024U };
 
-    template<typename UnitsEnum>
-    struct Units {
-        template<typename... Names> // NOLINTNEXTLINE(google-explicit-constructor, cppcoreguidelines-pro-type-member-init)
-        Units(Base base, Names... names)
-        {
-            set_base(base);
-
-            auto idx = size_t{ 0U };
-            (set_name(idx++, names), ...);
-        }
-
+    // The parts of Units that don't vary with UnitsEnum. Code that needs
+    // only the names and multipliers takes this instead, so that it can
+    // live in values.cc rather than being instantiated per enum.
+    class UnitsBase
+    {
+    public:
         [[nodiscard]] constexpr auto base() const noexcept
         {
             return static_cast<size_t>(base_);
@@ -47,17 +39,7 @@ struct Config {
             return std::string_view{ units < std::size(display_names_) ? std::data(display_names_[units]) : "" };
         }
 
-        [[nodiscard]] constexpr auto display_name(UnitsEnum multiplier) const noexcept
-        {
-            return display_name(static_cast<size_t>(multiplier));
-        }
-
-        [[nodiscard]] constexpr auto multiplier(UnitsEnum multiplier) const noexcept
-        {
-            return multipliers_[static_cast<int>(multiplier)];
-        }
-
-    private:
+    protected:
         constexpr void set_base(Base base) noexcept
         {
             base_ = base;
@@ -69,20 +51,49 @@ struct Config {
             }
         }
 
-        void set_name(size_t idx, std::string_view name)
-        {
-            *fmt::format_to_n(std::data(display_names_[idx]), std::size(display_names_[idx]) - 1, "{:s}", name).out = '\0';
-        }
+        // Copies as much of `name` as fits, truncating the rest.
+        void set_name(size_t idx, std::string_view name);
 
         std::array<std::array<char, 32>, 5> display_names_ = {};
-        std::array<uint64_t, 5> multipliers_;
-        Base base_ = {}; // NOLINT(bugprone-invalid-enum-default-initialization): overwritten by constructor
+        std::array<uint64_t, 5> multipliers_ = {};
+        Base base_ = {}; // NOLINT(bugprone-invalid-enum-default-initialization): overwritten by set_base()
+    };
+
+    template<typename UnitsEnum>
+    struct Units : UnitsBase {
+        template<typename... Names> // NOLINTNEXTLINE(google-explicit-constructor)
+        Units(Base base, Names... names)
+        {
+            set_base(base);
+
+            auto idx = size_t{ 0U };
+            (set_name(idx++, names), ...);
+        }
+
+        using UnitsBase::display_name;
+
+        [[nodiscard]] constexpr auto display_name(UnitsEnum multiplier) const noexcept
+        {
+            return UnitsBase::display_name(static_cast<size_t>(multiplier));
+        }
+
+        [[nodiscard]] constexpr auto multiplier(UnitsEnum multiplier) const noexcept
+        {
+            return multipliers_[static_cast<int>(multiplier)];
+        }
     };
 
     static Units<MemoryUnits> memory;
     static Units<SpeedUnits> speed;
     static Units<StorageUnits> storage;
 };
+
+namespace detail
+{
+// Renders `quantity` in the largest unit that keeps it readable,
+// e.g. 1'500'000 with Config::storage -> "1.50 MB".
+[[nodiscard]] std::string to_string(uint64_t quantity, Config::UnitsBase const& units);
+} // namespace detail
 
 template<typename UnitsEnum, Config::Units<UnitsEnum> const& units_>
 class Value
@@ -158,37 +169,9 @@ public:
 
     [[nodiscard]] constexpr bool operator==(Value const& that) const noexcept = default;
 
-    std::string_view to_string(char* buf, size_t buflen) const
-    {
-        auto idx = size_t{ 0 };
-        auto val = 1.0 * base_quantity_;
-        for (;;) {
-            if (std::fabs(val - std::floor(val)) < 0.001 && (val < 999.5 || std::empty(units_.display_name(idx + 1)))) {
-                *fmt::format_to_n(buf, buflen - 1, "{:.0Lf} {:s}", val, units_.display_name(idx)).out = '\0';
-                return buf;
-            }
-
-            if (val < 99.995) // 0.98 to 99.99
-            {
-                *fmt::format_to_n(buf, buflen - 1, "{:.2Lf} {:s}", val, units_.display_name(idx)).out = '\0';
-                return buf;
-            }
-
-            if (val < 999.95 || std::empty(units_.display_name(idx + 1))) // 100.0 to 999.9
-            {
-                *fmt::format_to_n(buf, buflen - 1, "{:.1Lf} {:s}", val, units_.display_name(idx)).out = '\0';
-                return buf;
-            }
-
-            val /= units_.base();
-            ++idx;
-        }
-    }
-
     [[nodiscard]] std::string to_string() const
     {
-        auto buf = std::array<char, 64>{};
-        return std::string{ to_string(std::data(buf), std::size(buf)) };
+        return detail::to_string(base_quantity_, units_);
     }
 
     [[nodiscard]] static constexpr auto const& units() noexcept

--- a/libtransmission/values.h
+++ b/libtransmission/values.h
@@ -11,6 +11,7 @@
 #include <cstdint> // for uint64_t
 #include <string>
 #include <string_view>
+#include <tuple>
 
 namespace tr::Values
 {
@@ -23,9 +24,6 @@ enum class SpeedUnits : uint8_t { Byps, KByps, MByps, GByps, TByps };
 struct Config {
     enum class Base : uint16_t { Kilo = 1000U, Kibi = 1024U };
 
-    // The parts of Units that don't vary with UnitsEnum. Code that needs
-    // only the names and multipliers takes this instead, so that it can
-    // live in values.cc rather than being instantiated per enum.
     class UnitsBase
     {
     public:
@@ -34,7 +32,7 @@ struct Config {
             return static_cast<size_t>(base_);
         }
 
-        [[nodiscard]] constexpr auto display_name(size_t units) const noexcept
+        [[nodiscard]] constexpr auto display_name(size_t const units) const noexcept
         {
             return std::string_view{ units < std::size(display_names_) ? std::data(display_names_[units]) : "" };
         }
@@ -64,6 +62,7 @@ struct Config {
         template<typename... Names> // NOLINTNEXTLINE(google-explicit-constructor)
         Units(Base base, Names... names)
         {
+            static_assert(sizeof...(Names) == std::tuple_size_v<decltype(display_names_)>);
             set_base(base);
 
             auto idx = size_t{ 0U };
@@ -79,7 +78,7 @@ struct Config {
 
         [[nodiscard]] constexpr auto multiplier(UnitsEnum multiplier) const noexcept
         {
-            return multipliers_[static_cast<int>(multiplier)];
+            return multipliers_[static_cast<size_t>(multiplier)];
         }
     };
 

--- a/libtransmission/values.h
+++ b/libtransmission/values.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <string_view>
 #include <tuple>
+#include <vector>
 
 namespace tr::Values
 {
@@ -36,6 +37,8 @@ struct Config {
         {
             return std::string_view{ units < std::size(display_names_) ? std::data(display_names_[units]) : "" };
         }
+
+        [[nodiscard]] std::vector<std::string> display_names() const;
 
     protected:
         constexpr void set_base(Base base) noexcept
@@ -68,8 +71,6 @@ struct Config {
             auto idx = size_t{ 0U };
             (set_name(idx++, names), ...);
         }
-
-        using UnitsBase::display_name;
 
         [[nodiscard]] constexpr auto display_name(UnitsEnum multiplier) const noexcept
         {


### PR DESCRIPTION
## Description

Refactor `libtransmission/values.h` to not `#include <fmt/...>`. This cuts down the `#include` fan-out for pretty much every source file we have, since `values.h` is included by `types.h`.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
