### PR TITLE
chore: `noexcept` correctness

### DIFF
--- a/libtransmission-app/favicon-cache.h
+++ b/libtransmission-app/favicon-cache.h
@@ -144,7 +144,7 @@ private:
             responses_.emplace_back(std::move(contents), code);
         }
 
-        [[nodiscard]] auto& web()
+        [[nodiscard]] auto& web() noexcept
         {
             return *web_;
         }

--- a/libtransmission-app/rpc-client.cc
+++ b/libtransmission-app/rpc-client.cc
@@ -53,7 +53,7 @@ RpcClient::RpcClient(UiThreadFunc run_on_ui_thread)
 
 RpcClient::~RpcClient() = default;
 
-void RpcClient::start(tr_session* session)
+void RpcClient::start(tr_session* session) noexcept
 {
     session_ = session;
 }

--- a/libtransmission-app/rpc-client.h
+++ b/libtransmission-app/rpc-client.h
@@ -55,7 +55,7 @@ public:
     RpcClient& operator=(RpcClient const&) = delete;
 
     // Use an in-process session
-    void start(tr_session* session);
+    void start(tr_session* session) noexcept;
 
     // Use the remote server at `url` (scheme://host:port/path).
     void start(std::string url, std::optional<std::string> username = {}, std::optional<std::string> password = {});

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -141,7 +141,7 @@ tr_tracker_tier_t tr_announce_list::nextTier() const
     return std::empty(trackers_) ? 0 : trackers_.back().tier + 1;
 }
 
-tr_tracker_id_t tr_announce_list::next_unique_id()
+tr_tracker_id_t tr_announce_list::next_unique_id() noexcept
 {
     static tr_tracker_id_t id = 0;
     return id++;

--- a/libtransmission/announce-list.h
+++ b/libtransmission/announce-list.h
@@ -118,7 +118,7 @@ private:
     [[nodiscard]] tr_tracker_tier_t get_tier(tr_tracker_tier_t tier, tr_url_parsed_t const& announce) const;
 
     [[nodiscard]] bool can_add(tr_url_parsed_t const& announce) const noexcept;
-    static tr_tracker_id_t next_unique_id();
+    static tr_tracker_id_t next_unique_id() noexcept;
     trackers_t::iterator find(std::string_view announce);
     trackers_t::iterator find(tr_tracker_id_t id);
 

--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -35,7 +35,7 @@ void tr_announcerParseHttpAnnounceResponse(tr_announce_response& response, std::
 
 void tr_announcerParseHttpScrapeResponse(tr_scrape_response& response, std::string_view benc, std::string_view log_name);
 
-[[nodiscard]] constexpr std::string_view tr_announce_event_get_string(tr_announce_event e)
+[[nodiscard]] constexpr std::string_view tr_announce_event_get_string(tr_announce_event e) noexcept
 {
     switch (e) {
     case TR_ANNOUNCE_EVENT_COMPLETED:

--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -57,7 +57,7 @@ Speed tr_bandwidth::get_speed(RateControl& r, unsigned int interval_msec, uint64
     return r.cache_val_;
 }
 
-void tr_bandwidth::notify_bandwidth_consumed_bytes(uint64_t const now, RateControl& r, size_t size)
+void tr_bandwidth::notify_bandwidth_consumed_bytes(uint64_t const now, RateControl& r, size_t size) noexcept
 {
     if (r.date_[r.newest_] + GranularityMSec >= now) {
         r.size_[r.newest_] += size;

--- a/libtransmission/bandwidth.h
+++ b/libtransmission/bandwidth.h
@@ -152,7 +152,7 @@ public:
      * @see `tr_bandwidth::allocate`
      * @see `tr_bandwidth::getDesiredSpeed`
      */
-    constexpr bool set_desired_speed(tr_direction dir, Speed desired_speed)
+    constexpr bool set_desired_speed(tr_direction dir, Speed desired_speed) noexcept
     {
         auto& value = band_[static_cast<uint8_t>(dir)].desired_speed_;
         auto const did_change = desired_speed != value;
@@ -164,7 +164,7 @@ public:
      * @brief Get the desired speed for the bandwidth subtree.
      * @see `tr_bandwidth::setDesiredSpeed`
      */
-    [[nodiscard]] constexpr auto get_desired_speed(tr_direction dir) const
+    [[nodiscard]] constexpr auto get_desired_speed(tr_direction dir) const noexcept
     {
         return band_[static_cast<uint8_t>(dir)].desired_speed_;
     }
@@ -183,7 +183,7 @@ public:
     /**
      * @brief Set whether or not this bandwidth should throttle its peer-io's speeds
      */
-    constexpr bool set_limited(tr_direction dir, bool is_limited)
+    constexpr bool set_limited(tr_direction dir, bool is_limited) noexcept
     {
         auto& value = band_[static_cast<uint8_t>(dir)].is_limited_;
         auto const did_change = is_limited != value;
@@ -205,7 +205,7 @@ public:
      * But when we set a torrent's speed mode to `TR_SPEEDLIMIT_UNLIMITED`, then
      * in that particular case we want to ignore the global speed limit...
      */
-    constexpr bool honor_parent_limits(tr_direction direction, bool is_enabled)
+    constexpr bool honor_parent_limits(tr_direction direction, bool is_enabled) noexcept
     {
         auto& value = band_[static_cast<uint8_t>(direction)].honor_parent_limits_;
         auto const did_change = is_enabled != value;
@@ -213,7 +213,7 @@ public:
         return did_change;
     }
 
-    [[nodiscard]] constexpr bool are_parent_limits_honored(tr_direction direction) const
+    [[nodiscard]] constexpr bool are_parent_limits_honored(tr_direction direction) const noexcept
     {
         return band_[static_cast<uint8_t>(direction)].honor_parent_limits_;
     }
@@ -249,7 +249,7 @@ private:
 
     void deparent() noexcept;
 
-    static void notify_bandwidth_consumed_bytes(uint64_t now, RateControl& r, size_t size);
+    static void notify_bandwidth_consumed_bytes(uint64_t now, RateControl& r, size_t size) noexcept;
 
     static void phase_one(std::vector<tr_peerIo*>& peers, tr_direction dir);
 
@@ -267,7 +267,7 @@ private:
 
 /* @} */
 
-constexpr auto tr_isPriority(tr_priority_t p)
+constexpr auto tr_isPriority(tr_priority_t p) noexcept
 {
     return p == TR_PRI_LOW || p == TR_PRI_NORMAL || p == TR_PRI_HIGH;
 }

--- a/libtransmission/benc.h
+++ b/libtransmission/benc.h
@@ -38,17 +38,17 @@ struct Handler {
         {
         }
 
-        [[nodiscard]] constexpr std::pair<long, long> tokenSpan() const
+        [[nodiscard]] constexpr std::pair<long, long> tokenSpan() const noexcept
         {
             return { token_begin_ - stream_begin_, token_end_ - stream_begin_ };
         }
 
-        [[nodiscard]] constexpr auto raw() const
+        [[nodiscard]] constexpr auto raw() const noexcept
         {
             return std::string_view{ token_begin_, static_cast<size_t>(token_end_ - token_begin_) };
         }
 
-        constexpr void setTokenSpan(char const* a, size_t len)
+        constexpr void setTokenSpan(char const* a, size_t len) noexcept
         {
             token_begin_ = a;
             token_end_ = token_begin_ + len;
@@ -117,12 +117,12 @@ struct BasicHandler : public Handler {
         return true;
     }
 
-    [[nodiscard]] constexpr auto key(size_t i) const
+    [[nodiscard]] constexpr auto key(size_t i) const noexcept
     {
         return keys_[i];
     }
 
-    [[nodiscard]] constexpr auto depth() const
+    [[nodiscard]] constexpr auto depth() const noexcept
     {
         return depth_;
     }
@@ -196,22 +196,22 @@ struct ParserStack {
         return depth == 0;
     }
 
-    constexpr void tokenWalked()
+    constexpr void tokenWalked() noexcept
     {
         ++stack[depth].n_children_walked;
     }
 
-    [[nodiscard]] constexpr Node& current()
+    [[nodiscard]] constexpr Node& current() noexcept
     {
         return stack[depth];
     }
 
-    [[nodiscard]] constexpr Node& current() const
+    [[nodiscard]] constexpr Node& current() const noexcept
     {
         return stack[depth];
     }
 
-    [[nodiscard]] constexpr bool expectingDictKey() const
+    [[nodiscard]] constexpr bool expectingDictKey() const noexcept
     {
         return depth > 0 && stack[depth].parent_type == ParentType::Dict && (stack[depth].n_children_walked % 2) == 0;
     }

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -57,7 +57,7 @@ public:
         return std::size(file_pieces_);
     }
 
-    [[nodiscard]] TR_CONSTEXPR_VEC auto byte_span_for_file(tr_file_index_t const file) const
+    [[nodiscard]] TR_CONSTEXPR_VEC auto byte_span_for_file(tr_file_index_t const file) const noexcept
     {
         auto const& span = file_bytes_[file];
         return tr_byte_span_t{ .begin = span.begin, .end = span.end };

--- a/libtransmission/history.h
+++ b/libtransmission/history.h
@@ -29,7 +29,7 @@ public:
      * @param now the current time in seconds, such as from tr_time()
      * @param n how many items to add to the history's counter
      */
-    constexpr void add(time_t now, SizeType n)
+    constexpr void add(time_t now, SizeType n) noexcept
     {
         if (timestamps_[newest_] != now) {
             newest_ = (newest_ + 1) % Seconds;
@@ -45,7 +45,7 @@ public:
      * @param now the current time in seconds, such as from tr_time()
      * @param age_sec how many seconds to count back through.
      */
-    [[nodiscard]] constexpr SizeType count(time_t now, unsigned int age_sec) const
+    [[nodiscard]] constexpr SizeType count(time_t now, unsigned int age_sec) const noexcept
     {
         auto sum = SizeType{};
         time_t const oldest = now - age_sec;

--- a/libtransmission/interned-string.h
+++ b/libtransmission/interned-string.h
@@ -82,7 +82,7 @@ public:
         return std::size(sv());
     }
 
-    constexpr void clear()
+    constexpr void clear() noexcept
     {
         *this = tr_interned_string{};
     }

--- a/libtransmission/ip-cache.cc
+++ b/libtransmission/ip-cache.cc
@@ -190,7 +190,7 @@ tr_address tr_ip_cache::bind_addr(tr_address_type type) const noexcept
     return {};
 }
 
-bool tr_ip_cache::set_global_addr(tr_address const& addr_new) noexcept
+bool tr_ip_cache::set_global_addr(tr_address const& addr_new)
 {
     if (addr_new.is_global_unicast()) {
         auto const lock = std::scoped_lock{ global_addr_mutex_[addr_new.type] };
@@ -248,7 +248,7 @@ void tr_ip_cache::update_global_addr(tr_address_type const type)
     mediator_.fetch(std::move(options));
 }
 
-void tr_ip_cache::update_source_addr(tr_address_type type) noexcept
+void tr_ip_cache::update_source_addr(tr_address_type type)
 {
     using namespace global_source_ip_helpers;
 
@@ -340,14 +340,14 @@ void tr_ip_cache::on_response_ip_query(tr_address_type const type, tr_web::Fetch
     unset_is_updating(type);
 }
 
-void tr_ip_cache::unset_global_addr(tr_address_type type) noexcept
+void tr_ip_cache::unset_global_addr(tr_address_type type)
 {
     auto const lock = std::scoped_lock{ global_addr_mutex_[type] };
     global_addr_[type].reset();
     tr_logAddTrace(fmt::format("Unset {} global address cache", tr_ip_protocol_to_sv(type)));
 }
 
-void tr_ip_cache::set_source_addr(tr_address const& addr_new) noexcept
+void tr_ip_cache::set_source_addr(tr_address const& addr_new)
 {
     auto const lock = std::scoped_lock{ source_addr_mutex_[addr_new.type] };
     if (auto& addr = source_addr_[addr_new.type]; addr != addr_new) {
@@ -356,7 +356,7 @@ void tr_ip_cache::set_source_addr(tr_address const& addr_new) noexcept
     }
 }
 
-void tr_ip_cache::unset_addr(tr_address_type type) noexcept
+void tr_ip_cache::unset_addr(tr_address_type type)
 {
     auto const lock = std::scoped_lock{ source_addr_mutex_[type] };
     source_addr_[type].reset();

--- a/libtransmission/ip-cache.h
+++ b/libtransmission/ip-cache.h
@@ -88,11 +88,11 @@ public:
 
     [[nodiscard]] tr_address bind_addr(tr_address_type type) const noexcept;
 
-    bool set_global_addr(tr_address const& addr_new) noexcept;
+    bool set_global_addr(tr_address const& addr_new);
 
     void update_addr(tr_address_type type);
     void update_global_addr(tr_address_type type);
-    void update_source_addr(tr_address_type type) noexcept;
+    void update_source_addr(tr_address_type type);
 
     // Only use as a callback for web_->fetch()
     void on_response_ip_query(tr_address_type type, tr_web::FetchResponse const& response);
@@ -108,9 +108,9 @@ private:
 
     explicit tr_ip_cache(Mediator& mediator_in);
 
-    void unset_global_addr(tr_address_type type) noexcept;
-    void set_source_addr(tr_address const& addr_new) noexcept;
-    void unset_addr(tr_address_type type) noexcept;
+    void unset_global_addr(tr_address_type type);
+    void set_source_addr(tr_address const& addr_new);
+    void unset_addr(tr_address_type type);
 
     void start_timer(tr_address_type type, std::chrono::milliseconds msec) noexcept
     {

--- a/libtransmission/local-data.cc
+++ b/libtransmission/local-data.cc
@@ -326,7 +326,7 @@ void LocalData::shutdown()
 {
 }
 
-uint64_t LocalData::enqueued_write_bytes()
+uint64_t LocalData::enqueued_write_bytes() noexcept
 {
     return 0U;
 }

--- a/libtransmission/local-data.h
+++ b/libtransmission/local-data.h
@@ -98,7 +98,7 @@ public:
     void remove(tr_torrent_id_t id, tr_torrent_remove_func remove_func);
     void rename(tr_torrent_id_t id, std::string_view oldpath, std::string_view newname, tr_torrent_rename_done_func callback);
     void shutdown();
-    [[nodiscard]] static uint64_t enqueued_write_bytes();
+    [[nodiscard]] static uint64_t enqueued_write_bytes() noexcept;
 
 private:
     std::unique_ptr<Backend> backend_;

--- a/libtransmission/makemeta.h
+++ b/libtransmission/makemeta.h
@@ -177,7 +177,7 @@ public:
 
     [[nodiscard]] static uint32_t default_piece_size(uint64_t total_size) noexcept;
 
-    [[nodiscard]] constexpr static bool is_legal_piece_size(uint32_t x)
+    [[nodiscard]] constexpr static bool is_legal_piece_size(uint32_t x) noexcept
     {
         // It must be a power of two and at least 16KiB
         auto constexpr MinSize = uint32_t{ 1024U * 16U };

--- a/libtransmission/net.cc
+++ b/libtransmission/net.cc
@@ -362,7 +362,7 @@ std::pair<tr_address, std::byte const*> tr_address::from_compact_ipv6(std::byte 
     return { address, compact };
 }
 
-std::optional<unsigned> tr_address::to_interface_index() const noexcept
+std::optional<unsigned> tr_address::to_interface_index() const
 {
     if (!is_valid()) {
         tr_logAddDebug("Invalid target address to find interface index");

--- a/libtransmission/net.h
+++ b/libtransmission/net.h
@@ -127,7 +127,7 @@ struct tr_address {
 
     // ---
 
-    [[nodiscard]] std::optional<unsigned> to_interface_index() const noexcept;
+    [[nodiscard]] std::optional<unsigned> to_interface_index() const;
 
     // --- comparisons
 
@@ -478,7 +478,7 @@ public:
 
 private:
     // https://stackoverflow.com/a/27952689/11390656
-    [[nodiscard]] static constexpr std::size_t hash_combine(std::size_t const a, std::size_t const b)
+    [[nodiscard]] static constexpr std::size_t hash_combine(std::size_t const a, std::size_t const b) noexcept
     {
         return a ^ (b + 0x9e3779b9U + (a << 6U) + (a >> 2U));
     }

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -70,7 +70,7 @@ public:
         tr_bandwidth* parent,
         std::shared_ptr<tr_peer_socket> socket);
 
-    constexpr void set_callbacks(CanRead can_read, DidWrite did_write, GotError got_error, void* user_data)
+    constexpr void set_callbacks(CanRead can_read, DidWrite did_write, GotError got_error, void* user_data) noexcept
     {
         can_read_ = can_read;
         did_write_ = did_write;
@@ -232,7 +232,7 @@ public:
         return priority_;
     }
 
-    constexpr void set_priority(tr_priority_t priority)
+    constexpr void set_priority(tr_priority_t priority) noexcept
     {
         priority_ = priority;
     }

--- a/libtransmission/peer-mgr-wishlist.h
+++ b/libtransmission/peer-mgr-wishlist.h
@@ -74,7 +74,7 @@ private:
             return (*this <=> that) == 0;
         }
 
-        [[nodiscard]] constexpr auto block_belongs(tr_block_index_t const block) const
+        [[nodiscard]] constexpr auto block_belongs(tr_block_index_t const block) const noexcept
         {
             return block_span.begin <= block && block < block_span.end;
         }

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -843,7 +843,7 @@ void tr_rpc_server::set_enabled(bool is_enabled)
     });
 }
 
-void tr_rpc_server::set_port(tr_port port) noexcept
+void tr_rpc_server::set_port(tr_port port)
 {
     if (settings_.port == port) {
         return;
@@ -870,7 +870,7 @@ void tr_rpc_server::set_whitelist(std::string_view whitelist)
 
 // --- PASSWORD
 
-void tr_rpc_server::set_username(std::string username) noexcept
+void tr_rpc_server::set_username(std::string username)
 {
     settings_.username = std::move(username);
     tr_logAddDebug(fmt::format("setting our username to '{:s}'", settings_.username));

--- a/libtransmission/rpc-server.h
+++ b/libtransmission/rpc-server.h
@@ -44,7 +44,7 @@ public:
 
     void load(Settings&& settings);
 
-    [[nodiscard]] constexpr Settings const& settings() const
+    [[nodiscard]] constexpr Settings const& settings() const noexcept
     {
         return settings_;
     }
@@ -54,7 +54,7 @@ public:
         return settings_.port;
     }
 
-    void set_port(tr_port port) noexcept;
+    void set_port(tr_port port);
 
     [[nodiscard]] constexpr auto is_enabled() const noexcept
     {
@@ -85,7 +85,7 @@ public:
         return settings_.username;
     }
 
-    void set_username(std::string username) noexcept;
+    void set_username(std::string username);
 
     [[nodiscard]] constexpr auto is_password_enabled() const noexcept
     {

--- a/libtransmission/session-settings.h
+++ b/libtransmission/session-settings.h
@@ -60,7 +60,7 @@ public:
         load(src);
     }
 
-    void fixup_from_preferred_transports();
+    void fixup_from_preferred_transports() noexcept;
     void fixup_to_preferred_transports();
 
     void load(tr::Settings const& src)

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -839,7 +839,7 @@ std::string tr::SessionSettings::get_default_download_dir()
     return tr::platform::get_download_dir();
 }
 
-void tr::SessionSettings::fixup_from_preferred_transports()
+void tr::SessionSettings::fixup_from_preferred_transports() noexcept
 {
     utp_enabled = false;
     tcp_enabled = false;

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -441,22 +441,22 @@ public:
         return session_thread_->event_base();
     }
 
-    [[nodiscard]] constexpr tr_torrents& torrents()
+    [[nodiscard]] constexpr tr_torrents& torrents() noexcept
     {
         return torrents_;
     }
 
-    [[nodiscard]] constexpr tr_torrents const& torrents() const
+    [[nodiscard]] constexpr tr_torrents const& torrents() const noexcept
     {
         return torrents_;
     }
 
-    [[nodiscard]] constexpr auto& torrent_queue()
+    [[nodiscard]] constexpr auto& torrent_queue() noexcept
     {
         return torrent_queue_;
     }
 
-    [[nodiscard]] constexpr auto const& torrent_queue() const
+    [[nodiscard]] constexpr auto const& torrent_queue() const noexcept
     {
         return torrent_queue_;
     }
@@ -1095,13 +1095,13 @@ public:
         return settings().unused_cache_size_mbytes;
     }
 
-    constexpr void set_unused_cache_size_mbytes(size_t const mbytes)
+    constexpr void set_unused_cache_size_mbytes(size_t const mbytes) noexcept
     {
         settings_.unused_cache_size_mbytes = mbytes;
     }
 
 private:
-    constexpr bool& scriptEnabledFlag(TrScript i)
+    constexpr bool& scriptEnabledFlag(TrScript i) noexcept
     {
         if (i == TR_SCRIPT_ON_TORRENT_ADDED) {
             return settings_.script_torrent_added_enabled;
@@ -1114,7 +1114,7 @@ private:
         return settings_.script_torrent_done_seeding_enabled;
     }
 
-    constexpr std::string& scriptFilename(TrScript i)
+    constexpr std::string& scriptFilename(TrScript i) noexcept
     {
         if (i == TR_SCRIPT_ON_TORRENT_ADDED) {
             return settings_.script_torrent_added_filename;

--- a/libtransmission/torrent-ctor.h
+++ b/libtransmission/torrent-ctor.h
@@ -109,7 +109,7 @@ public:
         return priority_;
     }
 
-    constexpr void set_bandwidth_priority(tr_priority_t priority)
+    constexpr void set_bandwidth_priority(tr_priority_t priority) noexcept
     {
         if (priority == TR_PRI_LOW || priority == TR_PRI_NORMAL || priority == TR_PRI_HIGH) {
             priority_ = priority;
@@ -159,7 +159,7 @@ public:
         return optional_args_[mode].paused_;
     }
 
-    constexpr void set_paused(tr_ctorMode const mode, bool const paused)
+    constexpr void set_paused(tr_ctorMode const mode, bool const paused) noexcept
     {
         optional_args_[mode].paused_ = paused;
     }
@@ -171,7 +171,7 @@ public:
         return optional_args_[mode].peer_limit_;
     }
 
-    constexpr void set_peer_limit(tr_ctorMode const mode, uint16_t const peer_limit)
+    constexpr void set_peer_limit(tr_ctorMode const mode, uint16_t const peer_limit) noexcept
     {
         optional_args_[mode].peer_limit_ = peer_limit;
     }
@@ -183,7 +183,7 @@ public:
         return should_delete_source_file_;
     }
 
-    constexpr void set_should_delete_source_file(bool should)
+    constexpr void set_should_delete_source_file(bool should) noexcept
     {
         should_delete_source_file_ = should;
     }

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -71,7 +71,7 @@ tr_metadata_download::tr_metadata_download(std::string_view log_name, int64_t co
     create_all_needed(n);
 }
 
-void tr_torrent::maybe_start_metadata_transfer(int64_t const size) noexcept
+void tr_torrent::maybe_start_metadata_transfer(int64_t const size)
 {
     if (has_metainfo() || metadata_download_) {
         return;

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -130,7 +130,7 @@ public:
         return is_private_;
     }
 
-    [[nodiscard]] TR_CONSTEXPR_VEC tr_sha1_digest_t const& piece_hash(tr_piece_index_t piece) const
+    [[nodiscard]] TR_CONSTEXPR_VEC tr_sha1_digest_t const& piece_hash(tr_piece_index_t piece) const noexcept
     {
         return pieces_[piece];
     }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1771,7 +1771,7 @@ void tr_torrent::set_labels(labels_t const& new_labels)
 
 // ---
 
-void tr_torrent::set_bandwidth_group(std::string_view group_name) noexcept
+void tr_torrent::set_bandwidth_group(std::string_view group_name)
 {
     group_name = tr_strv_strip(group_name);
 

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -627,7 +627,7 @@ struct tr_torrent {
 
     /// METAINFO - MAGNET
 
-    void maybe_start_metadata_transfer(int64_t size) noexcept;
+    void maybe_start_metadata_transfer(int64_t size);
 
     [[nodiscard]] std::optional<tr_metadata_piece> get_metadata_piece(int64_t piece) const;
 
@@ -694,7 +694,7 @@ struct tr_torrent {
         return unique_id_;
     }
 
-    void init_id(tr_torrent_id_t id)
+    void init_id(tr_torrent_id_t id) noexcept
     {
         TR_ASSERT(unique_id_ == tr_torrent_id_t{});
         TR_ASSERT(id != tr_torrent_id_t{});
@@ -797,7 +797,7 @@ struct tr_torrent {
         return date_changed_ > when;
     }
 
-    void set_bandwidth_group(std::string_view group_name) noexcept;
+    void set_bandwidth_group(std::string_view group_name);
 
     [[nodiscard]] constexpr auto get_priority() const noexcept
     {
@@ -1084,7 +1084,7 @@ private:
     class SimpleSmoothedSpeed
     {
     public:
-        constexpr auto update(uint64_t time_msec, Speed speed)
+        constexpr auto update(uint64_t time_msec, Speed speed) noexcept
         {
             // If the old speed is too old, just replace it
             if (timestamp_msec_ + MaxAgeMSec <= time_msec) {
@@ -1406,7 +1406,7 @@ private:
 
 // ---
 
-constexpr bool tr_isTorrent(tr_torrent const* tor)
+constexpr bool tr_isTorrent(tr_torrent const* tor) noexcept
 {
     return tor != nullptr && tor->session != nullptr;
 }

--- a/libtransmission/verify.cc
+++ b/libtransmission/verify.cc
@@ -183,7 +183,8 @@ tr_verify_worker::~tr_verify_worker()
     }
 }
 
-void tr_verify_worker::set_sleep_per_seconds_during_verify(std::chrono::milliseconds const sleep_per_seconds_during_verify)
+void tr_verify_worker::set_sleep_per_seconds_during_verify(
+    std::chrono::milliseconds const sleep_per_seconds_during_verify) noexcept
 {
     sleep_per_seconds_during_verify_ = sleep_per_seconds_during_verify;
 }

--- a/libtransmission/verify.h
+++ b/libtransmission/verify.h
@@ -51,7 +51,7 @@ public:
 
     void remove(tr_sha1_digest_t const& info_hash);
 
-    void set_sleep_per_seconds_during_verify(std::chrono::milliseconds sleep_per_seconds_during_verify);
+    void set_sleep_per_seconds_during_verify(std::chrono::milliseconds sleep_per_seconds_during_verify) noexcept;
 
     [[nodiscard]] constexpr auto sleep_per_seconds_during_verify() const noexcept
     {


### PR DESCRIPTION
## Description

No behavioral changes, just some `noexcept` correctness cleanup:

- Some methods can be marked `noexcept` that weren't
- Some methods were marked `noexcept` but should've been

Candidates identified by AI, inspected manually by me.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
