### PR TITLE
refactor: drop obsolete uClibc < 0.9.28 checks

### DIFF
--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -256,8 +256,6 @@ tr_target_compile_definitions_for_functions(${TR_NAME}
         ntohll
         posix_fadvise
         posix_fallocate
-        pread
-        pwrite
         sendfile64)
 
 target_include_directories(${TR_NAME}

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -69,15 +69,6 @@
 #define PATH_MAX 4096
 #endif
 
-#ifdef __APPLE__
-#ifndef HAVE_PREAD
-#define HAVE_PREAD
-#endif
-#ifndef HAVE_PWRITE
-#define HAVE_PWRITE
-#endif
-#endif
-
 using namespace std::literals;
 
 namespace
@@ -514,16 +505,7 @@ bool tr_sys_file_read_at(
 
     bool ret = false;
 
-#ifdef HAVE_PREAD
-
     auto const my_bytes_read = pread(handle, buffer, size, static_cast<off_t>(offset));
-
-#else
-
-    ssize_t const my_bytes_read = lseek(handle, static_cast<off_t>(offset), SEEK_SET) == -1 ? -1 : read(handle, buffer, size);
-
-#endif
-
     static_assert(sizeof(*bytes_read) >= sizeof(my_bytes_read));
 
     if (my_bytes_read > 0) {
@@ -577,16 +559,7 @@ bool tr_sys_file_write_at(
 
     bool ret = false;
 
-#ifdef HAVE_PWRITE
-
     auto const my_bytes_written = pwrite(handle, buffer, size, static_cast<off_t>(offset));
-
-#else
-
-    ssize_t const my_bytes_written = lseek(handle, static_cast<off_t>(offset), SEEK_SET) == -1 ? -1 :
-                                                                                                 write(handle, buffer, size);
-
-#endif
 
     static_assert(sizeof(*bytes_written) >= sizeof(my_bytes_written));
 

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -50,7 +50,6 @@
 #include "libtransmission/error.h"
 #include "libtransmission/file.h"
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/macros.h" // TR_UCLIBC_CHECK_VERSION
 #include "libtransmission/tr-strbuf.h"
 
 #ifndef O_LARGEFILE
@@ -68,12 +67,6 @@
 
 #ifndef PATH_MAX
 #define PATH_MAX 4096
-#endif
-
-// don't use pread/pwrite on old versions of uClibc because they're buggy.
-#if defined(__UCLIBC__) && !TR_UCLIBC_CHECK_VERSION(0, 9, 28)
-#undef HAVE_PREAD
-#undef HAVE_PWRITE
 #endif
 
 #ifdef __APPLE__

--- a/libtransmission/macros.h
+++ b/libtransmission/macros.h
@@ -31,14 +31,6 @@
 #define TR_IF_WIN32(ThenValue, ElseValue) ElseValue
 #endif
 
-#ifdef __UCLIBC__
-#define TR_UCLIBC_CHECK_VERSION(major, minor, micro) \
-    (__UCLIBC_MAJOR__ > (major) || (__UCLIBC_MAJOR__ == (major) && __UCLIBC_MINOR__ > (minor)) || \
-     (__UCLIBC_MAJOR__ == (major) && __UCLIBC_MINOR__ == (minor) && __UCLIBC_SUBLEVEL__ >= (micro)))
-#else
-#define TR_UCLIBC_CHECK_VERSION(major, minor, micro) 0
-#endif
-
 // ---
 
 #define TR_PROJ_DOMAIN_TLD "org"


### PR DESCRIPTION
## Description

uClibc 0.9.28 came out 21 years ago and was superseded by uClibc-ng. We can drop this build check.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
