### PR TITLE
perf: use `std::string_view` for `tr_torrent_files::FoundFile`'s filename

### DIFF
--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -83,7 +83,8 @@ bool write_entire_buf(tr_sys_file_t const fd, uint64_t file_offset, std::span<ui
     auto const prealloc = writable && tor.file_is_wanted(file_index) ? session.preallocationMode() :
                                                                        tr_file_preallocation::None;
     if (auto const found = tor.find_file(file_index); found) {
-        return open_files.get(tor_id, file_index, writable, found->filename(), prealloc, file_size);
+        auto const filename = found->filename<tr_pathbuf>();
+        return open_files.get(tor_id, file_index, writable, filename, prealloc, file_size);
     }
 
     // do we want to create it?

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -42,7 +42,6 @@
 #include "libtransmission/torrent-ctor.h"
 #include "libtransmission/torrent.h"
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/tr-strbuf.h"
 #include "libtransmission/types.h"
 #include "libtransmission/utils.h"
 #include "libtransmission/values.h"

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -119,12 +119,12 @@ std::optional<tr_torrent_files::FoundFile> tr_torrent_files::find(
     for (auto const base : paths) {
         filename.assign(base, '/', subpath);
         if (auto const info = tr_sys_path_get_info(filename); info) {
-            return FoundFile{ *info, std::move(filename), std::size(base) };
+            return FoundFile{ *info, base, subpath, false };
         }
 
-        filename.assign(base, '/', subpath, PartialFileSuffix);
+        filename.append(PartialFileSuffix);
         if (auto const info = tr_sys_path_get_info(filename); info) {
-            return FoundFile{ *info, std::move(filename), std::size(base) };
+            return FoundFile{ *info, base, subpath, true };
         }
     }
 
@@ -195,8 +195,8 @@ bool tr_torrent_files::move(
             continue;
         }
 
-        auto const& old_path = found->filename();
-        auto const path = tr_pathbuf{ parent, '/', found->subpath() };
+        auto const old_path = found->filename<tr_pathbuf>();
+        auto const path = found->filename_under<tr_pathbuf>(parent);
         tr_logAddTrace(fmt::format("Found file #{:d} '{:s}'", i, old_path), parent_name);
 
         if (tr_sys_path_is_same(old_path, path)) {
@@ -271,7 +271,9 @@ void tr_torrent_files::remove(
     for (tr_file_index_t idx = 0, n_files = file_count(); idx < n_files; ++idx) {
         if (auto const found = find(idx, paths); found) {
             // if moving a file fails, give up and let the error propagate
-            if (!tr_file_move(found->filename(), tr_pathbuf{ tmpdir, '/', found->subpath() }, false, error)) {
+            auto const from = found->filename<tr_pathbuf>();
+            auto const to = found->filename_under<tr_pathbuf>(tmpdir);
+            if (!tr_file_move(from, to, false, error)) {
                 return;
             }
         }
@@ -436,7 +438,7 @@ namespace
 }
 
 // https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations
-void append_sanitized_component(std::string_view in, tr_pathbuf& out, bool os_specific)
+void append_sanitized_component(std::string_view in, std::string& out, bool os_specific)
 {
 #ifdef _WIN32
     // remove leading and trailing spaces
@@ -450,7 +452,7 @@ void append_sanitized_component(std::string_view in, tr_pathbuf& out, bool os_sp
 
     // replace reserved filenames with an underscore
     if (is_reserved_file(in, os_specific)) {
-        out.append('_');
+        out += '_';
     }
 
     // replace reserved characters with an underscore
@@ -462,12 +464,12 @@ void append_sanitized_component(std::string_view in, tr_pathbuf& out, bool os_sp
 
 } // namespace
 
-void tr_torrent_files::sanitize_subpath(std::string_view path, tr_pathbuf& append_me, bool os_specific)
+void tr_torrent_files::sanitize_subpath(std::string_view path, std::string& append_me, bool os_specific)
 {
     auto segment = std::string_view{};
     while (tr_strv_sep(&path, &segment, '/')) {
         append_sanitized_component(segment, append_me, os_specific);
-        append_me.append('/');
+        append_me += '/';
     }
 
     if (auto const n = std::size(append_me); n > 0) {

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -19,7 +19,6 @@
 
 #include "libtransmission/file.h"
 #include "libtransmission/macros.h"
-#include "libtransmission/tr-strbuf.h"
 #include "libtransmission/types.h"
 
 struct tr_error;
@@ -61,10 +60,11 @@ public:
 
     void insert_subpath_prefix(std::string_view path)
     {
-        auto const buf = tr_pathbuf{ path, '/' };
+        auto prefix = std::string{ path };
+        prefix += '/';
 
         for (auto& file : files_) {
-            file.path_.insert(0, buf.sv());
+            file.path_.insert(0, prefix);
             file.path_.shrink_to_fit();
         }
     }
@@ -118,57 +118,72 @@ public:
         tr_torrent_remove_func const& func,
         tr_error* error = nullptr) const;
 
+    static constexpr std::string_view PartialFileSuffix = ".part";
+
+    /**
+     * A file located on disk.
+     *
+     * `base` views the same storage as the matching entry of the `paths` span
+     * passed into `find()`; `subpath` views the `tr_torrent_files`.
+     * A FoundFile is valid only as long as both of those outlive it.
+     *
+     * filename() builds the name in whichever buffer the caller names, so
+     * callers on hot paths can use a stack buffer, e.g. filename<tr_pathbuf>().
+     */
     struct FoundFile : public tr_sys_path_info {
-    public:
-        FoundFile(tr_sys_path_info info, tr_pathbuf&& filename_in, size_t base_len_in)
-            : tr_sys_path_info{ info }
-            , filename_{ std::move(filename_in) }
-            , base_len_{ base_len_in }
+        // "/home/foo/Downloads"
+        std::string_view base;
+
+        // "torrent/01-file-one.txt"
+        std::string_view subpath;
+
+        // whether the file is an incomplete download
+        bool is_partial = false;
+
+        // what `subpath` needs appended to name the file on disk
+        [[nodiscard]] constexpr std::string_view suffix() const noexcept
         {
+            return is_partial ? PartialFileSuffix : std::string_view{};
         }
 
-        [[nodiscard]] constexpr auto const& filename() const noexcept
+        // "/home/foo/Downloads/torrent/01-file-one.txt"
+        template<typename Buf = std::string>
+        [[nodiscard]] Buf filename() const
         {
-            // /home/foo/Downloads/torrent/01-file-one.txt
-            return filename_;
+            return filename_under<Buf>(base);
         }
 
-        [[nodiscard]] constexpr auto base() const noexcept
+        // what this file would be named if it lived under `parent` instead of `base`
+        template<typename Buf = std::string>
+        [[nodiscard]] Buf filename_under(std::string_view parent) const
         {
-            // /home/foo/Downloads
-            return filename_.sv().substr(0, base_len_);
+            auto buf = Buf{};
+            buf += parent;
+            buf += '/';
+            buf += subpath;
+            buf += suffix();
+            return buf;
         }
-
-        [[nodiscard]] constexpr auto subpath() const noexcept
-        {
-            // torrent/01-file-one.txt
-            return filename_.sv().substr(base_len_ + 1);
-        }
-
-    private:
-        tr_pathbuf filename_;
-        size_t base_len_;
     };
 
     [[nodiscard]] std::optional<FoundFile> find(tr_file_index_t file_index, std::span<std::string_view const> paths) const;
     [[nodiscard]] bool has_any_local_data(std::span<std::string_view const> paths) const;
     [[nodiscard]] std::string_view primary_mime_type() const;
 
-    static void sanitize_subpath(std::string_view path, tr_pathbuf& append_me, bool os_specific = true);
+    static void sanitize_subpath(std::string_view path, std::string& append_me, bool os_specific = true);
 
-    [[nodiscard]] static auto sanitize_subpath(std::string_view path, bool os_specific = true)
+    [[nodiscard]] static std::string sanitize_subpath(std::string_view path, bool os_specific = true)
     {
-        auto tmp = tr_pathbuf{};
-        sanitize_subpath(path, tmp, os_specific);
-        return std::string{ tmp.sv() };
+        auto ret = std::string{};
+        ret.reserve(std::size(path));
+        sanitize_subpath(path, ret, os_specific);
+        return ret;
     }
 
     [[nodiscard]] static bool is_subpath_sanitized(std::string_view path, bool os_specific = true)
     {
         return sanitize_subpath(path, os_specific) == path;
     }
-
-    static constexpr std::string_view PartialFileSuffix = ".part";
 
 private:
     struct file_t {

--- a/libtransmission/torrent-metainfo.cc
+++ b/libtransmission/torrent-metainfo.cc
@@ -65,7 +65,7 @@ struct MetainfoHandler final : public tr::benc::BasicHandler<MaxBencDepth> {
     std::string encoding_ = "UTF-8";
     std::string_view info_dict_begin_;
     tr_tracker_tier_t tier_ = 0;
-    tr_pathbuf file_subpath_;
+    std::string file_subpath_;
     int64_t file_length_ = 0;
 
     enum class State : uint8_t {
@@ -402,9 +402,7 @@ private:
             return false;
         }
 
-        auto root = tr_pathbuf{};
-        tr_torrent_files::sanitize_subpath(tm_.name_, root);
-        if (!std::empty(root)) {
+        if (auto const root = tr_torrent_files::sanitize_subpath(tm_.name_); !std::empty(root)) {
             tm_.files_.insert_subpath_prefix(root);
         }
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -771,7 +771,7 @@ bool tr_torrent::is_new_torrent_a_seed()
         }
 
         // it's not a new seed if a file is partial
-        if (tr_strv_ends_with(found->filename(), tr_torrent_files::PartialFileSuffix)) {
+        if (found->is_partial) {
             return false;
         }
 
@@ -1514,7 +1514,7 @@ tr_torrent_metainfo const& tr_torrent::VerifyMediator::metainfo() const
 std::optional<std::string> tr_torrent::VerifyMediator::find_file(tr_file_index_t const file_index) const
 {
     if (auto const found = tor_->find_file(file_index); found) {
-        return std::string{ found->filename().sv() };
+        return found->filename();
     }
 
     return {};
@@ -1529,10 +1529,11 @@ void tr_torrent::update_file_path(tr_file_index_t file, std::optional<bool> has_
 
     auto const has = has_file ? *has_file : this->has_file(file);
     auto const needs_suffix = session->isIncompleteFileNamingEnabled() && !has;
-    auto const oldpath = found->filename();
-    auto const newpath = needs_suffix ?
-        tr_pathbuf{ found->base(), '/', file_subpath(file), tr_torrent_files::PartialFileSuffix } :
-        tr_pathbuf{ found->base(), '/', file_subpath(file) };
+    auto const oldpath = found->filename<tr_pathbuf>();
+    auto const newpath = tr_pathbuf{ found->base,
+                                     '/',
+                                     found->subpath,
+                                     needs_suffix ? tr_torrent_files::PartialFileSuffix : ""sv };
 
     if (tr_sys_path_is_same(oldpath, newpath)) {
         return;
@@ -2099,8 +2100,11 @@ std::string tr_torrentFindFile(tr_torrent const* tor, tr_file_index_t file_num)
 {
     tr_return_val_if_fail(tr_isTorrent(tor), {});
 
-    auto const found = tor->find_file(file_num);
-    return std::string{ found ? found->filename().sv() : ""sv };
+    if (auto const found = tor->find_file(file_num); found) {
+        return found->filename();
+    }
+
+    return {};
 }
 
 void tr_torrent::set_download_dir(std::string_view path, bool is_new_torrent)
@@ -2137,7 +2141,7 @@ void tr_torrent::refresh_current_dir()
         dir = incomplete_dir();
     } else {
         auto const found = find_file(0);
-        dir = found ? tr::shared_string{ found->base() } : incomplete_dir();
+        dir = found ? tr::shared_string{ found->base } : incomplete_dir();
     }
 
     TR_ASSERT(!std::empty(dir));

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -89,10 +89,10 @@ protected:
     static bool testFileExistsAndConsistsOfThisString(tr_torrent const* tor, tr_file_index_t file_index, std::string_view str)
     {
         if (auto const found = tor->find_file(file_index); found) {
-            EXPECT_TRUE(tr_sys_path_exists(found->filename()));
+            auto const filename = found->filename();
+            EXPECT_TRUE(tr_sys_path_exists(filename));
             auto contents = std::vector<char>{};
-            return tr_file_read(found->filename(), contents) &&
-                std::string_view{ std::data(contents), std::size(contents) } == str;
+            return tr_file_read(filename, contents) && std::string_view{ std::data(contents), std::size(contents) } == str;
         }
 
         return false;

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -18,6 +18,7 @@
 #include <libtransmission/quark.h>
 #include <libtransmission/transmission.h>
 #include <libtransmission/rpcimpl.h>
+#include <libtransmission/tr-strbuf.h>
 #include <libtransmission/variant.h>
 
 #include "test-fixtures.h"

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -31,6 +31,7 @@
 #include <libtransmission/quark.h>
 #include <libtransmission/torrent-ctor.h>
 #include <libtransmission/torrent.h>
+#include <libtransmission/tr-strbuf.h>
 #include <libtransmission/variant.h>
 
 using namespace std::literals;

--- a/tests/libtransmission/torrent-files-test.cc
+++ b/tests/libtransmission/torrent-files-test.cc
@@ -94,6 +94,9 @@ TEST_F(TorrentFilesTest, find)
     EXPECT_TRUE(found.has_value());
     assert(found.has_value());
     EXPECT_EQ(filename, found->filename());
+    EXPECT_EQ(search_path_1, found->base);
+    EXPECT_EQ("first_dir/hello.txt"sv, found->subpath);
+    EXPECT_FALSE(found->is_partial);
 
     // same search, but with the search paths reversed
     search_path = std::vector<std::string_view>{ search_path_2.sv(), search_path_1.sv() };
@@ -110,6 +113,9 @@ TEST_F(TorrentFilesTest, find)
     EXPECT_TRUE(found.has_value());
     assert(found.has_value());
     EXPECT_EQ(partial_filename, found->filename());
+    EXPECT_EQ(search_path_1, found->base);
+    EXPECT_EQ("first_dir/hello.txt"sv, found->subpath);
+    EXPECT_TRUE(found->is_partial);
 
     // same search, but with the search paths reversed
     search_path = std::vector<std::string_view>{ search_path_2.sv(), search_path_1.sv() };

--- a/tests/libtransmission/torrent-queue-test.cc
+++ b/tests/libtransmission/torrent-queue-test.cc
@@ -14,6 +14,7 @@
 
 #include <libtransmission/torrent-queue.h>
 #include <libtransmission/torrent.h>
+#include <libtransmission/tr-strbuf.h>
 
 #include "test-fixtures.h"
 


### PR DESCRIPTION
## Description

Previously was held by a `tr_pathbuf` which is 4128 bytes, so every find() caller carried a ~4 KB std::optional to hold a path that most callers never use (only needing the size, mtime, or does-it-exist flag).

Notes: Improved libtransmission code to use less CPU.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
