### PR TITLE
refactor: remove unused tr_strv_find_invalid_utf8()

### DIFF
--- a/libtransmission/string-utils.cc
+++ b/libtransmission/string-utils.cc
@@ -162,9 +162,3 @@ std::string tr_win32_format_message(uint32_t code)
 }
 
 #endif
-
-std::string_view::size_type tr_strv_find_invalid_utf8(std::string_view const sv)
-{
-    auto const result = simdutf::validate_utf8_with_errors(std::data(sv), std::size(sv));
-    return result.error == simdutf::error_code::SUCCESS ? std::string_view::npos : result.count;
-}

--- a/libtransmission/string-utils.h
+++ b/libtransmission/string-utils.h
@@ -112,5 +112,3 @@ template <typename... Args> constexpr bool tr_strv_sep(std::string_view* sv, std
 #endif
 
 [[nodiscard]] std::string tr_strv_replace_invalid(std::string_view sv, char32_t replacement = 0xFFFD /*�*/);
-
-[[nodiscard]] std::string_view::size_type tr_strv_find_invalid_utf8(std::string_view sv);


### PR DESCRIPTION
## Description

Remove `tr_strv_find_invalid_utf8()`. Its last caller was removed in 35ce44e9.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
