### PR TITLE
refactor: drop `tr_ctorMode`

### DIFF
--- a/cli/cli.cc
+++ b/cli/cli.cc
@@ -346,7 +346,7 @@ int tr_main(int argc, char* argv[])
     auto* const h = tr_sessionInit(config_dir, false, settings);
     auto* const ctor = tr_ctorNew(h);
 
-    tr_ctorSetPaused(ctor, TR_FORCE, false);
+    tr_ctorSetPaused(ctor, false);
 
     if (tr_sys_path_exists(torrentPath) ? tr_ctorSetMetainfoFromFile(ctor, torrentPath) :
                                           tr_ctorSetMetainfoFromMagnetLink(ctor, torrentPath)) {

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -858,7 +858,7 @@ int tr_daemon::start([[maybe_unused]] bool foreground)
         tr_ctor* ctor = tr_ctorNew(my_session_);
 
         if (map.value_if<bool>(TR_KEY_start_paused).value_or(false)) {
-            tr_ctorSetPaused(ctor, TR_FORCE, true);
+            tr_ctorSetPaused(ctor, true);
         }
 
         tr_sessionLoadTorrents(my_session_, ctor);

--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -243,7 +243,7 @@ void MakeProgressDialog::addTorrent()
 {
     tr_ctor* ctor = tr_ctorNew(core_->get_session());
     tr_ctorSetMetainfoFromFile(ctor, target_);
-    tr_ctorSetDownloadDir(ctor, TR_FORCE, Glib::path_get_dirname(builder_.top()));
+    tr_ctorSetDownloadDir(ctor, Glib::path_get_dirname(builder_.top()));
     core_->add_ctor(ctor);
 }
 

--- a/gtk/OptionsDialog.cc
+++ b/gtk/OptionsDialog.cc
@@ -158,8 +158,8 @@ void OptionsDialog::Impl::sourceChanged(PathButton* b)
             new_file = true;
         }
 
-        tr_ctorSetDownloadDir(ctor_.get(), TR_FORCE, downloadDir_);
-        tr_ctorSetPaused(ctor_.get(), TR_FORCE, true);
+        tr_ctorSetDownloadDir(ctor_.get(), downloadDir_);
+        tr_ctorSetPaused(ctor_.get(), true);
         tr_ctorSetDeleteSource(ctor_.get(), false);
 
         tr_torrent* duplicate_of = nullptr;
@@ -242,7 +242,7 @@ OptionsDialog::Impl::Impl(
     , core_(core)
     , ctor_(std::move(ctor))
     , filename_{ tr_ctorGetSourceFile(ctor_.get()).value_or(""s) }
-    , downloadDir_{ tr_ctorGetDownloadDir(ctor_.get(), TR_FORCE).value_or(""s) }
+    , downloadDir_{ tr_ctorGetDownloadDir(ctor_.get()).value_or(""s) }
     , file_list_(gtr_get_widget_derived<FileList>(builder, "files_view_scroll", "files_view", core_, 0))
     , run_check_(gtr_get_widget<Gtk::CheckButton>(builder, "start_check"))
     , trash_check_(gtr_get_widget<Gtk::CheckButton>(builder, "trash_check"))
@@ -267,7 +267,7 @@ OptionsDialog::Impl::Impl(
         [this, destination_chooser]() { downloadDirChanged(destination_chooser); });
 
     bool flag = false;
-    if (!tr_ctorGetPaused(ctor_.get(), TR_FORCE, &flag)) {
+    if (!tr_ctorGetPaused(ctor_.get(), &flag)) {
         g_assert_not_reached();
     }
 

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -695,20 +695,20 @@ namespace
 
 void core_apply_defaults(tr_ctor* ctor)
 {
-    if (!tr_ctorGetPaused(ctor, TR_FORCE, nullptr)) {
-        tr_ctorSetPaused(ctor, TR_FORCE, !gtr_pref_flag_get(TR_KEY_start_added_torrents));
+    if (!tr_ctorGetPaused(ctor, nullptr)) {
+        tr_ctorSetPaused(ctor, !gtr_pref_flag_get(TR_KEY_start_added_torrents));
     }
 
     if (!tr_ctorGetDeleteSource(ctor, nullptr)) {
         tr_ctorSetDeleteSource(ctor, gtr_pref_flag_get(TR_KEY_trash_original_torrent_files));
     }
 
-    if (!tr_ctorGetPeerLimit(ctor, TR_FORCE, nullptr)) {
-        tr_ctorSetPeerLimit(ctor, TR_FORCE, gtr_pref_int_get<size_t>(TR_KEY_peer_limit_per_torrent));
+    if (!tr_ctorGetPeerLimit(ctor, nullptr)) {
+        tr_ctorSetPeerLimit(ctor, gtr_pref_int_get<size_t>(TR_KEY_peer_limit_per_torrent));
     }
 
-    if (!tr_ctorGetDownloadDir(ctor, TR_FORCE).has_value()) {
-        tr_ctorSetDownloadDir(ctor, TR_FORCE, gtr_pref_string_get(TR_KEY_download_dir));
+    if (!tr_ctorGetDownloadDir(ctor).has_value()) {
+        tr_ctorSetDownloadDir(ctor, gtr_pref_string_get(TR_KEY_download_dir));
     }
 }
 
@@ -776,7 +776,7 @@ bool Session::Impl::add(Glib::ustring const& name_in, bool const do_start, bool 
     bool handled = false;
     auto* ctor = tr_ctorNew(session);
     core_apply_defaults(ctor);
-    tr_ctorSetPaused(ctor, TR_FORCE, !do_start);
+    tr_ctorSetPaused(ctor, !do_start);
 
     bool loaded = false;
     auto file = Gio::File::create_for_parse_name(name);
@@ -879,10 +879,8 @@ void Session::load(bool force_paused)
     auto* const ctor = tr_ctorNew(impl_->get_session());
 
     if (force_paused) {
-        tr_ctorSetPaused(ctor, TR_FORCE, true);
+        tr_ctorSetPaused(ctor, true);
     }
-
-    tr_ctorSetPeerLimit(ctor, TR_FALLBACK, gtr_pref_int_get<size_t>(TR_KEY_peer_limit_per_torrent));
 
     auto* session = impl_->get_session();
     tr_sessionLoadTorrents(session, ctor);

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -739,45 +739,40 @@ tr_resume::fields_t load_from_file(tr_torrent* tor, tr_torrent::ResumeHelper& he
     return fields_loaded;
 }
 
-auto set_from_ctor(
-    tr_torrent* tor,
-    tr_torrent::ResumeHelper& helper,
-    tr_resume::fields_t const fields,
-    tr_ctor const& ctor,
-    tr_ctorMode const mode)
+auto set_from_ctor(tr_torrent* tor, tr_torrent::ResumeHelper& helper, tr_resume::fields_t const fields, tr_ctor const& ctor)
 {
     auto ret = tr_resume::fields_t{};
 
     if ((fields & tr_resume::Run) != 0) {
-        if (auto const val = ctor.paused(mode); val) {
+        if (auto const val = ctor.paused(); val) {
             helper.load_start_when_stable(!*val);
             ret |= tr_resume::Run;
         }
     }
 
     if ((fields & tr_resume::MaxPeers) != 0) {
-        if (auto const val = ctor.peer_limit(mode); val) {
+        if (auto const val = ctor.peer_limit(); val) {
             tor->set_peer_limit(*val);
             ret |= tr_resume::MaxPeers;
         }
     }
 
     if ((fields & tr_resume::DownloadDir) != 0) {
-        if (auto const& val = ctor.download_dir(mode); !std::empty(val)) {
+        if (auto const& val = ctor.download_dir(); !std::empty(val)) {
             helper.load_download_dir(val);
             ret |= tr_resume::DownloadDir;
         }
     }
 
     if ((fields & tr_resume::SequentialDownload) != 0) {
-        if (auto const& val = ctor.sequential_download(mode); val) {
+        if (auto const& val = ctor.sequential_download(); val) {
             tor->set_sequential_download(*val);
             ret |= tr_resume::SequentialDownload;
         }
     }
 
     if ((fields & tr_resume::SequentialDownloadFromPiece) != 0) {
-        if (auto const& val = ctor.sequential_download_from_piece(mode); val) {
+        if (auto const& val = ctor.sequential_download_from_piece(); val) {
             tor->set_sequential_download_from_piece(*val);
             ret |= tr_resume::SequentialDownloadFromPiece;
         }
@@ -786,36 +781,15 @@ auto set_from_ctor(
     return ret;
 }
 
-auto use_mandatory_fields(
-    tr_torrent* const tor,
-    tr_torrent::ResumeHelper& helper,
-    tr_resume::fields_t const fields,
-    tr_ctor const& ctor)
-{
-    return set_from_ctor(tor, helper, fields, ctor, TR_FORCE);
-}
-
-auto use_fallback_fields(
-    tr_torrent* const tor,
-    tr_torrent::ResumeHelper& helper,
-    tr_resume::fields_t const fields,
-    tr_ctor const& ctor)
-{
-    return set_from_ctor(tor, helper, fields, ctor, TR_FALLBACK);
-}
 } // namespace
 
 fields_t load(tr_torrent* tor, tr_torrent::ResumeHelper& helper, fields_t fields_to_load, tr_ctor const& ctor)
 {
     TR_ASSERT(tr_isTorrent(tor));
 
-    auto ret = fields_t{};
-
-    ret |= use_mandatory_fields(tor, helper, fields_to_load, ctor);
+    auto ret = set_from_ctor(tor, helper, fields_to_load, ctor);
     fields_to_load &= ~ret;
     ret |= load_from_file(tor, helper, fields_to_load);
-    fields_to_load &= ~ret;
-    ret |= use_fallback_fields(tor, helper, fields_to_load, ctor);
 
     return ret;
 }

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1576,15 +1576,15 @@ void torrentAdd(tr_session* session, tr_variant::Map const& args_in, tr_rpc_idle
     auto const cookies = args_in.value_if<std::string_view>(TR_KEY_cookies).value_or(""sv);
 
     if (download_dir && !std::empty(*download_dir)) {
-        ctor.set_download_dir(TR_FORCE, *download_dir);
+        ctor.set_download_dir(*download_dir);
     }
 
     if (auto const val = args_in.value_if<bool>(TR_KEY_paused)) {
-        ctor.set_paused(TR_FORCE, *val);
+        ctor.set_paused(*val);
     }
 
     if (auto const val = args_in.value_if<int64_t>(TR_KEY_peer_limit); val) {
-        ctor.set_peer_limit(TR_FORCE, static_cast<uint16_t>(*val));
+        ctor.set_peer_limit(static_cast<uint16_t>(*val));
     }
 
     if (auto const val = args_in.value_if<int64_t>(TR_KEY_bandwidth_priority); val) {
@@ -1628,11 +1628,11 @@ void torrentAdd(tr_session* session, tr_variant::Map const& args_in, tr_rpc_idle
     }
 
     if (auto const val = args_in.value_if<bool>(TR_KEY_sequential_download); val) {
-        ctor.set_sequential_download(TR_FORCE, *val);
+        ctor.set_sequential_download(*val);
     }
 
     if (auto const val = args_in.value_if<int64_t>(TR_KEY_sequential_download_from_piece); val) {
-        ctor.set_sequential_download_from_piece(TR_FORCE, *val);
+        ctor.set_sequential_download_from_piece(*val);
     }
 
     tr_logAddTrace(fmt::format("torrentAdd: filename is '{}'", filename));

--- a/libtransmission/torrent-ctor.cc
+++ b/libtransmission/torrent-ctor.cc
@@ -15,9 +15,6 @@ using namespace std::literals;
 tr_ctor::tr_ctor(tr_session* const session)
     : session_{ session }
 {
-    set_download_dir(TR_FALLBACK, session->downloadDir());
-    set_paused(TR_FALLBACK, session->shouldPauseAddedTorrents());
-    set_peer_limit(TR_FALLBACK, session->peerLimitPerTorrent());
     set_should_delete_source_file(session->shouldDeleteSource());
 }
 
@@ -123,19 +120,19 @@ bool tr_ctorGetDeleteSource(tr_ctor const* const ctor, bool* const setme)
     return false;
 }
 
-void tr_ctorSetPaused(tr_ctor* const ctor, tr_ctorMode const mode, bool const paused)
+void tr_ctorSetPaused(tr_ctor* const ctor, bool const paused)
 {
-    ctor->set_paused(mode, paused);
+    ctor->set_paused(paused);
 }
 
-void tr_ctorSetPeerLimit(tr_ctor* const ctor, tr_ctorMode const mode, uint16_t const peer_limit)
+void tr_ctorSetPeerLimit(tr_ctor* const ctor, uint16_t const peer_limit)
 {
-    ctor->set_peer_limit(mode, peer_limit);
+    ctor->set_peer_limit(peer_limit);
 }
 
-void tr_ctorSetDownloadDir(tr_ctor* const ctor, tr_ctorMode const mode, std::string_view const dir)
+void tr_ctorSetDownloadDir(tr_ctor* const ctor, std::string_view const dir)
 {
-    ctor->set_download_dir(mode, dir);
+    ctor->set_download_dir(dir);
 }
 
 void tr_ctorSetIncompleteDir(tr_ctor* const ctor, std::string_view const dir)
@@ -143,9 +140,9 @@ void tr_ctorSetIncompleteDir(tr_ctor* const ctor, std::string_view const dir)
     ctor->set_incomplete_dir(dir);
 }
 
-bool tr_ctorGetPeerLimit(tr_ctor const* const ctor, tr_ctorMode const mode, uint16_t* const setme)
+bool tr_ctorGetPeerLimit(tr_ctor const* const ctor, uint16_t* const setme)
 {
-    if (auto const val = ctor->peer_limit(mode); val) {
+    if (auto const val = ctor->peer_limit(); val) {
         if (setme != nullptr) {
             *setme = *val;
         }
@@ -156,9 +153,9 @@ bool tr_ctorGetPeerLimit(tr_ctor const* const ctor, tr_ctorMode const mode, uint
     return false;
 }
 
-bool tr_ctorGetPaused(tr_ctor const* const ctor, tr_ctorMode const mode, bool* const setme)
+bool tr_ctorGetPaused(tr_ctor const* const ctor, bool* const setme)
 {
-    if (auto const val = ctor->paused(mode); val) {
+    if (auto const val = ctor->paused(); val) {
         if (setme != nullptr) {
             *setme = *val;
         }
@@ -169,9 +166,9 @@ bool tr_ctorGetPaused(tr_ctor const* const ctor, tr_ctorMode const mode, bool* c
     return false;
 }
 
-std::optional<std::string> tr_ctorGetDownloadDir(tr_ctor const* const ctor, tr_ctorMode const mode)
+std::optional<std::string> tr_ctorGetDownloadDir(tr_ctor const* const ctor)
 {
-    if (auto const& dir = ctor->download_dir(mode); !std::empty(dir)) {
+    if (auto const& dir = ctor->download_dir(); !std::empty(dir)) {
         return dir;
     }
 

--- a/libtransmission/torrent-ctor.h
+++ b/libtransmission/torrent-ctor.h
@@ -9,7 +9,6 @@
 #error only libtransmission should #include this header.
 #endif
 
-#include <array>
 #include <cstdint> // uint16_t
 #include <optional>
 #include <string>
@@ -118,14 +117,14 @@ public:
 
     // ---
 
-    [[nodiscard]] constexpr auto const& download_dir(tr_ctorMode const mode) const noexcept
+    [[nodiscard]] constexpr auto const& download_dir() const noexcept
     {
-        return optional_args_[mode].download_dir_;
+        return download_dir_;
     }
 
-    TR_CONSTEXPR_STR void set_download_dir(tr_ctorMode const mode, std::string_view const dir)
+    TR_CONSTEXPR_STR void set_download_dir(std::string_view const dir)
     {
-        optional_args_[mode].download_dir_.assign(dir);
+        download_dir_.assign(dir);
     }
 
     // ---
@@ -154,26 +153,26 @@ public:
 
     // --
 
-    [[nodiscard]] constexpr auto paused(tr_ctorMode const mode) const noexcept
+    [[nodiscard]] constexpr auto paused() const noexcept
     {
-        return optional_args_[mode].paused_;
+        return paused_;
     }
 
-    constexpr void set_paused(tr_ctorMode const mode, bool const paused) noexcept
+    constexpr void set_paused(bool const paused) noexcept
     {
-        optional_args_[mode].paused_ = paused;
+        paused_ = paused;
     }
 
     // --
 
-    [[nodiscard]] constexpr auto peer_limit(tr_ctorMode const mode) const noexcept
+    [[nodiscard]] constexpr auto peer_limit() const noexcept
     {
-        return optional_args_[mode].peer_limit_;
+        return peer_limit_;
     }
 
-    constexpr void set_peer_limit(tr_ctorMode const mode, uint16_t const peer_limit) noexcept
+    constexpr void set_peer_limit(uint16_t const peer_limit) noexcept
     {
-        optional_args_[mode].peer_limit_ = peer_limit;
+        peer_limit_ = peer_limit;
     }
 
     // ---
@@ -204,38 +203,34 @@ public:
 
     // ---
 
-    [[nodiscard]] constexpr auto const& sequential_download(tr_ctorMode const mode) const noexcept
+    [[nodiscard]] constexpr auto const& sequential_download() const noexcept
     {
-        return optional_args_[mode].sequential_download_;
+        return sequential_download_;
     }
 
-    constexpr void set_sequential_download(tr_ctorMode const mode, bool const seq) noexcept
+    constexpr void set_sequential_download(bool const seq) noexcept
     {
-        optional_args_[mode].sequential_download_ = seq;
+        sequential_download_ = seq;
     }
 
-    [[nodiscard]] constexpr auto const& sequential_download_from_piece(tr_ctorMode const mode) const noexcept
+    [[nodiscard]] constexpr auto const& sequential_download_from_piece() const noexcept
     {
-        return optional_args_[mode].sequential_download_from_piece_;
+        return sequential_download_from_piece_;
     }
 
-    constexpr void set_sequential_download_from_piece(tr_ctorMode const mode, tr_piece_index_t const piece) noexcept
+    constexpr void set_sequential_download_from_piece(tr_piece_index_t const piece) noexcept
     {
-        optional_args_[mode].sequential_download_from_piece_ = piece;
+        sequential_download_from_piece_ = piece;
     }
 
 private:
-    struct OptionalArgs {
-        std::optional<bool> paused_;
-        std::optional<bool> sequential_download_;
-        std::optional<tr_piece_index_t> sequential_download_from_piece_;
-        std::optional<uint16_t> peer_limit_;
-        std::string download_dir_;
-    };
-
     tr_torrent_metainfo metainfo_ = {};
 
-    std::array<OptionalArgs, 2> optional_args_{};
+    std::optional<bool> paused_;
+    std::optional<bool> sequential_download_;
+    std::optional<tr_piece_index_t> sequential_download_from_piece_;
+    std::optional<uint16_t> peer_limit_;
+    std::string download_dir_;
 
     tr_torrent::VerifyDoneCallback verify_done_callback_;
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -836,12 +836,6 @@ void tr_torrent::init(tr_ctor const& ctor)
 
     on_metainfo_updated();
 
-    if (auto dir = ctor.download_dir(TR_FORCE); !std::empty(dir)) {
-        download_dir_ = dir;
-    } else if (dir = ctor.download_dir(TR_FALLBACK); !std::empty(dir)) {
-        download_dir_ = dir;
-    }
-
     if (tr_sessionIsIncompleteDirEnabled(session)) {
         auto const& dir = ctor.incomplete_dir();
         incomplete_dir_ = !std::empty(dir) ? dir : session->incompleteDir();
@@ -863,6 +857,8 @@ void tr_torrent::init(tr_ctor const& ctor)
 
     // these are defaults that will be overwritten by the resume file
     date_added_ = now_sec;
+    download_dir_ = session->downloadDir();
+    start_when_stable_ = !session->shouldPauseAddedTorrents();
     set_sequential_download(session->sequential_download());
 
     tr_resume::fields_t loaded = {};
@@ -874,6 +870,8 @@ void tr_torrent::init(tr_ctor const& ctor)
         // affect the 'is dirty' flag.
         auto const was_dirty = is_dirty();
         auto resume_helper = ResumeHelper{ *this };
+        // another default for the resume file to overwrite; it sits inside this guard because it dirties the torrent
+        set_peer_limit(static_cast<uint16_t>(session->peerLimitPerTorrent()));
         loaded = tr_resume::load(this, resume_helper, tr_resume::All, ctor);
         set_dirty(was_dirty);
         tr_torrent_metainfo::migrate_file(session->torrentDir(), name(), info_hash_string(), ".torrent"sv);

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -552,17 +552,17 @@ bool tr_ctorSetMetainfo(tr_ctor* ctor, char const* metainfo, size_t len, tr_erro
 bool tr_ctorSetMetainfoFromFile(tr_ctor* ctor, std::string_view filename, tr_error* error = nullptr);
 
 /** @brief Get this peer constructor's peer limit */
-[[nodiscard]] bool tr_ctorGetPeerLimit(tr_ctor const* ctor, tr_ctorMode mode, uint16_t* setme_count);
+[[nodiscard]] bool tr_ctorGetPeerLimit(tr_ctor const* ctor, uint16_t* setme_count);
 
 /** @brief Set how many peers this torrent can connect to. (Default: 50) */
-void tr_ctorSetPeerLimit(tr_ctor* ctor, tr_ctorMode mode, uint16_t limit);
+void tr_ctorSetPeerLimit(tr_ctor* ctor, uint16_t limit);
 
 /** @brief Get the download path from this peer constructor */
-[[nodiscard]] std::optional<std::string> tr_ctorGetDownloadDir(tr_ctor const* ctor, tr_ctorMode mode);
+[[nodiscard]] std::optional<std::string> tr_ctorGetDownloadDir(tr_ctor const* ctor);
 
 /** @brief Set the download folder for the torrent being added with this ctor.
     @see `tr_sessionInit()` */
-void tr_ctorSetDownloadDir(tr_ctor* ctor, tr_ctorMode mode, std::string_view dir);
+void tr_ctorSetDownloadDir(tr_ctor* ctor, std::string_view dir);
 
 /**
  * @brief Set the incompleteDir for this torrent.
@@ -575,11 +575,11 @@ void tr_ctorSetDownloadDir(tr_ctor* ctor, tr_ctorMode mode, std::string_view dir
 void tr_ctorSetIncompleteDir(tr_ctor* ctor, std::string_view dir);
 
 /** @brief Get the "isPaused" flag from this peer constructor */
-bool tr_ctorGetPaused(tr_ctor const* ctor, tr_ctorMode mode, bool* setme_is_paused);
+bool tr_ctorGetPaused(tr_ctor const* ctor, bool* setme_is_paused);
 
 /** Set whether or not the torrent begins downloading/seeding when created.
   (Default: not paused) */
-void tr_ctorSetPaused(tr_ctor* ctor, tr_ctorMode mode, bool is_paused);
+void tr_ctorSetPaused(tr_ctor* ctor, bool is_paused);
 
 /** @brief Get the torrent file that this ctor's metainfo came from,
            or empty if `tr_ctorSetMetainfoFromFile()` wasn't used */

--- a/libtransmission/types.h
+++ b/libtransmission/types.h
@@ -169,11 +169,6 @@ enum tr_completeness : uint8_t {
     TR_PARTIAL_SEED /* has the desired pieces, but not the entire torrent */
 };
 
-enum tr_ctorMode : uint8_t {
-    TR_FALLBACK, /* indicates the ctor value should be used only in case of missing resume settings */
-    TR_FORCE /* indicates the ctor value should be used regardless of what's in the resume settings */
-};
-
 enum class tr_blocklist_update_status : uint8_t { Ok, DownloadError, SaveError, InvalidData };
 
 enum class tr_direction : uint8_t {

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -658,7 +658,7 @@ static void removeKeRangerRansomware()
 
     //load previous transfers
     tr_ctor* ctor = tr_ctorNew(session);
-    tr_ctorSetPaused(ctor, TR_FORCE, true); // paused by default; unpause below after checking state history
+    tr_ctorSetPaused(ctor, true); // paused by default; unpause below after checking state history
     tr_sessionLoadTorrents(session, ctor);
     tr_ctorFree(ctor);
 

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -1714,9 +1714,9 @@ static tr_torrent_rename_done_func makeRenameDoneCallback(NSDictionary* contextI
         //set libtransmission settings for initialization
         tr_ctor* ctor = tr_ctorNew(lib);
 
-        tr_ctorSetPaused(ctor, TR_FORCE, YES);
+        tr_ctorSetPaused(ctor, YES);
         if (downloadFolder) {
-            tr_ctorSetDownloadDir(ctor, TR_FORCE, downloadFolder.UTF8String);
+            tr_ctorSetDownloadDir(ctor, downloadFolder.UTF8String);
         }
         if (incompleteFolder) {
             tr_ctorSetIncompleteDir(ctor, incompleteFolder.UTF8String);

--- a/tests/libtransmission/rename-test.cc
+++ b/tests/libtransmission/rename-test.cc
@@ -78,7 +78,7 @@ protected:
         auto error = tr_error{};
         EXPECT_TRUE(tr_ctorSetMetainfo(ctor, std::data(benc), std::size(benc), &error));
         EXPECT_FALSE(error) << error;
-        tr_ctorSetPaused(ctor, TR_FORCE, true);
+        tr_ctorSetPaused(ctor, true);
 
         // create the torrent
         auto* const tor = createTorrentAndWaitForVerifyDone(ctor);

--- a/tests/libtransmission/rpc-test.cc
+++ b/tests/libtransmission/rpc-test.cc
@@ -767,7 +767,7 @@ TEST_F(RpcTest, recentlyActiveEmptyOnStartup)
     }
 
     auto* const ctor = tr_ctorNew(session_);
-    ctor->set_paused(TR_FORCE, false);
+    ctor->set_paused(false);
     EXPECT_EQ(tr_sessionLoadTorrents(session_, ctor), 1U);
     tr_ctorFree(ctor);
 

--- a/tests/libtransmission/session-test.cc
+++ b/tests/libtransmission/session-test.cc
@@ -403,7 +403,7 @@ TEST_F(SessionTest, loadTorrentsThenMagnets)
     }
 
     auto* const ctor = tr_ctorNew(session_);
-    ctor->set_paused(TR_FORCE, false);
+    ctor->set_paused(false);
     EXPECT_EQ(tr_sessionLoadTorrents(session_, ctor), 1U);
     tr_ctorFree(ctor);
 

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -382,7 +382,7 @@ protected:
         auto error = tr_error{};
         EXPECT_TRUE(tr_ctorSetMetainfo(ctor, std::data(benc), std::size(benc), &error));
         EXPECT_FALSE(error) << error;
-        tr_ctorSetPaused(ctor, TR_FORCE, true);
+        tr_ctorSetPaused(ctor, true);
 
         // maybe create the files
         if (state != ZeroTorrentState::NoFiles) {
@@ -428,7 +428,7 @@ protected:
 
         auto ctor = tr_ctorNew(session_);
         ctor->set_metainfo_from_magnet_link(V1Hash);
-        tr_ctorSetPaused(ctor, TR_FORCE, true);
+        tr_ctorSetPaused(ctor, true);
 
         auto* const tor = tr_torrentNew(ctor, nullptr);
         EXPECT_NE(nullptr, tor);


### PR DESCRIPTION
## Description

This mode is both confusing and redundant. `tr_torrent::init()` already loads the defaults so we don't need `TR_FALLBACK` mode. Removing that only leaves one mode; so the enum can go away, too.

No behavior changes.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
