### PR TITLE
refactor: move the verify-done callback onto the session

### DIFF
--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -33,6 +33,8 @@
 
 #include <event2/util.h> // for evutil_socket_t
 
+#include <sigslot/signal.hpp>
+
 #include "libtransmission/announce-list.h"
 #include "libtransmission/announcer.h"
 #include "libtransmission/bandwidth.h"
@@ -458,6 +460,9 @@ public:
     {
         return torrent_queue_;
     }
+
+    // We fire this on the session thread after recheck_completeness(), so listeners see the torrent's final state.
+    sigslot::signal<tr_torrent_id_t> verify_done_;
 
     [[nodiscard]] auto unique_lock() const
     {

--- a/libtransmission/torrent-ctor.h
+++ b/libtransmission/torrent-ctor.h
@@ -187,20 +187,6 @@ public:
         should_delete_source_file_ = should;
     }
 
-    // --
-
-    [[nodiscard]] auto steal_verify_done_callback() noexcept
-    {
-        auto tmp = tr_torrent::VerifyDoneCallback{};
-        std::swap(verify_done_callback_, tmp);
-        return tmp;
-    }
-
-    void set_verify_done_callback(tr_torrent::VerifyDoneCallback&& callback) noexcept
-    {
-        verify_done_callback_ = std::move(callback);
-    }
-
     // ---
 
     [[nodiscard]] constexpr auto const& sequential_download() const noexcept
@@ -231,8 +217,6 @@ private:
     std::optional<tr_piece_index_t> sequential_download_from_piece_;
     std::optional<uint16_t> peer_limit_;
     std::string download_dir_;
-
-    tr_torrent::VerifyDoneCallback verify_done_callback_;
 
     tr_torrent::labels_t labels_;
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -993,7 +993,6 @@ tr_torrent* tr_torrentNew(tr_ctor* ctor, tr_torrent** setme_duplicate_of)
     }
 
     auto* const tor = new tr_torrent{ std::move(metainfo) };
-    tor->verify_done_callback_ = ctor->steal_verify_done_callback();
     tor->init(*ctor);
     return tor;
 }
@@ -1610,9 +1609,7 @@ void tr_torrent::VerifyMediator::on_verify_done(bool const aborted)
 
                 tor->recheck_completeness();
 
-                if (tor->verify_done_callback_) {
-                    tor->verify_done_callback_(tor);
-                }
+                session->verify_done_(tor_id);
 
                 if (tor->start_when_stable_) {
                     tor->start(false, !tor->checked_pieces_.has_none());

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -12,7 +12,6 @@
 #include <cstddef> // size_t
 #include <cstdint> // uint64_t, uint16_t
 #include <ctime>
-#include <functional>
 #include <memory>
 #include <optional>
 #include <span>
@@ -144,8 +143,6 @@ struct tr_torrent {
     };
 
     using labels_t = std::vector<tr::shared_string>;
-
-    using VerifyDoneCallback = std::function<void(tr_torrent*)>;
 
     class VerifyMediator : public tr_verify_worker::Mediator
     {
@@ -1307,8 +1304,6 @@ private:
     //tr_stat stats_ = {};
 
     Error error_;
-
-    VerifyDoneCallback verify_done_callback_;
 
     // true iff the piece was verified more recently than any of the piece's
     // files' mtimes (file_mtimes_). If checked_pieces_.test(piece) is false,

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -22,6 +22,8 @@
 
 #include <gtest/gtest.h>
 
+#include <sigslot/signal.hpp>
+
 #include <libtransmission/transmission.h>
 
 #include <libtransmission/crypto-utils.h> // tr_base64_decode()
@@ -334,18 +336,15 @@ protected:
         auto verified_lock = std::unique_lock(verified_mutex_);
         auto const n_previously_verified = std::size(verified_);
 
-        ctor->set_verify_done_callback([this](tr_torrent* const tor) {
-            auto lambda_verified_lock = std::scoped_lock{ verified_mutex_ };
-            verified_.emplace_back(tor);
-            verified_cv_.notify_one();
-        });
-
         auto* const tor = tr_torrentNew(ctor, nullptr);
-        auto const stop_waiting = [this, tor, n_previously_verified]() {
-            return std::size(verified_) > n_previously_verified && verified_.back() == tor;
-        };
-
         EXPECT_NE(nullptr, tor);
+        if (tor == nullptr) {
+            return nullptr;
+        }
+
+        auto const stop_waiting = [this, tor_id = tor->id(), n_previously_verified]() {
+            return std::size(verified_) > n_previously_verified && verified_.back() == tor_id;
+        };
         verified_cv_.wait_for(verified_lock, 20s, stop_waiting);
         return tor;
     }
@@ -456,8 +455,8 @@ protected:
         auto verified_lock = std::unique_lock(verified_mutex_);
 
         auto const n_previously_verified = std::size(verified_);
-        auto const stop_waiting = [this, tor, n_previously_verified]() {
-            return std::size(verified_) > n_previously_verified && verified_.back() == tor;
+        auto const stop_waiting = [this, tor_id = tor->id(), n_previously_verified]() {
+            return std::size(verified_) > n_previously_verified && verified_.back() == tor_id;
         };
         tr_torrentVerify(tor);
         verified_cv_.wait_for(verified_lock, 20s, stop_waiting);
@@ -479,10 +478,19 @@ protected:
         SandboxedTest::SetUp();
 
         session_ = sessionInit(settings());
+
+        // Every torrent in this session reports here when it finishes verifying,
+        // so blockingTorrentVerify() can wait on any of them.
+        verify_done_tag_ = session_->verify_done_.connect_scoped([this](tr_torrent_id_t const tor_id) {
+            auto const lock = std::scoped_lock{ verified_mutex_ };
+            verified_.emplace_back(tor_id);
+            verified_cv_.notify_one();
+        });
     }
 
     void TearDown() override
     {
+        verify_done_tag_.disconnect();
         sessionClose(session_);
         session_ = nullptr;
         settings_.reset();
@@ -491,9 +499,10 @@ protected:
     }
 
 private:
+    sigslot::scoped_connection verify_done_tag_;
     std::mutex verified_mutex_;
     std::condition_variable verified_cv_;
-    std::vector<tr_torrent*> verified_;
+    std::vector<tr_torrent_id_t> verified_;
 };
 
 } // namespace tr::test


### PR DESCRIPTION
## Description

First in a series of two PRs to remove the C API for tr_ctor.

This first PR does a necessary refactor that's good in its own right, and which also unblocks making the constructor class public API. In order to go public, it needs to not `#include "libtransmission/torrent.h"`, which it currently does for the test-only verify-done callback. That callback was kind of a kludge to begin with, and it predates the sigslot depdendency. We can replace it with a tr_session signal that emits a `torrent_id_t` when a torrent finishes verifying. This is a lot cleaner than what we had before and helps to decouple `torrent-ctor.h` from `torrent.h`.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
