### PR TITLE
test: cover RpcQueue and RpcClient's error, auth, and session paths

### DIFF
--- a/tests/libtransmission-app/CMakeLists.txt
+++ b/tests/libtransmission-app/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(libtransmission-app-test
 		converter-tests.cc
 		prefs-test.cc
 		rpc-client-test.cc
+		rpc-queue-test.cc
 		session-test.cc
 		test-fixtures.h)
 

--- a/tests/libtransmission-app/rpc-client-test.cc
+++ b/tests/libtransmission-app/rpc-client-test.cc
@@ -33,11 +33,15 @@
 #include <libtransmission/net.h> // sockaddr_storage, ntohs()
 #include <libtransmission/quark.h>
 #include <libtransmission/rpcimpl.h> // TrRpcVersionSemver
+#include <libtransmission/transmission.h> // tr_sessionInit()
 #include <libtransmission/utils.h> // tr_lib_init()
+#include <libtransmission/variant.h>
 
 #include <libtransmission-app/rpc-client.h>
 
 #include <gtest/gtest.h>
+
+#include "test-fixtures.h"
 
 namespace api_compat = tr::api_compat;
 using tr::app::RpcClient;
@@ -58,8 +62,10 @@ auto constexpr SessionId = "test-session-id"sv;
 class MockRpcServer
 {
 public:
-    explicit MockRpcServer(bool advertise_tr5)
+    explicit MockRpcServer(bool advertise_tr5, bool require_auth = false, std::string body_override = {})
         : advertise_tr5_{ advertise_tr5 }
+        , require_auth_{ require_auth }
+        , body_override_{ std::move(body_override) }
         , base_{ event_base_new() }
         , http_{ evhttp_new(base_) }
     {
@@ -119,6 +125,12 @@ public:
         return user_agent_;
     }
 
+    [[nodiscard]] bool saw_authorization() const
+    {
+        auto const lock = std::lock_guard{ mutex_ };
+        return saw_authorization_;
+    }
+
 private:
     static void on_request(evhttp_request* req, void* vself)
     {
@@ -135,7 +147,11 @@ private:
         auto* const out_headers = evhttp_request_get_output_headers(req);
         auto* const out = evbuffer_new();
 
-        if (session_id == nullptr) {
+        if (require_auth_ && evhttp_find_header(in_headers, "Authorization") == nullptr) {
+            // challenge with Basic so libcurl knows how to retry with credentials
+            evhttp_add_header(out_headers, "WWW-Authenticate", "Basic realm=\"transmission\"");
+            evhttp_send_reply(req, 401, "Unauthorized", out);
+        } else if (session_id == nullptr) {
             // CSRF handshake: reject and hand back a session id to retry with.
             evhttp_add_header(out_headers, std::data(TrRpcSessionIdHeader), std::string{ SessionId }.c_str());
             if (advertise_tr5_) {
@@ -144,8 +160,9 @@ private:
             evhttp_send_reply(req, 409, "Conflict", out);
         } else {
             evhttp_add_header(out_headers, "Content-Type", "application/json");
-            static auto constexpr Body = R"({"result":{}})"sv;
-            evbuffer_add(out, std::data(Body), std::size(Body));
+            static auto constexpr Body = R"({"jsonrpc":"2.0","id":1,"result":{}})"sv;
+            auto const& body = std::empty(body_override_) ? std::string{ Body } : body_override_;
+            evbuffer_add(out, std::data(body), std::size(body));
             evhttp_send_reply(req, 200, "OK", out);
         }
 
@@ -163,6 +180,7 @@ private:
 
         auto const* const content_type = evhttp_find_header(in_headers, "Content-Type");
         auto const* const user_agent = evhttp_find_header(in_headers, "User-Agent");
+        auto const* const authorization = evhttp_find_header(in_headers, "Authorization");
 
         auto const lock = std::lock_guard{ mutex_ };
         bodies_.push_back(std::move(body));
@@ -172,11 +190,17 @@ private:
         if (user_agent != nullptr) {
             user_agent_ = user_agent;
         }
+        if (authorization != nullptr) {
+            saw_authorization_ = true;
+        }
     }
 
     bool advertise_tr5_;
+    bool require_auth_;
+    std::string body_override_;
 
     mutable std::mutex mutex_;
+    bool saw_authorization_ = false;
     std::vector<std::string> bodies_;
     std::string content_type_;
     std::string user_agent_;
@@ -359,6 +383,134 @@ TEST_F(AppRpcClientTest, staysTr4AfterA409WithoutTheVersionHeader)
     ASSERT_FALSE(std::empty(bodies));
     EXPECT_NE(std::string::npos, bodies.back().find(R"("method":"session-get")")) << bodies.back();
     EXPECT_EQ(std::string::npos, bodies.back().find("jsonrpc")) << bodies.back();
+}
+
+TEST_F(AppRpcClientTest, reportsNetworkErrorWhenServerIsUnreachable)
+{
+    // bind a port, then shut the server down so connecting to it fails
+    auto url_str = std::string{};
+    {
+        auto const server = MockRpcServer{ /*advertise_tr5=*/false };
+        url_str = url(server);
+    }
+
+    auto loop = UiLoop{};
+    auto client = RpcClient{ loop.marshaler() };
+    client.start(url_str);
+
+    auto network_response_status = long{ -1 };
+    auto network_response_message = std::string{};
+    auto const tag = client.network_response.connect_scoped([&](long const status, std::string_view const message) {
+        network_response_status = status;
+        network_response_message = std::string{ message };
+    });
+
+    auto const response = exec_and_wait(client, loop, TR_KEY_session_get);
+    EXPECT_TRUE(response.network_error);
+    EXPECT_FALSE(response.success);
+    EXPECT_EQ(0, response.http_status);
+    EXPECT_FALSE(std::empty(response.errmsg));
+
+    EXPECT_EQ(0, network_response_status);
+    EXPECT_EQ(response.errmsg, network_response_message);
+}
+
+TEST_F(AppRpcClientTest, signalsAuthRequiredOn401)
+{
+    auto server = MockRpcServer{ /*advertise_tr5=*/false, /*require_auth=*/true };
+    auto loop = UiLoop{};
+    auto client = RpcClient{ loop.marshaler() };
+    client.start(url(server));
+
+    auto auth_signals = 0;
+    auto const tag = client.auth_required.connect_scoped([&auth_signals]() { ++auth_signals; });
+
+    auto const response = exec_and_wait(client, loop, TR_KEY_session_get);
+    EXPECT_EQ(401, response.http_status);
+    EXPECT_FALSE(response.success);
+    EXPECT_FALSE(response.network_error);
+    EXPECT_EQ(1, auth_signals);
+}
+
+TEST_F(AppRpcClientTest, authenticatesWithSuppliedCredentials)
+{
+    auto server = MockRpcServer{ /*advertise_tr5=*/false, /*require_auth=*/true };
+    auto loop = UiLoop{};
+    auto client = RpcClient{ loop.marshaler() };
+    client.start(url(server), "alice", "sekrit");
+
+    auto const response = exec_and_wait(client, loop, TR_KEY_session_get);
+    EXPECT_EQ(200, response.http_status);
+    EXPECT_TRUE(response.success) << response.errmsg;
+    EXPECT_TRUE(server.saw_authorization());
+}
+
+TEST_F(AppRpcClientTest, reportsAnUnparseableBodyAsAnError)
+{
+    auto server = MockRpcServer{ /*advertise_tr5=*/false, /*require_auth=*/false, "this is not json" };
+    auto loop = UiLoop{};
+    auto client = RpcClient{ loop.marshaler() };
+    client.start(url(server));
+
+    auto const response = exec_and_wait(client, loop, TR_KEY_session_get);
+    EXPECT_EQ(200, response.http_status);
+    EXPECT_FALSE(response.success);
+    EXPECT_FALSE(response.network_error);
+    EXPECT_FALSE(std::empty(response.errmsg));
+}
+
+// exec against a real tr_session, exercising the tr_rpc_request_exec dispatch
+class AppRpcClientSessionTest : public SandboxedTest
+{
+protected:
+    void SetUp() override
+    {
+        auto settings = tr_sessionGetDefaultSettings();
+        for (auto const key : { TR_KEY_dht_enabled, TR_KEY_lpd_enabled, TR_KEY_port_forwarding_enabled, TR_KEY_utp_enabled }) {
+            settings.insert_or_assign(key, false);
+        }
+
+        session_ = tr_sessionInit(sandbox_dir(), false, settings);
+    }
+
+    void TearDown() override
+    {
+        tr_sessionClose(session_, 0.5);
+        session_ = nullptr;
+    }
+
+    tr_session* session_ = nullptr;
+};
+
+TEST_F(AppRpcClientSessionTest, execParsesSuccessResponse)
+{
+    auto loop = UiLoop{};
+    auto client = RpcClient{ loop.marshaler() };
+    client.start(session_);
+
+    auto const response = exec_and_wait(client, loop, TR_KEY_session_get);
+    EXPECT_TRUE(response.success);
+    EXPECT_FALSE(response.network_error);
+    EXPECT_EQ(200, response.http_status);
+    EXPECT_TRUE(std::empty(response.errmsg));
+
+    ASSERT_NE(nullptr, response.args);
+    auto const* const args = response.args->get_if<tr_variant::Map>();
+    ASSERT_NE(nullptr, args);
+    EXPECT_TRUE(args->contains(TR_KEY_version));
+}
+
+TEST_F(AppRpcClientSessionTest, execReportsAnUnknownMethodAsAnError)
+{
+    auto loop = UiLoop{};
+    auto client = RpcClient{ loop.marshaler() };
+    client.start(session_);
+
+    // any quark that isn't an RPC method name will do
+    auto const response = exec_and_wait(client, loop, TR_KEY_compact_view);
+    EXPECT_FALSE(response.success);
+    EXPECT_FALSE(response.network_error);
+    EXPECT_FALSE(std::empty(response.errmsg));
 }
 
 } // namespace

--- a/tests/libtransmission-app/rpc-queue-test.cc
+++ b/tests/libtransmission-app/rpc-queue-test.cc
@@ -1,0 +1,163 @@
+// This file Copyright © Mnemosaic LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosaic LLC.
+// License text can be found in the licenses/ folder.
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <libtransmission/variant.h>
+
+#include "libtransmission-app/rpc-client.h"
+#include "libtransmission-app/rpc-queue.h"
+
+namespace
+{
+
+using tr::app::RpcClient;
+using tr::app::RpcQueue;
+using tr::app::RpcResponse;
+
+[[nodiscard]] RpcResponse ok_response()
+{
+    auto ret = RpcResponse{};
+    ret.success = true;
+    return ret;
+}
+
+[[nodiscard]] RpcResponse error_response(std::string errmsg, bool const network_error = false)
+{
+    auto ret = RpcResponse{};
+    ret.success = false;
+    ret.network_error = network_error;
+    ret.errmsg = std::move(errmsg);
+    return ret;
+}
+
+TEST(AppRpcQueueTest, runsStepsInOrderAndForwardsResponses)
+{
+    auto events = std::vector<std::string>{};
+
+    RpcQueue::create()
+        .add([&events](RpcClient::ResponseFunc done) {
+            events.emplace_back("first");
+            auto response = ok_response();
+            response.args = std::make_shared<tr_variant>(int64_t{ 42 });
+            done(std::move(response));
+        })
+        .add([&events](RpcResponse const& prev, RpcClient::ResponseFunc done) {
+            events.emplace_back("second");
+            EXPECT_TRUE(prev.success);
+            ASSERT_NE(nullptr, prev.args);
+            EXPECT_EQ(prev.args->value_if<int64_t>(), 42);
+            done(ok_response());
+        })
+        .finally([&events]() { events.emplace_back("finally"); })
+        .run();
+
+    EXPECT_EQ((std::vector<std::string>{ "first", "second", "finally" }), events);
+}
+
+TEST(AppRpcQueueTest, acceptsAllFourStepShapes)
+{
+    auto events = std::vector<std::string>{};
+
+    // an auxiliary step (no `done` parameter) reports success implicitly,
+    // so the chain keeps running after it
+    RpcQueue::create()
+        .add([&events](RpcResponse const& /*prev*/, RpcClient::ResponseFunc done) {
+            events.emplace_back("request-with-prev");
+            done(ok_response());
+        })
+        .add([&events](RpcClient::ResponseFunc done) {
+            events.emplace_back("request");
+            done(ok_response());
+        })
+        .add([&events](RpcResponse const& /*prev*/) { events.emplace_back("aux-with-prev"); })
+        .add([&events]() { events.emplace_back("aux"); })
+        .finally([&events]() { events.emplace_back("finally"); })
+        .run();
+
+    EXPECT_EQ((std::vector<std::string>{ "request-with-prev", "request", "aux-with-prev", "aux", "finally" }), events);
+}
+
+TEST(AppRpcQueueTest, stepFailureRunsItsErrorHandlerAndStopsTheChain)
+{
+    auto events = std::vector<std::string>{};
+
+    RpcQueue::create()
+        .add(
+            [&events](RpcClient::ResponseFunc done) {
+                events.emplace_back("first");
+                done(error_response("boom"));
+            },
+            [&events](RpcResponse const& response) { events.emplace_back("handler:" + response.errmsg); })
+        .add([&events]() { events.emplace_back("second"); })
+        .finally([&events]() { events.emplace_back("finally"); })
+        .run();
+
+    EXPECT_EQ((std::vector<std::string>{ "first", "handler:boom", "finally" }), events);
+}
+
+TEST(AppRpcQueueTest, errorHandlerMayTakeNoArguments)
+{
+    auto handled = false;
+
+    RpcQueue::create()
+        .add([](RpcClient::ResponseFunc done) { done(error_response("boom")); }, [&handled]() { handled = true; })
+        .run();
+
+    EXPECT_TRUE(handled);
+}
+
+// A network error can't be handled by a step's error handler,
+// so it aborts the chain without calling one.
+TEST(AppRpcQueueTest, networkErrorSkipsTheErrorHandler)
+{
+    auto events = std::vector<std::string>{};
+
+    RpcQueue::create()
+        .add(
+            [&events](RpcClient::ResponseFunc done) {
+                events.emplace_back("first");
+                done(error_response("lost", /*network_error=*/true));
+            },
+            [&events](RpcResponse const& /*response*/) { events.emplace_back("handler"); })
+        .add([&events]() { events.emplace_back("second"); })
+        .finally([&events]() { events.emplace_back("finally"); })
+        .run();
+
+    EXPECT_EQ((std::vector<std::string>{ "first", "finally" }), events);
+}
+
+TEST(AppRpcQueueTest, finallyRunsOnAnEmptyQueue)
+{
+    auto ran = false;
+    RpcQueue::create().finally([&ran]() { ran = true; }).run();
+    EXPECT_TRUE(ran);
+}
+
+// The queue owns itself while running: a step may park its `done` continuation
+// and invoke it after run() has returned, e.g. when an RPC response arrives.
+TEST(AppRpcQueueTest, staysAliveUntilAParkedStepCompletes)
+{
+    auto parked = RpcClient::ResponseFunc{};
+    auto events = std::vector<std::string>{};
+
+    RpcQueue::create()
+        .add([&parked](RpcClient::ResponseFunc done) { parked = std::move(done); })
+        .add([&events]() { events.emplace_back("second"); })
+        .finally([&events]() { events.emplace_back("finally"); })
+        .run();
+
+    EXPECT_TRUE(std::empty(events)); // parked: the chain is waiting on `done`
+
+    parked(ok_response());
+    EXPECT_EQ((std::vector<std::string>{ "second", "finally" }), events);
+}
+
+} // namespace


### PR DESCRIPTION
## Description

Add test coverage for tr::app::RpcQueue chaining, per-step error handlers, network connection faiure, 401 auth_required without credentials, and unparseable responses,

No new production code; only tests. Tests by Claude.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
