### PR TITLE
chore: call `mkdtemp()` unconditionally

### DIFF
--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -253,7 +253,6 @@ tr_target_compile_definitions_for_functions(${TR_NAME}
         fallocate64
         flock
         htonll
-        mkdtemp
         ntohll
         posix_fadvise
         posix_fallocate

--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -84,9 +84,6 @@
 #ifndef HAVE_PWRITE
 #define HAVE_PWRITE
 #endif
-#ifndef HAVE_MKDTEMP
-#define HAVE_MKDTEMP
-#endif
 #endif
 
 using namespace std::literals;
@@ -822,15 +819,7 @@ bool tr_sys_dir_create_temp(char* path_template, tr_error* error)
 {
     TR_ASSERT(path_template != nullptr);
 
-#ifdef HAVE_MKDTEMP
-
     bool const ret = mkdtemp(path_template) != nullptr;
-
-#else
-
-    bool const ret = mktemp(path_template) != nullptr && mkdir(path_template, 0700) != -1;
-
-#endif
 
     if (error != nullptr && !ret) {
         error->set_from_errno(errno);


### PR DESCRIPTION
## Description

`mkdtemp()` in `file-posix.cc` is POSIX.1-2008 and exists on all supported targets.

Windows uses `file-win32.cc` instead.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
