### PR TITLE
refactor: add `tr_hash_string` class

### DIFF
--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -56,6 +56,7 @@ target_sources(${TR_NAME}
         crypto-utils.h
         converters.cc
         converters.h
+        digest.h
         error-types.h
         error.cc
         error.h

--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "libtransmission/announcer.h"
+#include "libtransmission/digest.h"
 #include "libtransmission/interned-string.h"
 #include "libtransmission/net.h"
 #include "libtransmission/peer-mgr.h" // tr_pex

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -8,7 +8,6 @@
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
-#include <iterator>
 #include <optional>
 #include <ranges>
 #include <random>
@@ -25,7 +24,6 @@ extern "C" {
 
 #include "libtransmission/crypto-utils.h"
 #include "libtransmission/string-utils.h"
-#include "libtransmission/tr-assert.h"
 
 using namespace std::literals;
 
@@ -115,18 +113,6 @@ namespace
 namespace hex_impl
 {
 
-template<typename InIt, typename OutIt>
-constexpr void tr_binary_to_hex(InIt begin, InIt end, OutIt out)
-{
-    auto constexpr Hex = "0123456789abcdef"sv;
-
-    while (begin != end) {
-        auto const val = static_cast<unsigned int>(*begin++);
-        *out++ = Hex[val >> 4];
-        *out++ = Hex[val & 0xF];
-    }
-}
-
 constexpr void tr_hex_to_binary(char const* input, void* voutput, size_t byte_length)
 {
     auto constexpr Hex = "0123456789abcdef"sv;
@@ -145,22 +131,14 @@ constexpr void tr_hex_to_binary(char const* input, void* voutput, size_t byte_le
 
 tr_sha1_string tr_sha1_to_string(tr_sha1_digest_t const& digest)
 {
-    using namespace hex_impl;
-
-    auto str = tr_sha1_string{};
-    tr_binary_to_hex(std::begin(digest), std::end(digest), std::back_inserter(str));
-    TR_ASSERT(std::size(str) == TrSha1DigestStrlen);
-    return str;
+    static_assert(tr_sha1_string::Strlen == TrSha1DigestStrlen);
+    return tr_sha1_string{ digest };
 }
 
 tr_sha256_string tr_sha256_to_string(tr_sha256_digest_t const& digest)
 {
-    using namespace hex_impl;
-
-    auto str = tr_sha256_string{};
-    tr_binary_to_hex(std::begin(digest), std::end(digest), std::back_inserter(str));
-    TR_ASSERT(std::size(str) == TrSha256DigestStrlen);
-    return str;
+    static_assert(tr_sha256_string::Strlen == TrSha256DigestStrlen);
+    return tr_sha256_string{ digest };
 }
 
 std::optional<tr_sha1_digest_t> tr_sha1_from_string(std::string_view hex)

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -31,14 +31,10 @@ using namespace std::literals;
 
 namespace
 {
-constexpr auto TrSha1DigestStrlen = size_t{ 40 };
-
-constexpr auto TrSha256DigestStrlen = size_t{ 64 };
-
 namespace ssha1_impl
 {
 
-auto constexpr DigestStringSize = TrSha1DigestStrlen;
+auto constexpr DigestStringSize = tr_sha1_string::Strlen;
 auto constexpr SaltedPrefix = "{"sv;
 
 std::string tr_salt(std::string_view plaintext, std::string_view salt)
@@ -50,7 +46,7 @@ std::string tr_salt(std::string_view plaintext, std::string_view salt)
 
     // convert it to a string. string holds three parts:
     // DigestPrefix, stringified digest of plaintext + salt, and the salt.
-    return fmt::format("{:s}{:s}{:s}", SaltedPrefix, tr_sha1_to_string(digest), salt);
+    return fmt::format("{:s}{:s}{:s}", SaltedPrefix, tr_sha1_string{ digest }, salt);
 }
 
 } // namespace ssha1_impl
@@ -129,23 +125,11 @@ constexpr void tr_hex_to_binary(char const* input, void* voutput, size_t byte_le
 } // namespace hex_impl
 } // namespace
 
-tr_sha1_string tr_sha1_to_string(tr_sha1_digest_t const& digest)
-{
-    static_assert(tr_sha1_string::Strlen == TrSha1DigestStrlen);
-    return tr_sha1_string{ digest };
-}
-
-tr_sha256_string tr_sha256_to_string(tr_sha256_digest_t const& digest)
-{
-    static_assert(tr_sha256_string::Strlen == TrSha256DigestStrlen);
-    return tr_sha256_string{ digest };
-}
-
 std::optional<tr_sha1_digest_t> tr_sha1_from_string(std::string_view hex)
 {
     using namespace hex_impl;
 
-    if (std::size(hex) != TrSha1DigestStrlen) {
+    if (std::size(hex) != tr_sha1_string::Strlen) {
         return {};
     }
 
@@ -162,7 +146,7 @@ std::optional<tr_sha256_digest_t> tr_sha256_from_string(std::string_view hex)
 {
     using namespace hex_impl;
 
-    if (std::size(hex) != TrSha256DigestStrlen) {
+    if (std::size(hex) != tr_sha256_string::Strlen) {
         return {};
     }
 

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -15,8 +15,7 @@
 #include <string>
 #include <string_view>
 
-#include "libtransmission/tr-strbuf.h"
-#include "libtransmission/types.h" // tr_sha1_digest_t, tr_sha256_d...
+#include "libtransmission/digest.h" // tr_sha1_digest_t, tr_sha1_string, ...
 
 #if defined(WITH_CCRYPTO)
 #include <CommonCrypto/CommonDigest.h>
@@ -171,8 +170,6 @@ T tr_rand_obj()
  */
 [[nodiscard]] std::string tr_base64_decode(std::string_view input);
 
-using tr_sha1_string = tr_strbuf<char, (sizeof(tr_sha1_digest_t) * 2U) + 1U>;
-
 /**
  * @brief Generate an ascii hex string for a sha1 digest.
  */
@@ -182,8 +179,6 @@ using tr_sha1_string = tr_strbuf<char, (sizeof(tr_sha1_digest_t) * 2U) + 1U>;
  * @brief Generate a sha1 digest from a hex string.
  */
 [[nodiscard]] std::optional<tr_sha1_digest_t> tr_sha1_from_string(std::string_view hex);
-
-using tr_sha256_string = tr_strbuf<char, (sizeof(tr_sha256_digest_t) * 2U) + 1U>;
 
 /**
  * @brief Generate an ascii hex string for a sha256 digest.

--- a/libtransmission/crypto-utils.h
+++ b/libtransmission/crypto-utils.h
@@ -171,19 +171,9 @@ T tr_rand_obj()
 [[nodiscard]] std::string tr_base64_decode(std::string_view input);
 
 /**
- * @brief Generate an ascii hex string for a sha1 digest.
- */
-[[nodiscard]] tr_sha1_string tr_sha1_to_string(tr_sha1_digest_t const& digest);
-
-/**
  * @brief Generate a sha1 digest from a hex string.
  */
 [[nodiscard]] std::optional<tr_sha1_digest_t> tr_sha1_from_string(std::string_view hex);
-
-/**
- * @brief Generate an ascii hex string for a sha256 digest.
- */
-[[nodiscard]] tr_sha256_string tr_sha256_to_string(tr_sha256_digest_t const& digest);
 
 /**
  * @brief Generate a sha256 digest from a hex string.

--- a/libtransmission/digest.h
+++ b/libtransmission/digest.h
@@ -1,0 +1,100 @@
+// This file Copyright © Mnemosaic LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosaic LLC.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#include <array>
+#include <compare>
+#include <cstddef> // size_t, std::byte
+#include <string_view>
+
+using tr_sha1_digest_t = std::array<std::byte, 20U>;
+
+using tr_sha256_digest_t = std::array<std::byte, 32U>;
+
+/**
+ * A digest in its lowercase hex form, e.g. an info hash as it appears in
+ * magnet links and in the names of torrent and resume files.
+ *
+ * Instances are either empty or complete -- there is no way to fill one
+ * partway -- so a default-constructed instance doubles as the "no digest
+ * yet" marker that `empty()` reports.
+ */
+template<size_t DigestLen>
+class tr_hash_string
+{
+public:
+    static auto constexpr Strlen = DigestLen * 2U;
+
+    tr_hash_string() noexcept = default;
+
+    explicit constexpr tr_hash_string(std::array<std::byte, DigestLen> const& digest) noexcept
+    {
+        for (size_t i = 0; i < DigestLen; ++i) {
+            auto const val = std::to_integer<size_t>(digest[i]);
+            chars_[i * 2U] = HexDigits[val >> 4U];
+            chars_[(i * 2U) + 1U] = HexDigits[val & 0x0FU];
+        }
+    }
+
+    [[nodiscard]] constexpr auto const* data() const noexcept
+    {
+        return std::data(chars_);
+    }
+
+    [[nodiscard]] constexpr auto const* c_str() const noexcept
+    {
+        return data();
+    }
+
+    [[nodiscard]] constexpr bool empty() const noexcept
+    {
+        return chars_[0] == '\0';
+    }
+
+    [[nodiscard]] constexpr size_t size() const noexcept
+    {
+        return empty() ? 0U : Strlen;
+    }
+
+    [[nodiscard]] constexpr auto sv() const noexcept
+    {
+        return std::string_view{ data(), size() };
+    }
+
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    [[nodiscard]] constexpr operator std::string_view() const noexcept
+    {
+        return sv();
+    }
+
+    // Comparing the trailing zeroes along with the hex agrees with comparing
+    // sv(): NUL sorts below every hex digit, so an empty instance orders
+    // first, exactly as an empty string does.
+    [[nodiscard]] constexpr auto operator<=>(tr_hash_string const&) const = default;
+    [[nodiscard]] constexpr bool operator==(tr_hash_string const&) const = default;
+
+    [[nodiscard]] constexpr bool operator==(std::string_view rhs) const noexcept
+    {
+        return sv() == rhs;
+    }
+
+private:
+    static auto constexpr HexDigits = std::string_view{ "0123456789abcdef" };
+
+    std::array<char, Strlen + 1U> chars_ = {};
+};
+
+// Lets fmt print a tr_hash_string as its string_view. fmt finds this by ADL,
+// so it costs this header no fmt include; only the callers that format need one.
+template<size_t DigestLen>
+[[nodiscard]] constexpr auto format_as(tr_hash_string<DigestLen> const& hash) noexcept
+{
+    return hash.sv();
+}
+
+using tr_sha1_string = tr_hash_string<sizeof(tr_sha1_digest_t)>;
+
+using tr_sha256_string = tr_hash_string<sizeof(tr_sha256_digest_t)>;

--- a/libtransmission/handshake.h
+++ b/libtransmission/handshake.h
@@ -23,6 +23,7 @@
 
 #include <small/vector.hpp>
 
+#include "libtransmission/digest.h"
 #include "libtransmission/peer-mse.h" // tr_message_stream_encryption::DH
 #include "libtransmission/peer-io.h"
 #include "libtransmission/timer.h"

--- a/libtransmission/local-data.h
+++ b/libtransmission/local-data.h
@@ -19,6 +19,7 @@
 #include <small/vector.hpp>
 
 #include "libtransmission/constants.h"
+#include "libtransmission/digest.h"
 #include "libtransmission/error-types.h"
 #include "libtransmission/types.h"
 

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -196,7 +196,7 @@ bool tr_magnet_metainfo::parseMagnet(std::string_view magnet_link, tr_error* err
 {
     magnet_link = tr_strv_strip(magnet_link);
     if (auto const hash = parseHash(magnet_link); hash) {
-        return parseMagnet(fmt::format("magnet:?xt=urn:btih:{:s}", tr_sha1_to_string(*hash)));
+        return parseMagnet(fmt::format("magnet:?xt=urn:btih:{:s}", tr_sha1_string{ *hash }));
     }
 
     auto const parsed = tr_urlParse(magnet_link);
@@ -242,7 +242,7 @@ bool tr_magnet_metainfo::parseMagnet(std::string_view magnet_link, tr_error* err
         }
     }
 
-    info_hash_str_ = tr_sha1_to_string(this->info_hash());
+    info_hash_str_ = tr_sha1_string{ this->info_hash() };
 
     if (std::empty(name())) {
         this->set_name(info_hash_str_);

--- a/libtransmission/magnet-metainfo.h
+++ b/libtransmission/magnet-metainfo.h
@@ -11,8 +11,8 @@
 #include <vector>
 
 #include "libtransmission/announce-list.h"
-#include "libtransmission/crypto-utils.h"
-#include "libtransmission/macros.h" // TR_CONSTEXPR_VEC, tr_sha1_digest_t
+#include "libtransmission/digest.h" // tr_sha1_digest_t, tr_sha1_string, ...
+#include "libtransmission/macros.h" // TR_CONSTEXPR_VEC
 
 struct tr_error;
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -18,6 +18,7 @@
 
 #include "libtransmission/bandwidth.h"
 #include "libtransmission/block-info.h" // tr_block_info
+#include "libtransmission/digest.h"
 #include "libtransmission/error.h"
 #include "libtransmission/log.h"
 #include "libtransmission/net.h"

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -19,6 +19,7 @@
 #include <event2/util.h> // for evutil_socket_t
 
 #include "libtransmission/bandwidth.h"
+#include "libtransmission/digest.h"
 #include "libtransmission/peer-mse.h"
 #include "libtransmission/peer-socket.h"
 #include "libtransmission/tr-buffer.h"

--- a/libtransmission/peer-mse.h
+++ b/libtransmission/peer-mse.h
@@ -14,8 +14,8 @@
 #include <cstddef> // size_t, std::byte
 #include <span>
 
+#include "libtransmission/digest.h"
 #include "libtransmission/tr-arc4.h"
-#include "libtransmission/types.h" // tr_sha1_digest_t
 
 // Spec: https://wiki.vuze.com/w/Message_Stream_Encryption
 namespace tr_message_stream_encryption

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -41,6 +41,7 @@
 #include "libtransmission/blocklist.h"
 #include "libtransmission/blocklist-download.h"
 #include "libtransmission/converters.h"
+#include "libtransmission/digest.h"
 #include "libtransmission/interned-string.h"
 #include "libtransmission/ip-cache.h"
 #include "libtransmission/local-data.h"

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -319,7 +319,7 @@ struct MetainfoHandler final : public tr::benc::BasicHandler<MaxBencDepth> {
             // compatibility with Transmission <= 3.0
             if (value.length() == sizeof(tr_sha1_digest_t)) {
                 std::copy_n(std::data(value), sizeof(tr_sha1_digest_t), reinterpret_cast<char*>(std::data(tm_.info_hash_)));
-                tm_.info_hash_str_ = tr_sha1_to_string(tm_.info_hash_);
+                tm_.info_hash_str_ = tr_sha1_string{ tm_.info_hash_ };
                 tm_.has_magnet_info_hash_ = true;
             }
         } else if (
@@ -417,9 +417,9 @@ private:
         auto const hash2 = tr_sha256::digest(info_dict_benc);
 
         tm_.info_hash_ = hash;
-        tm_.info_hash_str_ = tr_sha1_to_string(tm_.info_hash_);
+        tm_.info_hash_str_ = tr_sha1_string{ tm_.info_hash_ };
         tm_.info_hash2_ = hash2;
-        tm_.info_hash2_str_ = tr_sha256_to_string(tm_.info_hash2_);
+        tm_.info_hash2_str_ = tr_sha256_string{ tm_.info_hash2_ };
         tm_.info_dict_size_ = std::size(info_dict_benc);
         return true;
     }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -28,6 +28,7 @@
 #include "libtransmission/bitfield.h"
 #include "libtransmission/block-info.h"
 #include "libtransmission/completion.h"
+#include "libtransmission/crypto-utils.h" // tr_rand_obj()
 #include "libtransmission/file-piece-map.h"
 #include "libtransmission/interned-string.h"
 #include "libtransmission/log.h"

--- a/libtransmission/torrents.h
+++ b/libtransmission/torrents.h
@@ -18,6 +18,7 @@
 #include <utility>
 #include <vector>
 
+#include "libtransmission/digest.h"
 #include "libtransmission/torrent-metainfo.h"
 
 struct tr_torrent;

--- a/libtransmission/tr-dht.h
+++ b/libtransmission/tr-dht.h
@@ -23,6 +23,7 @@
 
 #include <dht/dht.h>
 
+#include "libtransmission/digest.h"
 #include "libtransmission/net.h" // tr_port
 #include "libtransmission/types.h"
 

--- a/libtransmission/tr-udp.cc
+++ b/libtransmission/tr-udp.cc
@@ -17,6 +17,7 @@
 
 #include <fmt/format.h>
 
+#include "libtransmission/crypto-utils.h" // tr_base64_encode()
 #include "libtransmission/log.h"
 #include "libtransmission/net.h"
 #include "libtransmission/session.h"

--- a/libtransmission/types.h
+++ b/libtransmission/types.h
@@ -53,10 +53,6 @@ using tr_peer_id_t = std::array<char, 20>;
 
 using tr_piece_index_t = uint32_t;
 
-using tr_sha1_digest_t = std::array<std::byte, 20>;
-
-using tr_sha256_digest_t = std::array<std::byte, 32>;
-
 using tr_torrent_id_t = int;
 
 enum class tr_preferred_transport : uint8_t {

--- a/libtransmission/verify.h
+++ b/libtransmission/verify.h
@@ -19,6 +19,7 @@
 #include <thread>
 #include <utility> // std::move
 
+#include "libtransmission/digest.h"
 #include "libtransmission/torrent-metainfo.h"
 #include "libtransmission/types.h"
 

--- a/libtransmission/web-utils.h
+++ b/libtransmission/web-utils.h
@@ -14,7 +14,7 @@
 
 #include <fmt/format.h>
 
-#include "libtransmission/types.h" // tr_sha1_digest_t
+#include "libtransmission/digest.h"
 
 /** @brief convenience function to determine if an address is an IP address (IPv4 or IPv6) */
 bool tr_addressIsIP(char const* address);

--- a/qt/Torrent.h
+++ b/qt/Torrent.h
@@ -158,7 +158,7 @@ public:
     explicit TorrentHash(tr_sha1_digest_t const& data)
         : data_{ data }
     {
-        auto const hashstr = tr_sha1_to_string(data_);
+        auto const hashstr = tr_sha1_string{ data_ };
         data_str_ = Utils::qstringFromUtf8(hashstr);
     }
 

--- a/tests/libtransmission/crypto-test.cc
+++ b/tests/libtransmission/crypto-test.cc
@@ -117,13 +117,13 @@ TEST(Crypto, sha1)
             std::size(hash1)));
 
     auto const hash3 = tr_sha1::digest("test"sv);
-    EXPECT_EQ("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"sv, tr_sha1_to_string(hash3));
+    EXPECT_EQ("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"sv, tr_sha1_string{ hash3 });
 
     auto const hash4 = tr_sha1::digest("te"sv, "st"sv);
-    EXPECT_EQ("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"sv, tr_sha1_to_string(hash4));
+    EXPECT_EQ("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"sv, tr_sha1_string{ hash4 });
 
     auto const hash5 = tr_sha1::digest("t"sv, "e"sv, std::string{ "s" }, std::to_array<char>({ 't' }));
-    EXPECT_EQ("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"sv, tr_sha1_to_string(hash5));
+    EXPECT_EQ("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"sv, tr_sha1_string{ hash5 });
 }
 
 TEST(Crypto, ssha1)
@@ -205,7 +205,7 @@ TEST(Crypto, sha1FromString)
     auto const lc = tr_sha1_from_string(baseline);
     EXPECT_TRUE(lc.has_value());
     assert(lc.has_value());
-    EXPECT_EQ(baseline, tr_sha1_to_string(*lc));
+    EXPECT_EQ(baseline, tr_sha1_string{ *lc });
 
     // uppercase hex should yield the same result
     auto const uc = tr_sha1_from_string(tr_strupper(baseline));
@@ -231,7 +231,7 @@ TEST(Crypto, sha256FromString)
     auto const lc = tr_sha256_from_string(baseline);
     EXPECT_TRUE(lc.has_value());
     assert(lc.has_value());
-    EXPECT_EQ(baseline, tr_sha256_to_string(*lc));
+    EXPECT_EQ(baseline, tr_sha256_string{ *lc });
 
     // uppercase hex should yield the same result
     auto const uc = tr_sha256_from_string(tr_strupper(baseline));

--- a/tests/libtransmission/crypto-test.cc
+++ b/tests/libtransmission/crypto-test.cc
@@ -171,6 +171,25 @@ TEST(Crypto, ssha1)
     EXPECT_TRUE(tr_ssha1_matches("{d209a21d3bc4f8fc4f8faf347e69f3def597eb170pySy4ai1ZPMjeU1", "test"));
 }
 
+TEST(Crypto, hashString)
+{
+    // a default-constructed instance is the empty "no digest yet" state
+    auto const empty = tr_sha1_string{};
+    EXPECT_TRUE(empty.empty());
+    EXPECT_EQ(0U, std::size(empty));
+    EXPECT_EQ(""sv, empty.sv());
+    EXPECT_EQ('\0', *empty.c_str());
+    EXPECT_EQ(empty, tr_sha1_string{});
+
+    auto const full = tr_sha1_string{ tr_sha1::digest("test"sv) };
+    EXPECT_FALSE(full.empty());
+    EXPECT_EQ(tr_sha1_string::Strlen, std::size(full));
+    EXPECT_EQ("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"sv, full);
+
+    // an empty instance sorts before any complete one, as an empty string would
+    EXPECT_LT(empty, full);
+}
+
 TEST(Crypto, sha1FromString)
 {
     // bad lengths

--- a/tests/libtransmission/handshake-test.cc
+++ b/tests/libtransmission/handshake-test.cc
@@ -27,7 +27,7 @@
 
 #include <libtransmission/transmission.h>
 
-#include <libtransmission/crypto-utils.h> // tr_sha1_to_string, tr_base...
+#include <libtransmission/crypto-utils.h> // tr_sha1, tr_sha1_from_string, tr_base...
 #include <libtransmission/handshake.h>
 #include <libtransmission/net.h>
 #include <libtransmission/peer-io.h>
@@ -309,7 +309,7 @@ TEST_F(HandshakeTest, outgoingPlaintext)
     EXPECT_TRUE(res->peer_id);
     EXPECT_EQ(peer_id, res->peer_id);
     EXPECT_EQ(UbuntuTorrent.info_hash, io->torrent_hash());
-    EXPECT_EQ(tr_sha1_to_string(UbuntuTorrent.info_hash), tr_sha1_to_string(io->torrent_hash()));
+    EXPECT_EQ(tr_sha1_string{ UbuntuTorrent.info_hash }, tr_sha1_string{ io->torrent_hash() });
 
     tr_net_close_socket(sock);
 }
@@ -364,7 +364,7 @@ TEST_F(HandshakeTest, incomingEncrypted)
     EXPECT_TRUE(res->peer_id);
     EXPECT_EQ(ExpectedPeerId, res->peer_id);
     EXPECT_EQ(UbuntuTorrent.info_hash, io->torrent_hash());
-    EXPECT_EQ(tr_sha1_to_string(UbuntuTorrent.info_hash), tr_sha1_to_string(io->torrent_hash()));
+    EXPECT_EQ(tr_sha1_string{ UbuntuTorrent.info_hash }, tr_sha1_string{ io->torrent_hash() });
 
     tr_net_close_socket(sock);
 }
@@ -502,7 +502,7 @@ TEST_F(HandshakeTest, outgoingEncrypted)
     EXPECT_TRUE(res->peer_id);
     EXPECT_EQ(ExpectedPeerId, res->peer_id);
     EXPECT_EQ(UbuntuTorrent.info_hash, io->torrent_hash());
-    EXPECT_EQ(tr_sha1_to_string(UbuntuTorrent.info_hash), tr_sha1_to_string(io->torrent_hash()));
+    EXPECT_EQ(tr_sha1_string{ UbuntuTorrent.info_hash }, tr_sha1_string{ io->torrent_hash() });
 
     tr_net_close_socket(sock);
 }

--- a/tests/libtransmission/lpd-test.cc
+++ b/tests/libtransmission/lpd-test.cc
@@ -100,7 +100,7 @@ auto makeRandomHash()
 
 auto makeRandomHashString()
 {
-    return tr_strupper(tr_sha1_to_string(makeRandomHash()));
+    return tr_strupper(tr_sha1_string{ makeRandomHash() });
 }
 
 } // namespace

--- a/tests/libtransmission/serializer-tests.cc
+++ b/tests/libtransmission/serializer-tests.cc
@@ -15,6 +15,7 @@
 
 #include <fmt/core.h>
 
+#include <libtransmission/crypto-utils.h> // tr_rand_int()
 #include <libtransmission/net.h>
 #include <libtransmission/log.h>
 #include <libtransmission/quark.h>

--- a/tests/libtransmission/torrent-magnet-test.cc
+++ b/tests/libtransmission/torrent-magnet-test.cc
@@ -9,6 +9,7 @@
 
 #include <gtest/gtest.h>
 
+#include <libtransmission/crypto-utils.h> // tr_base64_decode()
 #include <libtransmission/error.h>
 #include <libtransmission/torrent-magnet.h>
 #include <libtransmission/torrent-metainfo.h>


### PR DESCRIPTION
## Description

- Use a fixed-size string rather than a `tr_strbuf` for digest strings. We know at compile time how large the string will always be, so `tr_strbuf` is overkill and its API (eg `append()`) doesn't make sense here.
- Move `tr_sha*_digest_t` and `tr_sha*_string` to a new `digest.h` header. This is to keep it out of `types.h` and `crypto-utils.h` so that they can be a standalone group and so that users don't have to include OS crypto library headers via `crypto-utils.h`.
- Add `format_as()` overload for the benefit of `fmt::formatter`.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.