### PR TITLE
fix: balance announces across a tier per BEP 12

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0A6169A80FE5C9A200C66CE6 /* bitfield.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A6169A60FE5C9A200C66CE6 /* bitfield.h */; };
 		0A89346B736DBCF81F3A4850 /* torrent-metainfo.cc in Sources */ = {isa = PBXBuildFile; fileRef = 0A89346B736DBCF81F3A4851 /* torrent-metainfo.cc */; };
 		0A89346B736DBCF81F3A4852 /* torrent-metainfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A89346B736DBCF81F3A4853 /* torrent-metainfo.h */; };
+		4D1A996DF3E6096A0EC5969E /* announcer-common.cc in Sources */ = {isa = PBXBuildFile; fileRef = 10D3CB271270C579F589D5A8 /* announcer-common.cc */; };
 		9F0B1F302E4D1A0100A1B2C3 /* env.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0B1F2A2E4D1A0100A1B2C3 /* env.h */; };
 		9F0B1F312E4D1A0100A1B2C3 /* file-utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0B1F2C2E4D1A0100A1B2C3 /* file-utils.h */; };
 		9F0B1F322E4D1A0100A1B2C3 /* string-utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0B1F2E2E4D1A0100A1B2C3 /* string-utils.h */; };
@@ -767,6 +768,7 @@
 		0A89346B736DBCF81F3A4851 /* torrent-metainfo.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "torrent-metainfo.cc"; sourceTree = "<group>"; };
 		0A89346B736DBCF81F3A4853 /* torrent-metainfo.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "torrent-metainfo.h"; sourceTree = "<group>"; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		10D3CB271270C579F589D5A8 /* announcer-common.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "announcer-common.cc"; sourceTree = "<group>"; };
 		1BB44E07B1B52E28291B4E30 /* file-piece-map.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "file-piece-map.cc"; sourceTree = "<group>"; };
 		1BB44E07B1B52E28291B4E31 /* file-piece-map.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "file-piece-map.h"; sourceTree = "<group>"; };
 		2856E0656A49F2665D69E761 /* benc.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = benc.h; sourceTree = "<group>"; };
@@ -2100,6 +2102,7 @@
 				EDC37BCC2EE9C2AD001E2612 /* api-compat.cc */,
 				66F977825E65AD498C028BB1 /* announce-list.cc */,
 				66F977825E65AD498C028BB3 /* announce-list.h */,
+				10D3CB271270C579F589D5A8 /* announcer-common.cc */,
 				A23F299F132A447400E9A83B /* announcer-common.h */,
 				A23F29A0132A447400E9A83B /* announcer-http.cc */,
 				A2AA9BE0132CAC8D00FA131E /* announcer-udp.cc */,
@@ -3692,6 +3695,7 @@
 				A284214412DA663E00FBDDBB /* tr-udp.cc in Sources */,
 				C17740D5273A002C00E455D2 /* web-utils.cc in Sources */,
 				A2679294130E00A000CB7464 /* tr-utp.cc in Sources */,
+				4D1A996DF3E6096A0EC5969E /* announcer-common.cc in Sources */,
 				A23F29A2132A447400E9A83B /* announcer-http.cc in Sources */,
 				EDBA62002D4180D5001470F8 /* torrent-queue.cc in Sources */,
 				C1FEE5791C3223CC00D62832 /* watchdir-kqueue.cc in Sources */,

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(${TR_NAME}
     PRIVATE
         announce-list.cc
         announce-list.h
+        announcer-common.cc
         announcer-common.h
         announcer-http.cc
         announcer-udp.cc

--- a/libtransmission/announcer-common.cc
+++ b/libtransmission/announcer-common.cc
@@ -1,0 +1,68 @@
+// This file Copyright © Mnemosaic LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosaic LLC.
+// License text can be found in the licenses/ folder.
+
+#include <algorithm> // std::shuffle, std::rotate
+#include <cstddef> // size_t, ptrdiff_t
+#include <iterator> // std::next
+#include <numeric> // std::iota
+#include <optional>
+
+#define LIBTRANSMISSION_ANNOUNCER_MODULE
+
+#include "libtransmission/announcer-common.h"
+#include "libtransmission/crypto-utils.h" // tr_urbg
+
+// --- TRYING ORDER
+
+tr_tracker_trying_order::tr_tracker_trying_order(size_t const tracker_count)
+    : order_(tracker_count)
+{
+    static thread_local auto urbg = tr_urbg<size_t>{};
+    std::iota(std::begin(order_), std::end(order_), size_t{});
+    std::shuffle(std::begin(order_), std::end(order_), urbg);
+}
+
+std::optional<size_t> tr_tracker_trying_order::current() const
+{
+    if (pos_) {
+        return order_[*pos_];
+    }
+
+    return {};
+}
+
+std::optional<size_t> tr_tracker_trying_order::advance()
+{
+    if (std::empty(order_)) {
+        pos_ = std::nullopt;
+    } else if (!pos_) {
+        pos_ = 0U;
+    } else {
+        pos_ = (*pos_ + 1U) % std::size(order_);
+    }
+
+    return current();
+}
+
+void tr_tracker_trying_order::promote_current()
+{
+    if (pos_ && *pos_ != 0U) {
+        auto const iter = std::next(std::begin(order_), static_cast<std::ptrdiff_t>(*pos_));
+        std::rotate(std::begin(order_), iter, std::next(iter));
+        pos_ = 0U;
+    }
+}
+
+void tr_tracker_trying_order::set_current(std::optional<size_t> const index)
+{
+    if (index) {
+        if (auto const iter = std::ranges::find(order_, *index); iter != std::end(order_)) {
+            pos_ = static_cast<size_t>(iter - std::begin(order_));
+            return;
+        }
+    }
+
+    pos_ = std::nullopt;
+}

--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -12,6 +12,7 @@
 #include <array>
 #include <chrono>
 #include <compare>
+#include <cstddef> // size_t
 #include <cstdint> // uint64_t
 #include <ctime>
 #include <optional>
@@ -156,6 +157,38 @@ struct tr_announce_response {
         // Non-empty error message most likely means we reached the tracker
         return static_cast<int>(std::empty(rhs.errmsg)) <=> static_cast<int>(std::empty(lhs.errmsg));
     }
+};
+
+// --- TRYING ORDER
+
+/**
+ * The order in which a tier's trackers are tried, per BEP 12:
+ * shuffled once when built, then stepped through in order, and a
+ * tracker that responds to an announce moves to the front.
+ * Holds indices into the tier's tracker list so that list can keep
+ * its display order. https://www.bittorrent.org/beps/bep_0012.html
+ */
+class tr_tracker_trying_order
+{
+public:
+    explicit tr_tracker_trying_order(size_t tracker_count);
+
+    // index of the tracker now being tried, or nullopt if none is
+    [[nodiscard]] std::optional<size_t> current() const;
+
+    // step to the next tracker in the trying order, wrapping around
+    std::optional<size_t> advance();
+
+    // move the current tracker to the front of the trying order
+    void promote_current();
+
+    // make `index` the tracker now being tried, or nullopt for none;
+    // the trying order itself is unchanged
+    void set_current(std::optional<size_t> index);
+
+private:
+    std::vector<size_t> order_;
+    std::optional<size_t> pos_;
 };
 
 // --- SCRAPE

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -341,7 +341,8 @@ private:
 /** @brief A group of trackers in a single tier, as per the multitracker spec */
 struct tr_tier {
     tr_tier(tr_announcer_impl* announcer, tr_torrent* tor_in, std::vector<tr_announce_list::tracker_info const*> const& infos)
-        : tor{ tor_in }
+        : trying_order_{ std::size(infos) }
+        , tor{ tor_in }
     {
         trackers.reserve(std::size(infos));
         for (auto const* info : infos) {
@@ -353,22 +354,17 @@ struct tr_tier {
 
     [[nodiscard]] tr_tracker* currentTracker()
     {
-        if (!current_tracker_index_) {
-            return nullptr;
-        }
-
-        TR_ASSERT(*current_tracker_index_ < std::size(trackers));
-        return &trackers[*current_tracker_index_];
+        return const_cast<tr_tracker*>(std::as_const(*this).currentTracker());
     }
 
     [[nodiscard]] tr_tracker const* currentTracker() const
     {
-        if (!current_tracker_index_) {
-            return nullptr;
+        if (auto const idx = trying_order_.current()) {
+            TR_ASSERT(*idx < std::size(trackers));
+            return &trackers[*idx];
         }
 
-        TR_ASSERT(*current_tracker_index_ < std::size(trackers));
-        return &trackers[*current_tracker_index_];
+        return {};
     }
 
     [[nodiscard]] constexpr bool needsToAnnounce(time_t now) const
@@ -392,14 +388,8 @@ struct tr_tier {
 
     tr_tracker* useNextTracker()
     {
-        // move our index to the next tracker in the tier
-        if (std::empty(trackers)) {
-            current_tracker_index_ = std::nullopt;
-        } else if (!current_tracker_index_) {
-            current_tracker_index_ = 0;
-        } else {
-            current_tracker_index_ = (*current_tracker_index_ + 1) % std::size(trackers);
-        }
+        // move to the next tracker in the tier's trying order
+        trying_order_.advance();
 
         // reset some of the tier's fields
         scrapeIntervalSec = DefaultScrapeIntervalSec;
@@ -463,7 +453,7 @@ struct tr_tier {
 
     std::vector<tr_tracker> trackers;
 
-    std::optional<size_t> current_tracker_index_;
+    tr_tracker_trying_order trying_order_;
 
     tr_torrent* const tor;
 
@@ -1001,6 +991,7 @@ void tr_announcer_impl::onAnnounceDone(
 
         auto* const tracker = tier->currentTracker();
         if (tracker != nullptr) {
+            tier->trying_order_.promote_current();
             tracker->consecutive_failures = 0;
 
             if (tracker->set_seeder_count(response.seeders)) {
@@ -1635,8 +1626,8 @@ void tr_announcer_impl::resetTorrent(tr_torrent* tor)
                     new_tier.announce_event_priority = old_tier->announce_event_priority;
 
                     auto const* const old_current = old_tier->currentTracker();
-                    new_tier.current_tracker_index_ = old_current == nullptr ? std::nullopt :
-                                                                               new_tier.indexOf(old_current->announce_url);
+                    new_tier.trying_order_.set_current(
+                        old_current == nullptr ? std::nullopt : new_tier.indexOf(old_current->announce_url));
                 }
             }
         }
@@ -1648,7 +1639,7 @@ void tr_announcer_impl::resetTorrent(tr_torrent* tor)
     auto const is_running = tor->is_running();
     auto const now = tr_time();
     for (auto& tier : newer->tiers) {
-        if (!tier.current_tracker_index_) {
+        if (tier.currentTracker() == nullptr) {
             tier.useNextTracker();
 
             if (is_running) {

--- a/tests/libtransmission/announcer-test.cc
+++ b/tests/libtransmission/announcer-test.cc
@@ -6,9 +6,11 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
-#include <cstddef> // std::byte
+#include <cstddef> // std::byte, size_t
 #include <optional>
+#include <set>
 #include <string_view>
+#include <vector>
 
 #define LIBTRANSMISSION_ANNOUNCER_MODULE
 
@@ -304,4 +306,109 @@ TEST_F(AnnouncerTest, parseHttpScrapeResponseMultiWithMissing)
     EXPECT_EQ(7, response.rows[2].seeders);
     EXPECT_EQ(8, response.rows[2].leechers);
     EXPECT_EQ(9, response.rows[2].downloads);
+}
+
+// --- TRYING ORDER
+
+namespace
+{
+// advancing a fresh tr_tracker_trying_order n_trackers times walks the
+// full trying order once; collect it for asserting on later laps
+[[nodiscard]] std::vector<size_t> advanceFullLap(tr_tracker_trying_order& order, size_t n_trackers)
+{
+    auto lap = std::vector<size_t>{};
+    lap.reserve(n_trackers);
+
+    for (size_t i = 0; i < n_trackers; ++i) {
+        auto const current = order.advance();
+        assert(current.has_value());
+        lap.push_back(*current);
+    }
+
+    return lap;
+}
+} // namespace
+
+TEST_F(AnnouncerTest, tryingOrderVisitsEveryTrackerOncePerLap)
+{
+    static auto constexpr TrackerCount = size_t{ 5 };
+    auto order = tr_tracker_trying_order{ TrackerCount };
+
+    // no tracker is current until the first advance()
+    EXPECT_EQ(std::nullopt, order.current());
+
+    // one lap visits each tracker exactly once...
+    auto const lap = advanceFullLap(order, TrackerCount);
+    EXPECT_EQ(TrackerCount, std::size(std::set<size_t>{ std::begin(lap), std::end(lap) }));
+    for (auto const idx : lap) {
+        EXPECT_LT(idx, TrackerCount);
+    }
+
+    // ...and the next lap repeats the same order
+    EXPECT_EQ(lap, advanceFullLap(order, TrackerCount));
+}
+
+TEST_F(AnnouncerTest, tryingOrderIsShuffled)
+{
+    static auto constexpr TrackerCount = size_t{ 6 };
+
+    auto distinct_orders = std::set<std::vector<size_t>>{};
+    for (auto i = 0U; i < 32U; ++i) {
+        auto order = tr_tracker_trying_order{ TrackerCount };
+        distinct_orders.insert(advanceFullLap(order, TrackerCount));
+    }
+
+    // a fixed start-at-the-first-tracker order would collapse
+    // all 32 orders into a single entry
+    EXPECT_GT(std::size(distinct_orders), 1U);
+}
+
+TEST_F(AnnouncerTest, tryingOrderPromoteMovesCurrentToFront)
+{
+    static auto constexpr TrackerCount = size_t{ 5 };
+    auto order = tr_tracker_trying_order{ TrackerCount };
+    auto const lap = advanceFullLap(order, TrackerCount);
+
+    // walk into the second lap, to the second tracker in the order
+    order.advance();
+    order.advance();
+    EXPECT_EQ(lap[1], order.current());
+
+    // promoting keeps it current...
+    order.promote_current();
+    EXPECT_EQ(lap[1], order.current());
+
+    // ...and the rest of the order now follows it
+    auto const expected = std::vector<size_t>{ lap[0], lap[2], lap[3], lap[4], lap[1] };
+    EXPECT_EQ(expected, advanceFullLap(order, TrackerCount));
+}
+
+TEST_F(AnnouncerTest, tryingOrderSetCurrent)
+{
+    static auto constexpr TrackerCount = size_t{ 4 };
+    auto order = tr_tracker_trying_order{ TrackerCount };
+    auto const lap = advanceFullLap(order, TrackerCount);
+
+    // selecting a tracker by index leaves the trying order unchanged
+    order.set_current(lap[2]);
+    EXPECT_EQ(lap[2], order.current());
+    EXPECT_EQ(lap[3], order.advance());
+
+    // nullopt unsets the current tracker, and advancing
+    // from there restarts at the front of the order
+    order.set_current(std::nullopt);
+    EXPECT_EQ(std::nullopt, order.current());
+    EXPECT_EQ(lap[0], order.advance());
+}
+
+TEST_F(AnnouncerTest, tryingOrderEmpty)
+{
+    auto order = tr_tracker_trying_order{ 0U };
+
+    EXPECT_EQ(std::nullopt, order.current());
+    EXPECT_EQ(std::nullopt, order.advance());
+
+    order.promote_current();
+    order.set_current(std::nullopt);
+    EXPECT_EQ(std::nullopt, order.current());
 }


### PR DESCRIPTION
## Description

Follow BEP 12 guidelines for randomizing tracker order in a tier. Previously, we were using the trackers in the announce_list order.

Notes: Announces are now spread evenly across trackers in the same tier, following [BEP 12](https://www.bittorrent.org/beps/bep_0012.html) guidelines.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
