### PR TITLE
refactor: use `std::filesystem` for `tr_sys_dir_get_files()`

### DIFF
--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -18,7 +18,6 @@
 #include <string>
 #include <vector>
 
-#include <dirent.h>
 #include <fcntl.h> /* O_LARGEFILE, posix_fadvise(), [posix_]fallocate(), fcntl() */
 #include <sys/stat.h>
 #include <unistd.h> /* lseek(), write(), ftruncate(), pread(), pwrite(), pathconf(), etc */
@@ -826,49 +825,4 @@ bool tr_sys_dir_create_temp(char* path_template, tr_error* error)
     }
 
     return ret;
-}
-
-tr_sys_dir_t tr_sys_dir_open(std::string_view path, tr_error* error)
-{
-    if (auto* const ret = opendir(tr_pathbuf{ path }.c_str()); ret != nullptr) {
-        return ret;
-    }
-
-    if (error != nullptr) {
-        error->set_from_errno(errno);
-    }
-
-    return TR_BAD_SYS_DIR;
-}
-
-char const* tr_sys_dir_read_name(tr_sys_dir_t handle, tr_error* error)
-{
-    TR_ASSERT(handle != TR_BAD_SYS_DIR);
-
-    errno = 0;
-
-    if (auto const* const entry = readdir(static_cast<DIR*>(handle)); entry != nullptr) {
-        return entry->d_name;
-    }
-
-    if (error != nullptr && errno != 0) {
-        error->set_from_errno(errno);
-    }
-
-    return {};
-}
-
-bool tr_sys_dir_close(tr_sys_dir_t handle, tr_error* error)
-{
-    TR_ASSERT(handle != TR_BAD_SYS_DIR);
-
-    if (auto const ret = closedir(static_cast<DIR*>(handle)) != -1; ret) {
-        return ret;
-    }
-
-    if (error != nullptr) {
-        error->set_from_errno(errno);
-    }
-
-    return {};
 }

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -24,13 +24,6 @@
 
 using namespace std::literals;
 
-struct tr_sys_dir_win32 {
-    std::wstring pattern;
-    HANDLE find_handle = INVALID_HANDLE_VALUE;
-    WIN32_FIND_DATAW find_data = {};
-    std::string utf8_name;
-};
-
 namespace
 {
 auto constexpr NativeLocalPathPrefix = L"\\\\?\\"sv;
@@ -41,13 +34,6 @@ void set_system_error(tr_error* error, DWORD code)
     if (error != nullptr) {
         auto const message = tr_win32_format_message(code);
         error->set(code, !std::empty(message) ? message : fmt::format("Unknown error: {:#08x}", code));
-    }
-}
-
-void set_system_error_if_file_found(tr_error* error, DWORD code)
-{
-    if (code != ERROR_FILE_NOT_FOUND && code != ERROR_PATH_NOT_FOUND && code != ERROR_NO_MORE_FILES) {
-        set_system_error(error, code);
     }
 }
 
@@ -733,74 +719,6 @@ bool tr_sys_dir_create_temp(char* path_template, tr_error* error)
         path_template,
         [&ret](char const* path, tr_error* error) { ret = create_dir(path, 0, 0, false, error); },
         error);
-
-    return ret;
-}
-
-tr_sys_dir_t tr_sys_dir_open(std::string_view path, tr_error* error)
-{
-    TR_ASSERT(!std::empty(path));
-
-    if (auto const info = tr_sys_path_get_info(path, 0); !info || !info->isFolder()) {
-        set_system_error(error, ERROR_DIRECTORY);
-        return TR_BAD_SYS_DIR;
-    }
-
-    auto const pattern = path_to_native_path(path);
-    if (std::empty(pattern)) {
-        set_system_error(error, GetLastError());
-        return TR_BAD_SYS_DIR;
-    }
-
-    auto* const ret = new tr_sys_dir_win32{};
-    ret->pattern = pattern;
-    ret->pattern.append(L"\\*");
-    return ret;
-}
-
-char const* tr_sys_dir_read_name(tr_sys_dir_t handle, tr_error* error)
-{
-    TR_ASSERT(handle != TR_BAD_SYS_DIR);
-
-    DWORD error_code = ERROR_SUCCESS;
-
-    if (handle->find_handle == INVALID_HANDLE_VALUE) {
-        handle->find_handle = FindFirstFileW(handle->pattern.c_str(), &handle->find_data);
-
-        if (handle->find_handle == INVALID_HANDLE_VALUE) {
-            error_code = GetLastError();
-        }
-    } else {
-        if (!to_bool(FindNextFileW(handle->find_handle, &handle->find_data))) {
-            error_code = GetLastError();
-        }
-    }
-
-    if (error_code != ERROR_SUCCESS) {
-        set_system_error_if_file_found(error, error_code);
-        return nullptr;
-    }
-
-    if (auto const utf8 = tr_win32_native_to_utf8(handle->find_data.cFileName); !std::empty(utf8)) {
-        handle->utf8_name = utf8;
-        return handle->utf8_name.c_str();
-    }
-
-    set_system_error(error, GetLastError());
-    return nullptr;
-}
-
-bool tr_sys_dir_close(tr_sys_dir_t handle, tr_error* error)
-{
-    TR_ASSERT(handle != TR_BAD_SYS_DIR);
-
-    bool const ret = to_bool(FindClose(handle->find_handle));
-
-    if (!ret) {
-        set_system_error(error, GetLastError());
-    }
-
-    delete handle;
 
     return ret;
 }

--- a/libtransmission/file.cc
+++ b/libtransmission/file.cc
@@ -41,6 +41,13 @@ template<typename InputIt>
     return tr_u8path(path.begin(), path.end());
 }
 
+// Inverse of tr_u8path(): a UTF-8 std::string holding `path`'s native representation.
+[[nodiscard]] std::string tr_u8string(std::filesystem::path const& path)
+{
+    auto const u8_path = path.u8string();
+    return { std::begin(u8_path), std::end(u8_path) };
+}
+
 } // namespace
 
 std::string tr_sys_path_resolve(std::string_view path, tr_error* error)
@@ -53,8 +60,7 @@ std::string tr_sys_path_resolve(std::string_view path, tr_error* error)
         return {};
     }
 
-    auto const u8_path = canonical_path.u8string();
-    return { std::begin(u8_path), std::end(u8_path) };
+    return tr_u8string(canonical_path);
 }
 
 bool tr_sys_path_is_relative(std::string_view path)
@@ -239,28 +245,33 @@ std::vector<std::string> tr_sys_dir_get_files(
     std::function<bool(std::string_view)> const& test,
     tr_error* error)
 {
+    // Callers point this at folders that may legitimately not exist yet,
+    // e.g. a config folder before its first write, and read that as "no files".
     if (auto const info = tr_sys_path_get_info(folder); !info || !info->isFolder()) {
         return {};
     }
 
-    auto const odir = tr_sys_dir_open(folder, error);
-    if (odir == TR_BAD_SYS_DIR) {
+    auto ec = std::error_code{};
+    auto iter = std::filesystem::directory_iterator{ tr_u8path(folder), ec };
+    if (ec) {
+        maybe_set_error(error, ec);
         return {};
     }
 
     auto filenames = std::vector<std::string>{};
-    for (;;) {
-        char const* const name = tr_sys_dir_read_name(odir, error);
-
-        if (name == nullptr) {
-            tr_sys_dir_close(odir, error);
-            return filenames;
+    for (auto const end = std::filesystem::directory_iterator{}; iter != end;) {
+        if (auto name = tr_u8string(iter->path().filename()); test(name)) {
+            filenames.emplace_back(std::move(name));
         }
 
-        if (test(name)) {
-            filenames.emplace_back(name);
+        // operator++() reports failure by throwing; this API reports it in `error`
+        if (iter.increment(ec); ec) {
+            maybe_set_error(error, ec);
+            break;
         }
     }
+
+    return filenames;
 }
 
 std::optional<tr_sys_path_capacity> tr_sys_path_get_capacity(std::string_view const path, tr_error* error)

--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -30,20 +30,13 @@ struct tr_error;
 using tr_sys_file_t = int;
 /** @brief Platform-specific invalid file descriptor constant. */
 #define TR_BAD_SYS_FILE (-1)
-/** @brief Platform-specific directory descriptor type. */
-using tr_sys_dir_t = void*;
 
 #else
 
 using tr_sys_file_t = HANDLE;
 #define TR_BAD_SYS_FILE INVALID_HANDLE_VALUE
-struct tr_sys_dir_win32;
-using tr_sys_dir_t = tr_sys_dir_win32*;
 
 #endif
-
-/** @brief Platform-specific invalid directory descriptor constant. */
-#define TR_BAD_SYS_DIR ((tr_sys_dir_t) nullptr)
 
 enum tr_sys_file_open_flags_t : uint8_t {
     TR_SYS_FILE_READ = (1 << 0),
@@ -93,9 +86,9 @@ struct tr_sys_path_capacity {
  *
  * Following functions accept paths in UTF-8 encoding and convert them to native
  * encoding internally if needed.
- * Descriptors returned (@ref tr_sys_file_t and @ref tr_sys_dir_t) may have
- * different type depending on platform and should generally not be passed to
- * native functions, but to wrapper functions instead.
+ * Descriptors returned (@ref tr_sys_file_t) may have different type depending
+ * on platform and should generally not be passed to native functions, but to
+ * wrapper functions instead.
  *
  * @{
  */
@@ -455,49 +448,30 @@ bool tr_sys_dir_create(std::string_view path, int flags, int permissions, tr_err
  */
 bool tr_sys_dir_create_temp(char* path_template, tr_error* error = nullptr);
 
-/**
- * @brief Portability wrapper for `opendir()`.
- *
- * @param[in]  path  Path to directory.
- * @param[out] error Pointer to error object. Optional, pass `nullptr` if you are
- *                   not interested in error details.
- *
- * @return Opened directory descriptor on success, `TR_BAD_SYS_DIR` otherwise
- *         (with `error` set accordingly).
- */
-tr_sys_dir_t tr_sys_dir_open(std::string_view path, tr_error* error = nullptr);
-
-/**
- * @brief Portability wrapper for `readdir()`.
- *
- * @param[in]  handle Valid directory descriptor.
- * @param[out] error  Pointer to error object. Optional, pass `nullptr` if you
- *                    are not interested in error details.
- *
- * @return Pointer to next directory entry name (stored internally, DO NOT free
- *         it) on success, `nullptr` otherwise (with `error` set accordingly).
- *         Note that `nullptr` will also be returned in case of end of directory.
- *         If you need to distinguish the two, check if `error` is `nullptr`
- *         afterwards.
- */
-char const* tr_sys_dir_read_name(tr_sys_dir_t handle, tr_error* error = nullptr);
-
-/**
- * @brief Portability wrapper for `closedir()`.
- *
- * @param[in]  handle Valid directory descriptor.
- * @param[out] error  Pointer to error object. Optional, pass `nullptr` if you
- *                    are not interested in error details.
- *
- * @return `True` on success, `false` otherwise (with `error` set accordingly).
- */
-bool tr_sys_dir_close(tr_sys_dir_t handle, tr_error* error = nullptr);
-
 [[nodiscard]] constexpr bool tr_basename_is_not_dotfile(std::string_view sv)
 {
     return std::empty(sv) || sv.front() != '.';
 }
 
+[[nodiscard]] constexpr bool tr_basename_accept_all(std::string_view /*sv*/) noexcept
+{
+    return true;
+}
+
+/**
+ * @brief List the entries of a directory.
+ *
+ * @param[in]  folder Path to directory.
+ * @param[in]  test   Predicate deciding which entry names to keep.
+ * @param[out] error  Pointer to error object. Optional, pass `nullptr` if you
+ *                    are not interested in error details.
+ *
+ * @return Names of the matching entries -- base names, not paths -- in
+ *         unspecified order. The `.` and `..` entries are never included.
+ *         A `folder` that is not a directory yields an empty result and leaves
+ *         `error` unset; callers read that as "no files". Any other failure
+ *         sets `error` and returns the names read before it, if any.
+ */
 [[nodiscard]] std::vector<std::string> tr_sys_dir_get_files(
     std::string_view folder,
     std::function<bool(std::string_view name)> const& test = tr_basename_is_not_dotfile,

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -45,40 +45,14 @@ using file_func_t = std::function<void(std::string_view filename)>;
 
 [[nodiscard]] bool is_empty_folder(std::string_view const path)
 {
-    if (!is_folder(path)) {
-        return false;
-    }
-
-    if (auto const odir = tr_sys_dir_open(path); odir != TR_BAD_SYS_DIR) {
-        char const* name_cstr = nullptr;
-        while ((name_cstr = tr_sys_dir_read_name(odir)) != nullptr) {
-            auto const name = std::string_view{ name_cstr };
-            if (name != "." && name != "..") {
-                tr_sys_dir_close(odir);
-                return false;
-            }
-        }
-        tr_sys_dir_close(odir);
-    }
-
-    return true;
+    return is_folder(path) && std::empty(tr_sys_dir_get_files(path, tr_basename_accept_all));
 }
 
 void depth_first_walk(std::string_view const path, file_func_t const& func, std::optional<int> max_depth = {})
 {
     if (is_folder(path) && (!max_depth || *max_depth > 0)) {
-        if (auto const odir = tr_sys_dir_open(path); odir != TR_BAD_SYS_DIR) {
-            char const* name_cstr = nullptr;
-            while ((name_cstr = tr_sys_dir_read_name(odir)) != nullptr) {
-                auto const name = std::string_view{ name_cstr };
-                if (name == "." || name == "..") {
-                    continue;
-                }
-
-                depth_first_walk(tr_pathbuf{ path, '/', name }, func, max_depth ? *max_depth - 1 : max_depth);
-            }
-
-            tr_sys_dir_close(odir);
+        for (auto const& name : tr_sys_dir_get_files(path, tr_basename_accept_all)) {
+            depth_first_walk(tr_pathbuf{ path, '/', name }, func, max_depth ? *max_depth - 1 : max_depth);
         }
     }
 

--- a/tests/libtransmission-app/test-fixtures.h
+++ b/tests/libtransmission-app/test-fixtures.h
@@ -74,13 +74,8 @@ private:
     static void rimraf(std::string_view const path)
     {
         if (auto const info = tr_sys_path_get_info(path); info && info->isFolder()) {
-            if (auto const dir = tr_sys_dir_open(path); dir != TR_BAD_SYS_DIR) {
-                for (char const* name = nullptr; (name = tr_sys_dir_read_name(dir)) != nullptr;) {
-                    if (auto const name_sv = std::string_view{ name }; name_sv != "." && name_sv != "..") {
-                        rimraf(fmt::format("{:s}/{:s}", path, name));
-                    }
-                }
-                tr_sys_dir_close(dir);
+            for (auto const& name : tr_sys_dir_get_files(path, tr_basename_accept_all)) {
+                rimraf(fmt::format("{:s}/{:s}", path, name));
             }
         }
 

--- a/tests/libtransmission/file-test.cc
+++ b/tests/libtransmission/file-test.cc
@@ -159,40 +159,15 @@ protected:
         }
     }
 
-    static void testDirReadImpl(tr_pathbuf const& path, bool* have1, bool* have2)
+    // tr_sys_dir_get_files() in unspecified order, as a set, expecting no error
+    [[nodiscard]] static std::set<std::string> getFiles(
+        std::string_view path,
+        bool (*test)(std::string_view) = tr_basename_accept_all)
     {
-        *have1 = *have2 = false;
-
-        auto err = tr_error{};
-        auto dd = tr_sys_dir_open(path, &err);
-        EXPECT_NE(TR_BAD_SYS_DIR, dd);
-        EXPECT_FALSE(err) << err;
-
-        for (;;) {
-            char const* name = tr_sys_dir_read_name(dd, &err);
-            if (name == nullptr) {
-                break;
-            }
-
-            EXPECT_FALSE(err) << err;
-
-            if (strcmp(name, ".") == 0 || strcmp(name, "..") == 0) {
-                continue;
-            }
-
-            if (strcmp(name, "a") == 0) {
-                *have1 = true;
-            } else if (strcmp(name, "b") == 0) {
-                *have2 = true;
-            } else {
-                FAIL();
-            }
-        }
-
-        EXPECT_FALSE(err) << err;
-
-        EXPECT_TRUE(tr_sys_dir_close(dd, &err));
-        EXPECT_FALSE(err) << err;
+        auto error = tr_error{};
+        auto const files = tr_sys_dir_get_files(path, test, &error);
+        EXPECT_FALSE(error) << error;
+        return { std::begin(files), std::end(files) };
     }
 };
 } // namespace
@@ -1274,72 +1249,99 @@ TEST_F(FileTest, dirCreateTemp)
     EXPECT_TRUE(error);
 }
 
-TEST_F(FileTest, dirRead)
+TEST_F(FileTest, dirGetFiles)
 {
     auto const test_dir = createTestDir(currentTestName());
 
     auto const path1 = tr_pathbuf{ test_dir, "/a"sv };
     auto const path2 = tr_pathbuf{ test_dir, "/b"sv };
+    auto const path3 = tr_pathbuf{ test_dir, "/c"sv };
 
-    auto have1 = bool{};
-    auto have2 = bool{};
-    testDirReadImpl(test_dir, &have1, &have2);
-    EXPECT_FALSE(have1);
-    EXPECT_FALSE(have2);
+    // an empty folder lists nothing -- not even the `.` and `..` entries
+    EXPECT_EQ(std::set<std::string>{}, getFiles(test_dir));
 
     createFileWithContents(path1, "test");
-    testDirReadImpl(test_dir, &have1, &have2);
-    EXPECT_TRUE(have1);
-    EXPECT_FALSE(have2);
+    EXPECT_EQ(std::set<std::string>({ "a" }), getFiles(test_dir));
 
     createFileWithContents(path2, "test");
-    testDirReadImpl(test_dir, &have1, &have2);
-    EXPECT_TRUE(have1);
-    EXPECT_TRUE(have2);
+    EXPECT_EQ(std::set<std::string>({ "a", "b" }), getFiles(test_dir));
+
+    // subfolders are listed, as base names like everything else
+    tr_sys_dir_create(path3, 0, 0700);
+    createFileWithContents(tr_pathbuf{ path3, "/d"sv }, "test");
+    EXPECT_EQ(std::set<std::string>({ "a", "b", "c" }), getFiles(test_dir));
 
     tr_sys_path_remove(path1);
-    testDirReadImpl(test_dir, &have1, &have2);
-    EXPECT_FALSE(have1);
-    EXPECT_TRUE(have2);
+    EXPECT_EQ(std::set<std::string>({ "b", "c" }), getFiles(test_dir));
 }
 
-TEST_F(FileTest, dirOpen)
+TEST_F(FileTest, dirGetFilesPredicate)
 {
     auto const test_dir = createTestDir(currentTestName());
 
-    auto const file = tr_pathbuf{ test_dir, "/foo.fxt" };
-    auto constexpr Contents = "hello, world!"sv;
-    createFileWithContents(file, std::data(Contents), std::size(Contents));
+    createFileWithContents(tr_pathbuf{ test_dir, "/visible"sv }, "test");
+    createFileWithContents(tr_pathbuf{ test_dir, "/.hidden"sv }, "test");
+
+    auto error = tr_error{};
+    auto const defaulted = tr_sys_dir_get_files(test_dir, tr_basename_is_not_dotfile, &error);
+    EXPECT_FALSE(error) << error;
+    EXPECT_EQ(std::vector<std::string>({ "visible" }), defaulted);
+
+    EXPECT_EQ(std::set<std::string>({ "visible" }), getFiles(test_dir, tr_basename_is_not_dotfile));
+    EXPECT_EQ(std::set<std::string>({ ".hidden", "visible" }), getFiles(test_dir, tr_basename_accept_all));
+}
+
+TEST_F(FileTest, dirGetFilesUtf8)
+{
+    auto const test_dir = createTestDir(currentTestName());
+
+    // hiragana has no decomposed form, so this name survives the
+    // NFD normalization that some filesystems apply to what they store
+    auto constexpr Name = "こんにちは.txt"sv;
+    createFileWithContents(tr_pathbuf{ test_dir, '/', Name }, "test");
+
+    EXPECT_EQ(std::set<std::string>({ std::string{ Name } }), getFiles(test_dir));
+}
+
+// A folder that isn't there is "no files", not an error: callers watch
+// folders that may not exist yet and would otherwise log on every poll.
+TEST_F(FileTest, dirGetFilesNotAFolder)
+{
+    auto const test_dir = createTestDir(currentTestName());
+
+    auto const file = tr_pathbuf{ test_dir, "/foo.fxt"sv };
+    createFileWithContents(file, "test");
 
     // path does not exist
-    auto err = tr_error{};
-    auto odir = tr_sys_dir_open("/no/such/path", &err);
-    EXPECT_EQ(TR_BAD_SYS_DIR, odir);
-    EXPECT_TRUE(err);
-    err = {};
+    auto error = tr_error{};
+    EXPECT_EQ(std::vector<std::string>{}, tr_sys_dir_get_files("/no/such/path", tr_basename_accept_all, &error));
+    EXPECT_FALSE(error) << error;
 
-    // path is not a directory
-    odir = tr_sys_dir_open(file, &err);
-    EXPECT_EQ(TR_BAD_SYS_DIR, odir);
-    EXPECT_TRUE(err);
-    err = {};
-
-    // path exists and is readable
-    odir = tr_sys_dir_open(test_dir, &err);
-    EXPECT_NE(TR_BAD_SYS_DIR, odir);
-    EXPECT_FALSE(err);
-    auto files = std::set<std::string>{};
-    for (;;) {
-        char const* const filename = tr_sys_dir_read_name(odir, &err);
-        if (filename == nullptr) {
-            break;
-        }
-        files.insert(filename);
-    }
-    EXPECT_EQ(3U, std::size(files));
-    EXPECT_FALSE(err) << err;
-    EXPECT_TRUE(tr_sys_dir_close(odir, &err));
-    EXPECT_FALSE(err) << err;
+    // path is a file
+    EXPECT_EQ(std::vector<std::string>{}, tr_sys_dir_get_files(file, tr_basename_accept_all, &error));
+    EXPECT_FALSE(error) << error;
 }
+
+#ifndef _WIN32
+TEST_F(FileTest, dirGetFilesUnreadable)
+{
+    if (getuid() == 0) {
+        GTEST_SKIP() << "root can read a folder regardless of its permissions";
+    }
+
+    auto const test_dir = createTestDir(currentTestName());
+    auto const unreadable = tr_pathbuf{ test_dir, "/unreadable"sv };
+    tr_sys_dir_create(unreadable, 0, 0700);
+    createFileWithContents(tr_pathbuf{ unreadable, "/a"sv }, "test");
+    ASSERT_EQ(0, chmod(unreadable.c_str(), 0));
+
+    auto error = tr_error{};
+    EXPECT_EQ(std::vector<std::string>{}, tr_sys_dir_get_files(unreadable, tr_basename_accept_all, &error));
+    EXPECT_TRUE(error);
+
+    // let the sandbox clean up after itself
+    EXPECT_EQ(0, chmod(unreadable.c_str(), 0700));
+}
+#endif
 
 } // namespace tr::test

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -50,20 +50,8 @@ using file_func_t = std::function<void(std::string_view filename)>;
 static void depthFirstWalk(std::string_view const path, file_func_t const& func)
 {
     if (auto const info = tr_sys_path_get_info(path); info && info->isFolder()) {
-        if (auto const odir = tr_sys_dir_open(path); odir != TR_BAD_SYS_DIR) {
-            for (;;) {
-                char const* const name = tr_sys_dir_read_name(odir);
-                if (name == nullptr) {
-                    break;
-                }
-
-                if ("."sv != name && ".."sv != name) {
-                    auto const child = fmt::format("{:s}/{:s}"sv, path, name);
-                    depthFirstWalk(child, func);
-                }
-            }
-
-            tr_sys_dir_close(odir);
+        for (auto const& name : tr_sys_dir_get_files(path, tr_basename_accept_all)) {
+            depthFirstWalk(fmt::format("{:s}/{:s}"sv, path, name), func);
         }
     }
 


### PR DESCRIPTION
## Description

Replace the bespoke POSIX and Win32 code for `tr_sys_get_files()` with `std::filesystem` calls.

Notes: Moved from C++17 to C++20.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
