### PR TITLE
build(qt): enforce `camelBack` class method naming

### DIFF
--- a/libtransmission-app/.clang-tidy
+++ b/libtransmission-app/.clang-tidy
@@ -28,6 +28,7 @@ Checks:
   - -cppcoreguidelines-pro-bounds-array-to-pointer-decay
   - -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access
   - -cppcoreguidelines-pro-bounds-constant-array-index
+  - -cppcoreguidelines-pro-bounds-pointer-arithmetic
   - -cppcoreguidelines-pro-type-const-cast
   - -cppcoreguidelines-pro-type-reinterpret-cast
   - -cppcoreguidelines-pro-type-union-access

--- a/libtransmission/.clang-tidy
+++ b/libtransmission/.clang-tidy
@@ -1,8 +1,6 @@
 ---
 HeaderFilterRegex: .*/libtransmission/.*
 
-# TODO: Enable `cppcoreguidelines-pro-bounds-pointer-arithmetic` after converting all pointers to std::span
-#
 # PRs welcome to fix & re-enable any of these explicitly-disabled checks
 Checks:
   - bugprone-*
@@ -11,7 +9,7 @@ Checks:
   - -bugprone-implicit-widening-of-multiplication-result
   - -bugprone-throwing-static-initialization
   - cert-*
-  - -cert-err58-cpp # alias of `bugprone-throwing-static-initialization
+  - -cert-err58-cpp # alias of `bugprone-throwing-static-initialization`
   - -cert-int09-c # alias of `readability-enum-initial-value`
   - clang-analyzer-*
   # -clang-analyzer-optin.core.EnumCastOutOfRange: disabled due false <filesystem> warning in file.cc calling

--- a/qt/.clang-tidy
+++ b/qt/.clang-tidy
@@ -62,8 +62,6 @@ CheckOptions:
   - { key: readability-identifier-naming.ClassCase,                         value: CamelCase  }
 #  - { key: readability-identifier-naming.ClassMethodCase,                   value: lower_case } TODO: enable later
   - { key: readability-identifier-naming.ConstexprVariableCase,             value: CamelCase  }
-#  - { key: readability-identifier-naming.EnumConstantCase,                  value: UPPER_CASE } TODO: enable later
-#  - { key: readability-identifier-naming.FunctionCase,                      value: lower_case } TODO: enable later
   - { key: readability-identifier-naming.GlobalConstantCase,                value: CamelCase  }
   - { key: readability-identifier-naming.MemberConstantCase,                value: CamelCase  }
   - { key: readability-identifier-naming.NamespaceCase,                     value: lower_case }

--- a/qt/.clang-tidy
+++ b/qt/.clang-tidy
@@ -60,7 +60,9 @@ Checks:
 CheckOptions:
   - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros,                   value: true       }
   - { key: readability-identifier-naming.ClassCase,                         value: CamelCase  }
-#  - { key: readability-identifier-naming.ClassMethodCase,                   value: lower_case } TODO: enable later
+  # https://stackoverflow.com/a/49892587/11390656:
+  # Qt slot names with underscore has a special meaning, so we don't use lower_case for class method names
+  - { key: readability-identifier-naming.ClassMethodCase,                   value: camelBack  }
   - { key: readability-identifier-naming.ConstexprVariableCase,             value: CamelCase  }
   - { key: readability-identifier-naming.GlobalConstantCase,                value: CamelCase  }
   - { key: readability-identifier-naming.MemberConstantCase,                value: CamelCase  }

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -548,19 +548,19 @@ void DetailsDialog::refreshUI()
         double const d = size_when_done == 0 ?
             100.0 :
             100.0 * static_cast<double>(size_when_done - left_until_done) / static_cast<double>(size_when_done);
-        auto const pct = Formatter::percent_to_string(d);
-        auto const size_when_done_str = Formatter::storage_to_string(size_when_done);
+        auto const pct = Formatter::percentToString(d);
+        auto const size_when_done_str = Formatter::storageToString(size_when_done);
 
         if (have_unverified == 0U && left_until_done == 0U) {
             //: Text following the "Have:" label in torrent properties dialog;
             //: %1 is amount of downloaded and verified data
-            string = tr("%1 (100%)").arg(Formatter::storage_to_string(have_verified));
+            string = tr("%1 (100%)").arg(Formatter::storageToString(have_verified));
         } else if (have_unverified == 0U) {
             //: Text following the "Have:" label in torrent properties dialog;
             //: %1 is amount of downloaded and verified data,
             //: %2 is overall size of torrent data,
             //: %3 is percentage (%1/%2*100)
-            string = tr("%1 of %2 (%3%)").arg(Formatter::storage_to_string(have_verified)).arg(size_when_done_str).arg(pct);
+            string = tr("%1 of %2 (%3%)").arg(Formatter::storageToString(have_verified)).arg(size_when_done_str).arg(pct);
         } else {
             //: Text following the "Have:" label in torrent properties dialog;
             //: %1 is amount of downloaded data (both verified and unverified),
@@ -568,10 +568,10 @@ void DetailsDialog::refreshUI()
             //: %3 is percentage (%1/%2*100),
             //: %4 is amount of downloaded but not yet verified data
             string = tr("%1 of %2 (%3%), %4 Unverified")
-                         .arg(Formatter::storage_to_string(have_verified + have_unverified))
+                         .arg(Formatter::storageToString(have_verified + have_unverified))
                          .arg(size_when_done_str)
                          .arg(pct)
-                         .arg(Formatter::storage_to_string(have_unverified));
+                         .arg(Formatter::storageToString(have_unverified));
         }
     }
 
@@ -582,7 +582,7 @@ void DetailsDialog::refreshUI()
         string = none;
     } else {
         auto const percent = 100.0 * static_cast<double>(available) / static_cast<double>(size_when_done);
-        string = QStringLiteral("%1%").arg(Formatter::percent_to_string(percent));
+        string = QStringLiteral("%1%").arg(Formatter::percentToString(percent));
     }
 
     ui_.availabilityValueLabel->setText(string);
@@ -599,8 +599,8 @@ void DetailsDialog::refreshUI()
             f += t->failedEver();
         }
 
-        auto const dstr = Formatter::storage_to_string(d);
-        auto const fstr = Formatter::storage_to_string(f);
+        auto const dstr = Formatter::storageToString(d);
+        auto const fstr = Formatter::storageToString(f);
 
         if (f != 0) {
             string = tr("%1 (+%2 discarded after failed checksum)").arg(dstr).arg(fstr);
@@ -624,8 +624,8 @@ void DetailsDialog::refreshUI()
         }
 
         string = tr("%1 (Ratio: %2)")
-                     .arg(Formatter::storage_to_string(uploaded))
-                     .arg(Formatter::ratio_to_string(tr_getRatio(uploaded, denominator)));
+                     .arg(Formatter::storageToString(uploaded))
+                     .arg(Formatter::ratioToString(tr_getRatio(uploaded, denominator)));
     }
 
     ui_.uploadedValueLabel->setText(string);
@@ -653,7 +653,7 @@ void DetailsDialog::refreshUI()
             string = mixed;
         } else {
             auto const seconds = static_cast<int>(std::difftime(now, baseline));
-            string = Formatter::time_to_string(seconds);
+            string = Formatter::timeToString(seconds);
         }
     }
 
@@ -678,7 +678,7 @@ void DetailsDialog::refreshUI()
             if (baseline < 0) {
                 string = tr("Unknown");
             } else {
-                string = Formatter::time_to_string(baseline);
+                string = Formatter::timeToString(baseline);
             }
         }
     }
@@ -702,7 +702,7 @@ void DetailsDialog::refreshUI()
         } else if (seconds < 5) {
             string = tr("Active now");
         } else {
-            string = tr("%1 ago").arg(Formatter::time_to_string(seconds));
+            string = tr("%1 ago").arg(Formatter::timeToString(seconds));
         }
     }
 
@@ -752,10 +752,10 @@ void DetailsDialog::refreshUI()
             string = none;
         } else if (piece_size > 0) {
             string = tr("%1 (%Ln pieces @ %2)", "", pieces)
-                         .arg(Formatter::storage_to_string(size))
-                         .arg(Formatter::memory_to_string(piece_size));
+                         .arg(Formatter::storageToString(size))
+                         .arg(Formatter::memoryToString(piece_size));
         } else {
-            string = tr("%1 (%Ln pieces)", "", pieces).arg(Formatter::storage_to_string(size));
+            string = tr("%1 (%Ln pieces)", "", pieces).arg(Formatter::storageToString(size));
         }
     }
 
@@ -1124,11 +1124,11 @@ void DetailsDialog::refreshUI()
                 code_tip.resize(code_tip.size() - 1); // eat the trailing linefeed
             }
 
-            item->setText(COL_UP, peer.rate_to_peer.is_zero() ? QString{} : peer.rate_to_peer.to_qstring());
+            item->setText(COL_UP, peer.rate_to_peer.is_zero() ? QString{} : peer.rate_to_peer.toQstring());
             item->setText(
                 COL_UP_REQS,
                 peer.active_reqs_to_client > 0 ? QString::number(peer.active_reqs_to_client) : QString{});
-            item->setText(COL_DOWN, peer.rate_to_client.is_zero() ? QString{} : peer.rate_to_client.to_qstring());
+            item->setText(COL_DOWN, peer.rate_to_client.is_zero() ? QString{} : peer.rate_to_client.toQstring());
             item->setText(COL_DOWN_REQS, peer.active_reqs_to_peer > 0 ? QString::number(peer.active_reqs_to_peer) : QString{});
             item->setText(
                 COL_PERCENT,
@@ -1359,7 +1359,7 @@ void DetailsDialog::onRemoveTrackerClicked()
 
 void DetailsDialog::initOptionsTab()
 {
-    auto const speed_unit_suffix = QStringLiteral(" %1").arg(Speed::display_name(Speed::Units::KByps));
+    auto const speed_unit_suffix = QStringLiteral(" %1").arg(Speed::displayName(Speed::Units::KByps));
     ui_.singleDownSpin->setSuffix(speed_unit_suffix);
     ui_.singleUpSpin->setSuffix(speed_unit_suffix);
 
@@ -1449,7 +1449,7 @@ void DetailsDialog::initTrackerTab()
 
 void DetailsDialog::initPeersTab()
 {
-    auto const speed_width_str = Speed{ 1024U, Speed::Units::MByps }.to_qstring();
+    auto const speed_width_str = Speed{ 1024U, Speed::Units::MByps }.toQstring();
 
     ui_.peersView->setHeaderLabels(
         { QString{}, tr("Up"), tr("Up Reqs"), tr("Down"), tr("Dn Reqs"), tr("%"), tr("Status"), tr("Address"), tr("Client") });

--- a/qt/FileTreeItem.cc
+++ b/qt/FileTreeItem.cc
@@ -195,7 +195,7 @@ double FileTreeItem::progress() const
 
 QString FileTreeItem::sizeString() const
 {
-    return Formatter::storage_to_string(size());
+    return Formatter::storageToString(size());
 }
 
 uint64_t FileTreeItem::size() const

--- a/qt/Formatter.cc
+++ b/qt/Formatter.cc
@@ -14,12 +14,12 @@ using namespace std::literals;
 using namespace tr::Values;
 
 // static
-QString Formatter::percent_to_string(double const x)
+QString Formatter::percentToString(double const x)
 {
     return QString::fromStdString(tr_strpercent(x));
 }
 
-QString Formatter::memory_to_string(int64_t const bytes)
+QString Formatter::memoryToString(int64_t const bytes)
 {
     if (bytes < 0) {
         return tr("Unknown");
@@ -32,7 +32,7 @@ QString Formatter::memory_to_string(int64_t const bytes)
     return QString::fromStdString(Memory{ bytes, Memory::Units::Bytes }.to_string());
 }
 
-QString Formatter::storage_to_string(uint64_t const bytes)
+QString Formatter::storageToString(uint64_t const bytes)
 {
     if (bytes == 0) {
         return tr("None");
@@ -41,16 +41,16 @@ QString Formatter::storage_to_string(uint64_t const bytes)
     return QString::fromStdString(Storage{ bytes, Storage::Units::Bytes }.to_string());
 }
 
-QString Formatter::storage_to_string(int64_t const bytes)
+QString Formatter::storageToString(int64_t const bytes)
 {
     if (bytes < 0) {
         return tr("Unknown");
     }
 
-    return storage_to_string(static_cast<uint64_t>(bytes));
+    return storageToString(static_cast<uint64_t>(bytes));
 }
 
-QString Formatter::ratio_to_string(double ratio)
+QString Formatter::ratioToString(double ratio)
 {
     static auto constexpr Infinity = "\xE2\x88\x9E"sv;
     static auto const None = tr("None").toStdString();
@@ -58,7 +58,7 @@ QString Formatter::ratio_to_string(double ratio)
     return QString::fromStdString(tr_strratio(ratio, None, Infinity));
 }
 
-QString Formatter::time_to_string(int seconds)
+QString Formatter::timeToString(int seconds)
 {
     seconds = std::max(seconds, 0);
 

--- a/qt/Formatter.h
+++ b/qt/Formatter.h
@@ -17,10 +17,10 @@ class Formatter
 public:
     Formatter() = delete;
 
-    [[nodiscard]] static QString memory_to_string(int64_t bytes);
-    [[nodiscard]] static QString percent_to_string(double x);
-    [[nodiscard]] static QString ratio_to_string(double ratio);
-    [[nodiscard]] static QString storage_to_string(int64_t bytes);
-    [[nodiscard]] static QString storage_to_string(uint64_t bytes);
-    [[nodiscard]] static QString time_to_string(int seconds);
+    [[nodiscard]] static QString memoryToString(int64_t bytes);
+    [[nodiscard]] static QString percentToString(double x);
+    [[nodiscard]] static QString ratioToString(double ratio);
+    [[nodiscard]] static QString storageToString(int64_t bytes);
+    [[nodiscard]] static QString storageToString(uint64_t bytes);
+    [[nodiscard]] static QString timeToString(int seconds);
 };

--- a/qt/FreeSpaceLabel.cc
+++ b/qt/FreeSpaceLabel.cc
@@ -95,7 +95,7 @@ void FreeSpaceLabel::onTimer()
 
             // update the label
             if (auto const bytes = dictFind<int64_t>(r.args.get(), TR_KEY_size_bytes); bytes && *bytes > 1) {
-                self->setText(tr("%1 free").arg(Formatter::storage_to_string(*bytes)));
+                self->setText(tr("%1 free").arg(Formatter::storageToString(*bytes)));
             } else {
                 self->setText(QString{});
             }

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -288,7 +288,7 @@ void MainWindow::initStatusBar()
     ui_.optionsButton->setMenu(createOptionsMenu());
 
     int const minimum_speed_width = ui_.downloadSpeedLabel->fontMetrics()
-                                        .size(0, Speed{ 999.99, Speed::Units::KByps }.to_qstring())
+                                        .size(0, Speed{ 999.99, Speed::Units::KByps }.toQstring())
                                         .width();
     ui_.downloadSpeedLabel->setMinimumWidth(minimum_speed_width);
     ui_.uploadSpeedLabel->setMinimumWidth(minimum_speed_width);
@@ -323,7 +323,7 @@ QMenu* MainWindow::createOptionsMenu()
                 }
             });
 
-            on_action = menu->addAction(tr("Limited at %1").arg(Speed{ current_value, Speed::Units::KByps }.to_qstring()));
+            on_action = menu->addAction(tr("Limited at %1").arg(Speed{ current_value, Speed::Units::KByps }.toQstring()));
             on_action->setCheckable(true);
             action_group->addAction(on_action);
             connect(on_action, &QAction::triggered, this, [set_limit, current_value](bool is_checked) {
@@ -335,7 +335,7 @@ QMenu* MainWindow::createOptionsMenu()
             menu->addSeparator();
 
             for (auto const kbyps : { 50, 100, 250, 500, 1000, 2500, 5000, 10000 }) {
-                auto* const action = menu->addAction(Speed{ kbyps, Speed::Units::KByps }.to_qstring());
+                auto* const action = menu->addAction(Speed{ kbyps, Speed::Units::KByps }.toQstring());
                 connect(action, &QAction::triggered, this, [set_limit, kbyps]() { set_limit(kbyps); });
             }
         };
@@ -363,7 +363,7 @@ QMenu* MainWindow::createOptionsMenu()
                 }
             });
 
-            on_action = menu->addAction(tr("Stop at Ratio (%1)").arg(Formatter::ratio_to_string(current_value)));
+            on_action = menu->addAction(tr("Stop at Ratio (%1)").arg(Formatter::ratioToString(current_value)));
             on_action->setCheckable(true);
             action_group->addAction(on_action);
             connect(on_action, &QAction::triggered, this, [set_ratio, current_value](bool is_checked) {
@@ -375,7 +375,7 @@ QMenu* MainWindow::createOptionsMenu()
             menu->addSeparator();
 
             for (double const i : StockRatios) {
-                QAction* action = menu->addAction(Formatter::ratio_to_string(i));
+                QAction* action = menu->addAction(Formatter::ratioToString(i));
                 connect(action, &QAction::triggered, this, [set_ratio, i]() { set_ratio(i); });
             }
         };
@@ -709,9 +709,9 @@ void MainWindow::refreshTrayIcon(TransferStats const& stats)
     } else if (stats.peers_sending == 0 && stats.peers_receiving == 0) {
         tip = tr("Idle");
     } else if (stats.peers_sending != 0) {
-        tip = stats.speed_down.to_download_qstring() + QStringLiteral("   ") + stats.speed_up.to_upload_qstring();
+        tip = stats.speed_down.toDownloadQstring() + QStringLiteral("   ") + stats.speed_up.toUploadQstring();
     } else if (stats.peers_receiving != 0) {
-        tip = stats.speed_up.to_upload_qstring();
+        tip = stats.speed_up.toUploadQstring();
     }
 
     tray_icon_.setToolTip(tip);
@@ -719,9 +719,9 @@ void MainWindow::refreshTrayIcon(TransferStats const& stats)
 
 void MainWindow::refreshStatusBar(TransferStats const& stats)
 {
-    ui_.uploadSpeedLabel->setText(stats.speed_up.to_upload_qstring());
+    ui_.uploadSpeedLabel->setText(stats.speed_up.toUploadQstring());
     ui_.uploadSpeedLabel->setVisible(stats.peers_sending || stats.peers_receiving);
-    ui_.downloadSpeedLabel->setText(stats.speed_down.to_download_qstring());
+    ui_.downloadSpeedLabel->setText(stats.speed_down.toDownloadQstring());
     ui_.downloadSpeedLabel->setVisible(stats.peers_sending);
 
     static_assert(StatsModeCount == 4U && "StatsMode changed: update this code");
@@ -731,9 +731,9 @@ void MainWindow::refreshStatusBar(TransferStats const& stats)
     ui_.statsLabel->setText(
         mode == StatsMode::SessionTransfer || mode == StatsMode::TotalTransfer ?
             tr("Down: %1, Up: %2")
-                .arg(Formatter::storage_to_string(st.downloadedBytes))
-                .arg(Formatter::storage_to_string(st.uploadedBytes)) :
-            tr("Ratio: %1").arg(Formatter::ratio_to_string(st.ratio)));
+                .arg(Formatter::storageToString(st.downloadedBytes))
+                .arg(Formatter::storageToString(st.uploadedBytes)) :
+            tr("Ratio: %1").arg(Formatter::ratioToString(st.ratio)));
 }
 
 void MainWindow::refreshTorrentViewHeader()
@@ -1069,7 +1069,7 @@ void MainWindow::refreshPref(tr_quark const key)
         break;
 
     case TR_KEY_speed_limit_down:
-        dlimit_on_action_->setText(tr("Limited at %1").arg(Speed{ prefs_.get<int>(key), Speed::Units::KByps }.to_qstring()));
+        dlimit_on_action_->setText(tr("Limited at %1").arg(Speed{ prefs_.get<int>(key), Speed::Units::KByps }.toQstring()));
         break;
 
     case TR_KEY_speed_limit_up_enabled:
@@ -1077,7 +1077,7 @@ void MainWindow::refreshPref(tr_quark const key)
         break;
 
     case TR_KEY_speed_limit_up:
-        ulimit_on_action_->setText(tr("Limited at %1").arg(Speed{ prefs_.get<int>(key), Speed::Units::KByps }.to_qstring()));
+        ulimit_on_action_->setText(tr("Limited at %1").arg(Speed{ prefs_.get<int>(key), Speed::Units::KByps }.toQstring()));
         break;
 
     case TR_KEY_seed_ratio_limited:
@@ -1085,7 +1085,7 @@ void MainWindow::refreshPref(tr_quark const key)
         break;
 
     case TR_KEY_seed_ratio_limit:
-        ratio_on_action_->setText(tr("Stop at Ratio (%1)").arg(Formatter::ratio_to_string(prefs_.get<double>(key))));
+        ratio_on_action_->setText(tr("Stop at Ratio (%1)").arg(Formatter::ratioToString(prefs_.get<double>(key))));
         break;
 
     case TR_KEY_show_filterbar:
@@ -1151,7 +1151,7 @@ void MainWindow::refreshPref(tr_quark const key)
                                  tr("Click to enable Temporary Speed Limits\n (%1 down, %2 up)");
             auto const d = Speed{ prefs_.get<int>(TR_KEY_alt_speed_down), Speed::Units::KByps };
             auto const u = Speed{ prefs_.get<int>(TR_KEY_alt_speed_up), Speed::Units::KByps };
-            ui_.altSpeedButton->setToolTip(fmt.arg(d.to_qstring()).arg(u.to_qstring()));
+            ui_.altSpeedButton->setToolTip(fmt.arg(d.toQstring()).arg(u.toQstring()));
             break;
         }
 
@@ -1380,7 +1380,7 @@ void MainWindow::updateNetworkLabel()
     } else if (seconds_since_last_read < 30) {
         tip = tr("%1 is responding").arg(url);
     } else if (seconds_since_last_read < 120) {
-        tip = tr("%1 last responded %2 ago").arg(url).arg(Formatter::time_to_string(static_cast<int>(seconds_since_last_read)));
+        tip = tr("%1 last responded %2 ago").arg(url).arg(Formatter::timeToString(static_cast<int>(seconds_since_last_read)));
     } else {
         tip = tr("%1 is not responding").arg(url);
     }

--- a/qt/MakeDialog.cc
+++ b/qt/MakeDialog.cc
@@ -290,10 +290,10 @@ void MakeDialog::updatePiecesLabel()
         auto const files = tr("%Ln File(s)", nullptr, static_cast<int>(builder_->file_count()));
         auto const pieces = tr("%Ln Piece(s)", nullptr, static_cast<int>(builder_->piece_count()));
         text = tr("%1 in %2; %3 @ %4")
-                   .arg(Formatter::storage_to_string(builder_->total_size()))
+                   .arg(Formatter::storageToString(builder_->total_size()))
                    .arg(files)
                    .arg(pieces)
-                   .arg(Formatter::memory_to_string(builder_->piece_size()));
+                   .arg(Formatter::memoryToString(builder_->piece_size()));
         ui_.pieceSizeSlider->setEnabled(true);
     }
 

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -246,7 +246,7 @@ void PrefsDialog::initRemoteTab()
 
 void PrefsDialog::initSpeedTab()
 {
-    auto const suffix = QStringLiteral(" %1").arg(Speed::display_name(Speed::Units::KByps));
+    auto const suffix = QStringLiteral(" %1").arg(Speed::displayName(Speed::Units::KByps));
 
     ui_.uploadSpeedLimitSpin->setSuffix(suffix);
     ui_.downloadSpeedLimitSpin->setSuffix(suffix);

--- a/qt/Speed.h
+++ b/qt/Speed.h
@@ -31,24 +31,24 @@ public:
     {
     }
 
-    [[nodiscard]] auto to_qstring() const noexcept
+    [[nodiscard]] auto toQstring() const noexcept
     {
         return QString::fromStdString(to_string());
     }
 
-    [[nodiscard]] auto to_upload_qstring() const
+    [[nodiscard]] auto toUploadQstring() const
     {
         static auto constexpr UploadSymbol = QChar{ 0x25B4 };
-        return tr("%1 %2").arg(to_qstring()).arg(UploadSymbol);
+        return tr("%1 %2").arg(toQstring()).arg(UploadSymbol);
     }
 
-    [[nodiscard]] auto to_download_qstring() const
+    [[nodiscard]] auto toDownloadQstring() const
     {
         static auto constexpr DownloadSymbol = QChar{ 0x25BE };
-        return tr("%1 %2").arg(to_qstring()).arg(DownloadSymbol);
+        return tr("%1 %2").arg(toQstring()).arg(DownloadSymbol);
     }
 
-    [[nodiscard]] static auto display_name(Speed::Units const units)
+    [[nodiscard]] static auto displayName(Speed::Units const units)
     {
         auto const speed_unit_sv = Speed::units().display_name(units);
         return Utils::qstringFromUtf8(speed_unit_sv);

--- a/qt/StatsDialog.cc
+++ b/qt/StatsDialog.cc
@@ -50,15 +50,15 @@ void StatsDialog::updateStats()
     tr_session_stats const& current(session_.getStats());
     tr_session_stats const& total(session_.getCumulativeStats());
 
-    ui_.currentUploadedValueLabel->setText(Formatter::storage_to_string(current.uploadedBytes));
-    ui_.currentDownloadedValueLabel->setText(Formatter::storage_to_string(current.downloadedBytes));
-    ui_.currentRatioValueLabel->setText(Formatter::ratio_to_string(current.ratio));
-    ui_.currentDurationValueLabel->setText(Formatter::time_to_string(static_cast<int>(current.secondsActive)));
+    ui_.currentUploadedValueLabel->setText(Formatter::storageToString(current.uploadedBytes));
+    ui_.currentDownloadedValueLabel->setText(Formatter::storageToString(current.downloadedBytes));
+    ui_.currentRatioValueLabel->setText(Formatter::ratioToString(current.ratio));
+    ui_.currentDurationValueLabel->setText(Formatter::timeToString(static_cast<int>(current.secondsActive)));
 
-    ui_.totalUploadedValueLabel->setText(Formatter::storage_to_string(total.uploadedBytes));
-    ui_.totalDownloadedValueLabel->setText(Formatter::storage_to_string(total.downloadedBytes));
-    ui_.totalRatioValueLabel->setText(Formatter::ratio_to_string(total.ratio));
-    ui_.totalDurationValueLabel->setText(Formatter::time_to_string(static_cast<int>(total.secondsActive)));
+    ui_.totalUploadedValueLabel->setText(Formatter::storageToString(total.uploadedBytes));
+    ui_.totalDownloadedValueLabel->setText(Formatter::storageToString(total.downloadedBytes));
+    ui_.totalRatioValueLabel->setText(Formatter::ratioToString(total.ratio));
+    ui_.totalDurationValueLabel->setText(Formatter::timeToString(static_cast<int>(total.secondsActive)));
 
     ui_.startCountLabel->setText(tr("Started %Ln time(s)", nullptr, static_cast<int>(total.sessionCount)));
 }

--- a/qt/TorrentDelegate.cc
+++ b/qt/TorrentDelegate.cc
@@ -170,7 +170,7 @@ QString TorrentDelegate::progressString(Torrent const& tor)
         //: First part of torrent progress string,
         //: %1 is the percentage of torrent metadata downloaded
         str = tr("Magnetized transfer - retrieving metadata (%1%)")
-                  .arg(Formatter::percent_to_string(tor.metadataPercentDone() * 100.0));
+                  .arg(Formatter::percentToString(tor.metadataPercentDone() * 100.0));
     } else if (!is_done) // downloading
     {
         //: First part of torrent progress string,
@@ -178,9 +178,9 @@ QString TorrentDelegate::progressString(Torrent const& tor)
         //: %2 is how much we'll have when done,
         //: %3 is a percentage of the two
         str = tr("%1 of %2 (%3%)")
-                  .arg(Formatter::storage_to_string(have_total))
-                  .arg(Formatter::storage_to_string(tor.sizeWhenDone()))
-                  .arg(Formatter::percent_to_string(tor.percentDone() * 100.0));
+                  .arg(Formatter::storageToString(have_total))
+                  .arg(Formatter::storageToString(tor.sizeWhenDone()))
+                  .arg(Formatter::percentToString(tor.percentDone() * 100.0));
     } else if (!is_seed) // partial seed
     {
         if (seed_ratio_limit) {
@@ -192,12 +192,12 @@ QString TorrentDelegate::progressString(Torrent const& tor)
             //: %5 is our upload-to-download ratio,
             //: %6 is the ratio we want to reach before we stop uploading
             str = tr("%1 of %2 (%3%), uploaded %4 (Ratio: %5 Goal: %6)")
-                      .arg(Formatter::storage_to_string(have_total))
-                      .arg(Formatter::storage_to_string(tor.totalSize()))
-                      .arg(Formatter::percent_to_string(tor.percentComplete() * 100.0))
-                      .arg(Formatter::storage_to_string(tor.uploadedEver()))
-                      .arg(Formatter::ratio_to_string(tor.ratio()))
-                      .arg(Formatter::ratio_to_string(*seed_ratio_limit));
+                      .arg(Formatter::storageToString(have_total))
+                      .arg(Formatter::storageToString(tor.totalSize()))
+                      .arg(Formatter::percentToString(tor.percentComplete() * 100.0))
+                      .arg(Formatter::storageToString(tor.uploadedEver()))
+                      .arg(Formatter::ratioToString(tor.ratio()))
+                      .arg(Formatter::ratioToString(*seed_ratio_limit));
         } else {
             //: First part of torrent progress string,
             //: %1 is how much we've got,
@@ -206,11 +206,11 @@ QString TorrentDelegate::progressString(Torrent const& tor)
             //: %4 is how much we've uploaded,
             //: %5 is our upload-to-download ratio
             str = tr("%1 of %2 (%3%), uploaded %4 (Ratio: %5)")
-                      .arg(Formatter::storage_to_string(have_total))
-                      .arg(Formatter::storage_to_string(tor.totalSize()))
-                      .arg(Formatter::percent_to_string(tor.percentComplete() * 100.0))
-                      .arg(Formatter::storage_to_string(tor.uploadedEver()))
-                      .arg(Formatter::ratio_to_string(tor.ratio()));
+                      .arg(Formatter::storageToString(have_total))
+                      .arg(Formatter::storageToString(tor.totalSize()))
+                      .arg(Formatter::percentToString(tor.percentComplete() * 100.0))
+                      .arg(Formatter::storageToString(tor.uploadedEver()))
+                      .arg(Formatter::ratioToString(tor.ratio()));
         }
     } else // seeding
     {
@@ -221,10 +221,10 @@ QString TorrentDelegate::progressString(Torrent const& tor)
             //: %3 is our upload-to-download ratio,
             //: %4 is the ratio we want to reach before we stop uploading
             str = tr("%1, uploaded %2 (Ratio: %3 Goal: %4)")
-                      .arg(Formatter::storage_to_string(have_total))
-                      .arg(Formatter::storage_to_string(tor.uploadedEver()))
-                      .arg(Formatter::ratio_to_string(tor.ratio()))
-                      .arg(Formatter::ratio_to_string(*seed_ratio_limit));
+                      .arg(Formatter::storageToString(have_total))
+                      .arg(Formatter::storageToString(tor.uploadedEver()))
+                      .arg(Formatter::ratioToString(tor.ratio()))
+                      .arg(Formatter::ratioToString(*seed_ratio_limit));
         } else // seeding w/o a ratio
         {
             //: First part of torrent progress string,
@@ -232,9 +232,9 @@ QString TorrentDelegate::progressString(Torrent const& tor)
             //: %2 is how much we've uploaded,
             //: %3 is our upload-to-download ratio
             str = tr("%1, uploaded %2 (Ratio: %3)")
-                      .arg(Formatter::storage_to_string(have_total))
-                      .arg(Formatter::storage_to_string(tor.uploadedEver()))
-                      .arg(Formatter::ratio_to_string(tor.ratio()));
+                      .arg(Formatter::storageToString(have_total))
+                      .arg(Formatter::storageToString(tor.uploadedEver()))
+                      .arg(Formatter::ratioToString(tor.ratio()));
         }
     }
 
@@ -244,7 +244,7 @@ QString TorrentDelegate::progressString(Torrent const& tor)
             //: Second (optional) part of torrent progress string,
             //: %1 is duration,
             //: notice that leading space (before the dash) is included here
-            str += tr(" - %1 left").arg(Formatter::time_to_string(tor.getETA()));
+            str += tr(" - %1 left").arg(Formatter::timeToString(tor.getETA()));
         } else {
             //: Second (optional) part of torrent progress string,
             //: notice that leading space (before the dash) is included here
@@ -263,9 +263,9 @@ QString TorrentDelegate::shortTransferString(Torrent const& tor)
     bool const have_up(have_meta && tor.peersWeAreUploadingTo() > 0);
 
     if (have_down) {
-        str = tor.downloadSpeed().to_download_qstring() + QStringLiteral("   ") + tor.uploadSpeed().to_upload_qstring();
+        str = tor.downloadSpeed().toDownloadQstring() + QStringLiteral("   ") + tor.uploadSpeed().toUploadQstring();
     } else if (have_up) {
-        str = tor.uploadSpeed().to_upload_qstring();
+        str = tor.uploadSpeed().toUploadQstring();
     }
 
     return str.trimmed();
@@ -277,12 +277,12 @@ QString TorrentDelegate::shortStatusString(Torrent const& tor)
 
     switch (tor.getActivity()) {
     case TR_STATUS_CHECK:
-        str = tr("Verifying local data (%1% tested)").arg(Formatter::percent_to_string(tor.getVerifyProgress() * 100.0));
+        str = tr("Verifying local data (%1% tested)").arg(Formatter::percentToString(tor.getVerifyProgress() * 100.0));
         break;
 
     case TR_STATUS_DOWNLOAD:
     case TR_STATUS_SEED:
-        str = shortTransferString(tor) + QStringLiteral("    ") + tr("Ratio: %1").arg(Formatter::ratio_to_string(tor.ratio()));
+        str = shortTransferString(tor) + QStringLiteral("    ") + tr("Ratio: %1").arg(Formatter::ratioToString(tor.ratio()));
         break;
 
     default:
@@ -298,7 +298,7 @@ QString TorrentDelegate::shortStatusString(Torrent const& tor)
             //: Second (optional) part of torrent progress string,
             //: %1 is duration,
             //: notice that leading space (before the dash) is included here
-            str += tr("%1 left").arg(Formatter::time_to_string(tor.getETA()));
+            str += tr("%1 left").arg(Formatter::timeToString(tor.getETA()));
         } else {
             //: Second (optional) part of torrent progress string,
             //: notice that leading space (before the dash) is included here
@@ -328,7 +328,7 @@ QString TorrentDelegate::statusString(Torrent const& tor)
         case TR_STATUS_DOWNLOAD:
             if (!tor.hasMetadata()) {
                 str = tr("Downloading metadata from %Ln peer(s) (%1% done)", nullptr, tor.peersWeAreDownloadingFrom())
-                          .arg(Formatter::percent_to_string(100.0 * tor.metadataPercentDone()));
+                          .arg(Formatter::percentToString(100.0 * tor.metadataPercentDone()));
             } else {
                 /* it would be nicer for translation if this was all one string, but I don't see how to do multiple %n's in
                  * tr() */

--- a/qt/TrackerDelegate.cc
+++ b/qt/TrackerDelegate.cc
@@ -169,7 +169,7 @@ QString timeToRoundedString(int seconds)
         seconds -= seconds % 60;
     }
 
-    return Formatter::time_to_string(seconds);
+    return Formatter::timeToString(seconds);
 }
 } // namespace
 


### PR DESCRIPTION
## Description

Underscores in Qt slots names have a special meaning. Ban `lower_case` from class method names to prevent accidents.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
