### PR TITLE
fix: copy local utf8 string in JsonWriter

### DIFF
--- a/libtransmission/variant-json.cc
+++ b/libtransmission/variant-json.cc
@@ -301,7 +301,7 @@ struct JsonWriter {
     void WriteString(StringWriteFunc const func, std::string_view sv) const
     {
         auto const utf8 = tr_strv_to_utf8_string(sv);
-        (writer.*func)(std::data(utf8), std::size(utf8), false);
+        (writer.*func)(std::data(utf8), std::size(utf8), true);
     }
 
     void operator()(std::monostate /*unused*/) const


### PR DESCRIPTION
## Description

Fixup #158. Since the utf8 string is local, in principle, we need to tell RapidJSON to copy it.

Not that it matters for the writers we are using now.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
