### PR TITLE
perf: `tr_urlPercentEncode()` appends to a `std::string`

### DIFF
--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -34,7 +34,6 @@
 #include "libtransmission/session.h"
 #include "libtransmission/string-utils.h"
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/tr-strbuf.h" // tr_strbuf, tr_urlbuf
 #include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 #include "libtransmission/web-utils.h"
@@ -161,18 +160,26 @@ void onAnnounceDone(tr_web::FetchResponse const& web_response)
     }
 }
 
-void announce_url_new(tr_urlbuf& url, tr_session const* session, tr_announce_request const& req)
+[[nodiscard]] std::string announce_url_new(tr_session const* session, tr_announce_request const& req)
 {
-    url.clear();
+    // Enough for the query fields below in all but pathological cases,
+    // e.g. an unusually long tracker id. Overshooting is cheap: `url` is
+    // moved into the FetchOptions, and copies of it are sized to fit.
+    static auto constexpr TypicalQueryLen = 512U;
+
+    auto url = std::string{};
+    url.reserve(std::size(req.announce_url.sv()) + TypicalQueryLen);
+
+    // the info_hash is appended rather than formatted in so that it
+    // needs no intermediate buffer of its own
+    url += req.announce_url.sv();
+    url += tr_strv_contains(req.announce_url.sv(), '?') ? '&' : '?';
+    url += "info_hash="sv;
+    tr_urlPercentEncode(url, req.info_hash);
+
     auto out = std::back_inserter(url);
-
-    auto escaped_info_hash = tr_urlbuf{};
-    tr_urlPercentEncode(std::back_inserter(escaped_info_hash), req.info_hash);
-
     fmt::format_to(
         out,
-        "{url}"
-        "{sep}info_hash={info_hash}"
         "&peer_id={peer_id}"
         "&port={port}"
         "&uploaded={uploaded}"
@@ -182,9 +189,6 @@ void announce_url_new(tr_urlbuf& url, tr_session const* session, tr_announce_req
         "&key={key:08X}"
         "&compact=1"
         "&supportcrypto=1",
-        fmt::arg("url", req.announce_url.sv()),
-        fmt::arg("sep", tr_strv_contains(req.announce_url.sv(), '?') ? '&' : '?'),
-        fmt::arg("info_hash", std::data(escaped_info_hash)),
         fmt::arg("peer_id", std::string_view{ std::data(req.peer_id), std::size(req.peer_id) }),
         fmt::arg("port", req.port.host()),
         fmt::arg("uploaded", req.up),
@@ -210,16 +214,16 @@ void announce_url_new(tr_urlbuf& url, tr_session const* session, tr_announce_req
     }
 
     if (auto ipv4_addr = session->global_address(TR_AF_INET); ipv4_addr) {
-        auto const display_name = ipv4_addr->display_name();
-        fmt::format_to(out, "&ipv4=");
-        tr_urlPercentEncode(out, display_name);
+        url += "&ipv4="sv;
+        tr_urlPercentEncode(url, ipv4_addr->display_name());
     }
 
     if (auto ipv6_addr = session->global_address(TR_AF_INET6); ipv6_addr) {
-        auto const display_name = ipv6_addr->display_name();
-        fmt::format_to(out, "&ipv6=");
-        tr_urlPercentEncode(out, display_name);
+        url += "&ipv6="sv;
+        tr_urlPercentEncode(url, ipv6_addr->display_name());
     }
+
+    return url;
 }
 
 [[nodiscard]] std::string format_ip_arg(std::string_view ip)
@@ -249,9 +253,7 @@ void tr_tracker_http_announce(
        and to be safe we also add the "ipv4=" and "ipv6=" parameters, if
        we already have them.
      */
-    auto url = tr_urlbuf{};
-    announce_url_new(url, session, request);
-    auto options = tr_web::FetchOptions{ url.sv(), onAnnounceDone, d };
+    auto options = tr_web::FetchOptions{ announce_url_new(session, request), onAnnounceDone, d };
     options.timeout_secs = TrAnnounceTimeoutSec;
     options.sndbuf = 4096;
     options.rcvbuf = 4096;
@@ -453,16 +455,24 @@ void onScrapeDone(tr_web::FetchResponse const& web_response)
     delete data;
 }
 
-void scrape_url_new(tr_pathbuf& scrape_url, tr_scrape_request const& req)
+[[nodiscard]] std::string scrape_url_new(tr_scrape_request const& req)
 {
-    scrape_url = req.scrape_url.sv();
+    // a delimiter, "info_hash=", and a percent-encoded digest
+    static auto constexpr MaxCharsPerHash = 1U + 10U + (3U * std::tuple_size_v<tr_sha1_digest_t>);
+
+    auto scrape_url = std::string{};
+    scrape_url.reserve(std::size(req.scrape_url.sv()) + (req.info_hash_count * MaxCharsPerHash));
+    scrape_url += req.scrape_url.sv();
     char delimiter = tr_strv_contains(scrape_url, '?') ? '&' : '?';
 
     for (size_t i = 0; i < req.info_hash_count; ++i) {
-        scrape_url.append(delimiter, "info_hash=");
-        tr_urlPercentEncode(std::back_inserter(scrape_url), req.info_hash[i]);
+        scrape_url += delimiter;
+        scrape_url += "info_hash="sv;
+        tr_urlPercentEncode(scrape_url, req.info_hash[i]);
         delimiter = '&';
     }
+
+    return scrape_url;
 }
 } // namespace scrape_helpers
 } // namespace
@@ -480,10 +490,9 @@ void tr_tracker_http_scrape(tr_session const* session, tr_scrape_request const& 
         response.rows[i].info_hash = request.info_hash[i];
     }
 
-    auto scrape_url = tr_pathbuf{};
-    scrape_url_new(scrape_url, request);
+    auto scrape_url = scrape_url_new(request);
     tr_logAddTrace(fmt::format("Sending scrape to libcurl: '{}'", scrape_url), request.log_name);
-    auto options = tr_web::FetchOptions{ scrape_url, onScrapeDone, d };
+    auto options = tr_web::FetchOptions{ std::move(scrape_url), onScrapeDone, d };
     options.timeout_secs = TrScrapeTimeoutSec;
     options.sndbuf = 4096;
     options.rcvbuf = 4096;

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -150,7 +150,7 @@ std::optional<tr_sha256_digest_t> parseHash2(std::string_view sv)
 
 std::string tr_magnet_metainfo::magnet() const
 {
-    auto buf = std::string{ "magnet:?xt=urn:btih:"sv };
+    auto buf = "magnet:?xt=urn:btih:"s;
     buf += info_hash_string();
 
     if (!std::empty(name_)) {

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -7,7 +7,6 @@
 #include <array>
 #include <cstdint> // uint8_t
 #include <cstring>
-#include <iterator> // back_inserter
 #include <optional>
 #include <ranges>
 #include <string>
@@ -20,7 +19,6 @@
 #include "libtransmission/error.h"
 #include "libtransmission/magnet-metainfo.h"
 #include "libtransmission/string-utils.h"
-#include "libtransmission/tr-strbuf.h" // for tr_urlbuf
 #include "libtransmission/types.h" // for tr_sha1_digest_t
 #include "libtransmission/web-utils.h"
 
@@ -152,24 +150,25 @@ std::optional<tr_sha256_digest_t> parseHash2(std::string_view sv)
 
 std::string tr_magnet_metainfo::magnet() const
 {
-    auto buf = tr_urlbuf{ "magnet:?xt=urn:btih:"sv, info_hash_string() };
+    auto buf = std::string{ "magnet:?xt=urn:btih:"sv };
+    buf += info_hash_string();
 
     if (!std::empty(name_)) {
         buf += "&dn="sv;
-        tr_urlPercentEncode(std::back_inserter(buf), name_);
+        tr_urlPercentEncode(buf, name_);
     }
 
     for (auto const& tracker : this->announce_list()) {
         buf += "&tr="sv;
-        tr_urlPercentEncode(std::back_inserter(buf), tracker.announce.sv());
+        tr_urlPercentEncode(buf, tracker.announce.sv());
     }
 
     for (auto const& webseed : webseed_urls_) {
         buf += "&ws="sv;
-        tr_urlPercentEncode(std::back_inserter(buf), webseed);
+        tr_urlPercentEncode(buf, webseed);
     }
 
-    return std::string{ buf.sv() };
+    return buf;
 }
 
 void tr_magnet_metainfo::set_name(std::string_view name)

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1398,7 +1398,7 @@ void portTest(tr_session* session, tr_variant::Map const& args_in, struct tr_rpc
     static auto constexpr TimeoutSecs = 20s;
 
     auto const port = session->advertisedPeerPort();
-    auto const url = fmt::format("{:s}/{:d}", TR_PROJ_URL_PORTCHECK, port.host());
+    auto url = fmt::format("{:s}/{:d}", TR_PROJ_URL_PORTCHECK, port.host());
     auto ip_proto = std::optional<tr_web::FetchOptions::IPProtocol>{};
 
     if (auto const val = args_in.value_if<std::string_view>(TR_KEY_ip_protocol); val) {
@@ -1415,7 +1415,7 @@ void portTest(tr_session* session, tr_variant::Map const& args_in, struct tr_rpc
     }
 
     auto options = tr_web::FetchOptions{
-        url,
+        std::move(url),
         [](tr_web::FetchResponse const& r) { onPortTested(r); },
         idle_data,
     };
@@ -1638,7 +1638,7 @@ void torrentAdd(tr_session* session, tr_variant::Map const& args_in, tr_rpc_idle
     if (isCurlURL(filename)) {
         auto* const d = new add_torrent_idle_data{ idle_data, std::move(ctor) };
         auto options = tr_web::FetchOptions{
-            filename,
+            std::string{ filename },
             [](tr_web::FetchResponse const& r) { onMetadataFetched(r); },
             d,
         };

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -431,6 +431,37 @@ std::vector<std::pair<std::string_view, std::string_view>> tr_url_parsed_t::quer
     return ret;
 }
 
+void tr_urlPercentEncode(std::string& appendme, std::string_view input, bool escape_reserved)
+{
+    auto constexpr IsUnreserved = [](unsigned char ch) {
+        return ('0' <= ch && ch <= '9') || ('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z') || ch == '-' || ch == '_' ||
+            ch == '.' || ch == '~';
+    };
+
+    auto constexpr IsReserved = [](unsigned char ch) {
+        return ch == '!' || ch == '*' || ch == '(' || ch == ')' || ch == ';' || ch == ':' || ch == '@' || ch == '&' ||
+            ch == '=' || ch == '+' || ch == '$' || ch == ',' || ch == '/' || ch == '?' || ch == '%' || ch == '#' || ch == '[' ||
+            ch == ']' || ch == '\'';
+    };
+
+    auto constexpr HexDigits = std::string_view{ "0123456789ABCDEF" };
+
+    for (unsigned char const ch : input) {
+        if (IsUnreserved(ch) || (!escape_reserved && IsReserved(ch))) {
+            appendme += static_cast<char>(ch);
+        } else {
+            appendme += '%';
+            appendme += HexDigits[ch >> 4U];
+            appendme += HexDigits[ch & 0xFU];
+        }
+    }
+}
+
+void tr_urlPercentEncode(std::string& appendme, tr_sha1_digest_t const& digest)
+{
+    tr_urlPercentEncode(appendme, std::string_view{ reinterpret_cast<char const*>(std::data(digest)), std::size(digest) });
+}
+
 std::string tr_urlPercentDecode(std::string_view in)
 {
     auto out = std::string{};

--- a/libtransmission/web-utils.h
+++ b/libtransmission/web-utils.h
@@ -12,8 +12,6 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/format.h>
-
 #include "libtransmission/digest.h"
 
 /** @brief convenience function to determine if an address is an IP address (IPv4 or IPv6) */
@@ -54,34 +52,15 @@ struct tr_url_parsed_t {
 // This is to avoid logging sensitive info, e.g. a personal announcer id in the URL.
 [[nodiscard]] std::string tr_urlTrackerLogName(std::string_view url);
 
-template<typename BackInsertIter>
-constexpr void tr_urlPercentEncode(BackInsertIter out, std::string_view input, bool escape_reserved = true)
-{
-    auto constexpr IsUnreserved = [](unsigned char ch) {
-        return ('0' <= ch && ch <= '9') || ('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z') || ch == '-' || ch == '_' ||
-            ch == '.' || ch == '~';
-    };
+// Appends the percent-encoded form of `input` to `appendme`.
+// When `escape_reserved` is false, the RFC 3986 reserved characters are
+// passed through as-is; use that when encoding a URL rather than a single
+// URL component, e.g. so that a webseed URL keeps its '/' separators.
+void tr_urlPercentEncode(std::string& appendme, std::string_view input, bool escape_reserved = true);
 
-    auto constexpr IsReserved = [](unsigned char ch) {
-        return ch == '!' || ch == '*' || ch == '(' || ch == ')' || ch == ';' || ch == ':' || ch == '@' || ch == '&' ||
-            ch == '=' || ch == '+' || ch == '$' || ch == ',' || ch == '/' || ch == '?' || ch == '%' || ch == '#' || ch == '[' ||
-            ch == ']' || ch == '\'';
-    };
-
-    for (unsigned char ch : input) {
-        if (IsUnreserved(ch) || (!escape_reserved && IsReserved(ch))) {
-            out = ch;
-        } else {
-            fmt::format_to(out, "%{:02X}", ch);
-        }
-    }
-}
-
-template<typename BackInsertIter>
-constexpr void tr_urlPercentEncode(BackInsertIter out, tr_sha1_digest_t const& digest)
-{
-    tr_urlPercentEncode(out, std::string_view{ reinterpret_cast<char const*>(digest.data()), std::size(digest) });
-}
+// Appends the percent-encoded form of `digest`'s bytes to `appendme`.
+// Appends at most `3 * std::size(digest)` chars.
+void tr_urlPercentEncode(std::string& appendme, tr_sha1_digest_t const& digest);
 
 [[nodiscard]] char const* tr_webGetResponseStr(long response_code);
 

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -53,11 +53,11 @@ public:
         };
 
         FetchOptions(
-            std::string_view url_in,
+            std::string url_in,
             FetchDoneFunc&& done_func_in,
             void* done_func_user_data_in,
             std::chrono::seconds timeout_secs_in = DefaultTimeoutSecs)
-            : url{ url_in }
+            : url{ std::move(url_in) }
             , done_func{ std::move(done_func_in) }
             , done_func_user_data{ done_func_user_data_in }
             , timeout_secs{ timeout_secs_in }

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -27,7 +27,6 @@
 #include "libtransmission/torrent.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-buffer.h"
-#include "libtransmission/tr-strbuf.h"
 #include "libtransmission/types.h"
 #include "libtransmission/web-utils.h"
 #include "libtransmission/web.h"
@@ -437,16 +436,22 @@ void tr_webseed_task::on_partial_data_fetched(tr_web::FetchResponse const& web_r
     webseed->on_idle();
 }
 
-template<typename OutputIt>
-void makeUrl(tr_webseed_impl const* const webseed, std::string_view name, OutputIt out)
+[[nodiscard]] std::string makeUrl(tr_webseed_impl const* const webseed, std::string_view name)
 {
+    // slack for the chars that percent-encoding expands
+    static auto constexpr Slack = 32U;
+
     auto const& url = webseed->base_url;
 
-    out = std::copy(std::begin(url), std::end(url), out);
+    auto ret = std::string{};
+    ret.reserve(std::size(url) + std::size(name) + Slack);
+    ret += url;
 
     if (tr_strv_ends_with(url, "/"sv) && !std::empty(name)) {
-        tr_urlPercentEncode(out, name, false);
+        tr_urlPercentEncode(ret, name, false);
     }
+
+    return ret;
 }
 
 void tr_webseed_task::request_next_chunk()
@@ -463,9 +468,7 @@ void tr_webseed_task::request_next_chunk()
 
     webseed_->connection_limiter.task_started();
 
-    auto url = tr_urlbuf{};
-    makeUrl(webseed_, tor.file_subpath(file_index), std::back_inserter(url));
-    auto options = tr_web::FetchOptions{ url.sv(), on_partial_data_fetched, this };
+    auto options = tr_web::FetchOptions{ makeUrl(webseed_, tor.file_subpath(file_index)), on_partial_data_fetched, this };
     options.range.emplace(file_offset, file_offset + this_chunk - 1);
     options.speed_limit_tag = tor.id();
     options.on_data_received = [this](size_t const n_bytes) {

--- a/tests/libtransmission/web-utils-test.cc
+++ b/tests/libtransmission/web-utils-test.cc
@@ -290,8 +290,8 @@ TEST_F(WebUtilsTest, urlPercentEncode)
     });
 
     for (auto const& [decoded, encoded, escape_reserved] : Tests) {
-        auto buf = tr_urlbuf{};
-        tr_urlPercentEncode(std::back_inserter(buf), decoded, escape_reserved);
+        auto buf = std::string{};
+        tr_urlPercentEncode(buf, decoded, escape_reserved);
         EXPECT_EQ(encoded, buf);
     }
 }

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -11,10 +11,11 @@
 #include <ctime>
 #include <chrono>
 #include <future>
-#include <iterator> // std::back_inserter
+#include <iterator> // std::size()
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility> // std::move()
 #include <vector>
 
 #include <fmt/chrono.h>
@@ -29,7 +30,6 @@
 #include <libtransmission/string-utils.h>
 #include <libtransmission/torrent-metainfo.h>
 #include <libtransmission/tr-getopt.h>
-#include <libtransmission/tr-strbuf.h>
 #include <libtransmission/utils.h>
 #include <libtransmission/values.h>
 #include <libtransmission/variant.h>
@@ -267,10 +267,10 @@ void doScrape(tr_torrent_metainfo const& metainfo)
         }
 
         // build the full scrape URL
-        auto scrape_url = tr_urlbuf{ tracker.scrape.sv() };
-        auto delimiter = tr_strv_contains(scrape_url, '?') ? '&' : '?';
-        scrape_url.append(delimiter, "info_hash=");
-        tr_urlPercentEncode(std::back_inserter(scrape_url), hash);
+        auto scrape_url = std::string{ tracker.scrape.sv() };
+        scrape_url += tr_strv_contains(scrape_url, '?') ? '&' : '?';
+        scrape_url += "info_hash="sv;
+        tr_urlPercentEncode(scrape_url, hash);
         fmt::print("{:s} ... ", scrape_url);
         fflush(stdout);
 
@@ -280,7 +280,7 @@ void doScrape(tr_torrent_metainfo const& metainfo)
         auto response_promise = std::promise<tr_web::FetchResponse>{};
         auto response_future = response_promise.get_future();
         web->fetch(
-            { scrape_url,
+            { std::move(scrape_url),
               [&response_promise](tr_web::FetchResponse const& resp) { response_promise.set_value(resp); },
               nullptr,
               TimeoutSecs });


### PR DESCRIPTION
Avoid using tr_strbuf since it's a false savings here: every caller's URL turns into a std::string via either (1) tr_magnet_metainfo::magnet() or (2) tr_web::fetch().

## Description

Avoid using `tr_strbuf` in `tr_urlPercentEncode()` since it's a false savings here: every caller's URL turns into a `std::string` via either (1) `tr_magnet_metainfo::magnet()` or (2) `tr_web::fetch()`.

Notes: Improved libtransmission code to use less CPU.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
