### PR TITLE
ci: run the `new` label expiry every 15 minutes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,10 @@
+## Description
+
+Description goes here.
+
+Notes: If the PR has user-facing changes, add a short (ideally one-sentence) description here in terms an end user will understand.
+
+## Checklist
+
 - [ ] I have manually written or manually audited all changes in this PR and vouch for them.
+- [ ] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -23,6 +23,10 @@ env:
   # Bumping CACHE_SCHEMA re-keys every ccache and win-deps family; the
   # janitor deletes keys that do not carry the current value.
   CACHE_SCHEMA: cache-v2
+  # Identify the compiler by its contents. Runner images are respun more
+  # often than the compilers they ship, and the mtime default counts a
+  # reinstalled but unchanged compiler as a different one.
+  CCACHE_COMPILERCHECK: content
   CCACHE_COMPRESSLEVEL: '5'
   CCACHE_DIR: ${{ github.workspace }}/.ccache
   GTEST_OUTPUT: xml:./

--- a/.github/workflows/pr-new-label-expiry.yml
+++ b/.github/workflows/pr-new-label-expiry.yml
@@ -1,11 +1,14 @@
 name: Expire the "new" label on pull requests
 
 # Removes the `new` label once min(2 weekdays, 3 calendar days) have elapsed
-# since a PR was opened. Runs hourly on a schedule.
+# since a PR was opened.
 
 on:
   schedule:
-    - cron: '0 * * * *' # hourly
+    # Run every 15 minutes.  The odd minutes are deliberate:
+    # GitHub delays or silently drops scheduled events under load,
+    # so we're avoiding the commonly-oversubscribed slots of 0,15,30,45.
+    - cron: '7,22,37,52 * * * *' # every 15 minutes
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Description

Run the `new` label expiration job every 15 minutes.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
