### PR TITLE
fix: regression in the CSRF token handling

### DIFF
--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -68,7 +68,7 @@ struct tr_torrent;
 #endif
 
 #define MY_NAME TR_PROJ_APPNAME "-daemon"
-#define MY_CONFIG_DIRNAME TR_PROJ_CONFIG_DIRNAME "-daemon"
+#define MY_CONFIG_DIRNAME TR_PROJ_SHARED_CONFIG_DIRNAME "-daemon"
 
 using namespace std::literals;
 using tr::Watchdir;

--- a/gtk/main.cc
+++ b/gtk/main.cc
@@ -38,7 +38,7 @@
 
 namespace
 {
-auto const* const AppConfigDirName = TR_PROJ_CONFIG_DIRNAME;
+auto const* const AppConfigDirName = TR_PROJ_SHARED_CONFIG_DIRNAME;
 auto const* const AppTranslationDomainName = MY_NAME;
 auto const* const AppName = MY_NAME;
 

--- a/libtransmission/constants.h
+++ b/libtransmission/constants.h
@@ -27,7 +27,7 @@ inline auto constexpr TrMaxRecentDirs = 6U;
 
 inline auto constexpr TrHttpServerRpcRelativePath = std::string_view{ "rpc" };
 inline auto constexpr TrHttpServerWebRelativePath = std::string_view{ "web/" };
-inline auto constexpr TrRpcSessionIdHeader = std::string_view{ TR_PROJ_RPC_SESSION_ID_HEADER };
-inline auto constexpr TrRpcVersionHeader = std::string_view{ TR_PROJ_RPC_VERSION_HEADER };
+inline auto constexpr TrRpcSessionIdHeader = std::string_view{ TR_PROJ_SHARED_RPC_SESSION_ID_HEADER };
+inline auto constexpr TrRpcVersionHeader = std::string_view{ TR_PROJ_SHARED_RPC_VERSION_HEADER };
 
 inline auto constexpr TrBlockSize = uint32_t{ 1024U * 16U };

--- a/libtransmission/macros.h
+++ b/libtransmission/macros.h
@@ -52,10 +52,6 @@
 #define TR_PROJ_APPNAME_CAPITALIZED "Retransmission"
 #define TR_PROJ_APPNAME_RDNS TR_PROJ_DOMAIN_APEX_REVERSED "." TR_PROJ_APPNAME
 
-// Config dirs keep the old name for compatibility.
-// Everything else uses TR_PROJ_APPNAME.
-#define TR_PROJ_CONFIG_DIRNAME "transmission"
-
 #define TR_PROJ_URL_HOMEPAGE "https://" TR_PROJ_DOMAIN_APEX
 #define TR_PROJ_URL_DONATE TR_PROJ_URL_HOMEPAGE "/donate"
 #define TR_PROJ_URL_HELP TR_PROJ_URL_HOMEPAGE "/help"
@@ -71,5 +67,8 @@
 #define TR_PROJ_DBUS_INTERFACE TR_PROJ_DBUS_SERVICE
 
 #define TR_PROJ_WEB_SERVER_BASE_PATH "/" TR_PROJ_APPNAME "/"
-#define TR_PROJ_RPC_SESSION_ID_HEADER "X-" TR_PROJ_APPNAME_CAPITALIZED "-Session-Id"
-#define TR_PROJ_RPC_VERSION_HEADER "X-" TR_PROJ_APPNAME_CAPITALIZED "-Rpc-Version"
+
+// Places where we keep the 'transmission' name for compatibility
+#define TR_PROJ_SHARED_CONFIG_DIRNAME "transmission"
+#define TR_PROJ_SHARED_RPC_SESSION_ID_HEADER "X-Transmission-Session-Id"
+#define TR_PROJ_SHARED_RPC_VERSION_HEADER "X-Transmission-Rpc-Version"

--- a/qt/main.cc
+++ b/qt/main.cc
@@ -238,7 +238,7 @@ int tr_main(int argc, char** argv)
 
     // set the fallback config dir
     if (config_dir.isNull()) {
-        config_dir = QString::fromStdString(tr::platform::get_default_config_dir(TR_PROJ_CONFIG_DIRNAME));
+        config_dir = QString::fromStdString(tr::platform::get_default_config_dir(TR_PROJ_SHARED_CONFIG_DIRNAME));
     }
 
     auto prefs = Prefs{ config_dir };

--- a/tests/libtransmission-app/rpc-client-test.cc
+++ b/tests/libtransmission-app/rpc-client-test.cc
@@ -51,7 +51,7 @@ auto constexpr SessionId = "test-session-id"sv;
 
 // A minimal in-process stand-in for transmission-daemon's RPC endpoint. It does
 // just enough to exercise tr::app::RpcClient's remote transport end to end: the
-// CSRF handshake (reply 409 with an TR_PROJ_RPC_SESSION_ID_HEADER that the
+// CSRF handshake (reply 409 with an TR_PROJ_SHARED_RPC_SESSION_ID_HEADER that the
 // client must echo back), optionally advertising the Tr5 RPC version, followed
 // by a valid success response. It records every request body so tests can assert
 // on the wire format. Everything stays on 127.0.0.1, so there's nothing to flake.

--- a/tests/qt/rpc-test-fixtures.h
+++ b/tests/qt/rpc-test-fixtures.h
@@ -28,7 +28,7 @@
 
 // A minimal in-process stand-in for transmission-daemon's RPC endpoint. It does
 // just enough to exercise Session's remote transport end to end: the CSRF
-// handshake (reply 409 with an TR_PROJ_RPC_SESSION_ID_HEADER that the client
+// handshake (reply 409 with an TR_PROJ_SHARED_RPC_SESSION_ID_HEADER that the client
 // must echo back) followed by a valid, empty success response. Every request
 // body is recorded so tests can assert on the wire format. It never advertises
 // an RPC version, so the client keeps its original api_compats style.

--- a/tests/utils/remote-test.cc
+++ b/tests/utils/remote-test.cc
@@ -37,7 +37,7 @@ auto constexpr SessionId = "test-session-id"sv;
 
 // A minimal in-process stand-in for transmission-daemon's RPC endpoint. It
 // mimics just enough of the daemon to exercise transmission-remote end to end:
-// the CSRF handshake (reply 409 with an TR_PROJ_RPC_SESSION_ID_HEADER the
+// the CSRF handshake (reply 409 with an TR_PROJ_SHARED_RPC_SESSION_ID_HEADER the
 // client must echo back) followed by a valid, empty success response.
 // Everything stays on 127.0.0.1, so there's no external dependency.
 class MockRpcServer
@@ -106,13 +106,13 @@ private:
         request_count_.fetch_add(1);
 
         auto* const in_headers = evhttp_request_get_input_headers(req);
-        auto const* const session_id = evhttp_find_header(in_headers, TR_PROJ_RPC_SESSION_ID_HEADER);
+        auto const* const session_id = evhttp_find_header(in_headers, TR_PROJ_SHARED_RPC_SESSION_ID_HEADER);
         auto* const out_headers = evhttp_request_get_output_headers(req);
         auto* const out = evbuffer_new();
 
         if (session_id == nullptr) {
             // CSRF handshake: reject and hand back a session id to retry with.
-            evhttp_add_header(out_headers, TR_PROJ_RPC_SESSION_ID_HEADER, std::string{ SessionId }.c_str());
+            evhttp_add_header(out_headers, TR_PROJ_SHARED_RPC_SESSION_ID_HEADER, std::string{ SessionId }.c_str());
             evhttp_send_reply(req, 409, "Conflict", out);
         } else {
             authenticated_request_seen_.store(std::string_view{ session_id } == SessionId);


### PR DESCRIPTION
## Description

Proof that I don't use AI for everything ... AI would have found this and flagged it as a bug. :roll_eyes: 

Mass-renaming everything to `Retransmission` broke the CSRF ID token name s.t. we can no longer connect to Transmission servers.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
