### PR TITLE
refactor: move pref-to-session sync into tr::app::Session

### DIFF
--- a/libtransmission-app/prefs.cc
+++ b/libtransmission-app/prefs.cc
@@ -9,8 +9,10 @@
 
 #include <fmt/format.h>
 
+#include "libtransmission/log.h"
 #include "libtransmission/quark.h"
 #include "libtransmission/session-settings.h"
+#include "libtransmission/tr-assert.h"
 #include "libtransmission/transmission.h"
 
 #include "libtransmission-app/prefs.h"
@@ -85,8 +87,20 @@ void Prefs::save(std::string_view const config_dir, std::optional<tr::Settings> 
 
 void Prefs::set(tr_quark const key, tr_variant const& var)
 {
+    warn_if_unregistered(key);
+
     if (tr::serializer::set_from_variant(key, var, app_prefs_, session_prefs_)) {
         changed_(key);
     }
+}
+
+void Prefs::warn_if_unregistered(tr_quark const key)
+{
+    if (tr::serializer::has_key<AppPrefs>(key) || tr::serializer::has_key<SessionPrefs>(key)) {
+        return;
+    }
+
+    tr_logAddWarn(fmt::format("No pref is registered for key '{:s}'", tr_quark_get_string_view(key)));
+    TR_ASSERT_MSG(false, "no pref is registered for this key");
 }
 } // namespace tr::app

--- a/libtransmission-app/prefs.h
+++ b/libtransmission-app/prefs.h
@@ -35,7 +35,7 @@ namespace tr::app
  * Local application preferences
  *
  * These belong to this client and are always meaningful,
- * whether we run an in-process session or are connected to a remote one.
+ * whether the session is embedded or remote.
  */
 struct AppPrefs {
     template<auto MemberPtr>
@@ -285,6 +285,8 @@ public:
     template<typename T>
     void set(tr_quark const key, T const& val)
     {
+        warn_if_unregistered(key);
+
         if (tr::serializer::set(key, val, app_prefs_, session_prefs_)) {
             changed_(key);
         }
@@ -293,6 +295,8 @@ public:
     template<typename T>
     [[nodiscard]] T get(tr_quark const key) const
     {
+        warn_if_unregistered(key);
+
         if constexpr (std::is_same_v<T, tr_variant>) {
             return tr::serializer::to_variant(key, app_prefs_, session_prefs_).value_or(T{});
         } else {
@@ -312,6 +316,11 @@ public:
     }
 
 private:
+    // Getting a key with no field in AppPrefs or SessionPrefs yields a
+    // default-constructed value, and setting one is ignored; warn (and in
+    // debug builds, assert) so those calls surface as programming errors.
+    static void warn_if_unregistered(tr_quark key);
+
     mutable sigslot::signal<tr_quark> changed_;
     AppPrefs app_prefs_;
     SessionPrefs session_prefs_;

--- a/libtransmission-app/rpc-client.cc
+++ b/libtransmission-app/rpc-client.cc
@@ -89,7 +89,7 @@ void RpcClient::exec(tr_quark const method, tr_variant::Map args, ResponseFunc o
     auto req = build_request(method, std::move(args));
 
     if (session_ != nullptr) {
-        send_local_request(std::move(req), std::move(on_done));
+        send_embedded_request(std::move(req), std::move(on_done));
     } else if (!std::empty(url_)) {
         api_compat::convert(req, network_style_);
         auto body = tr_variant_serde::json().compact().to_string(req);
@@ -109,7 +109,7 @@ void RpcClient::exec(tr_quark const method, tr_variant* args, ResponseFunc on_do
     exec(method, tr_variant::Map{}, std::move(on_done));
 }
 
-void RpcClient::send_local_request(tr_variant&& req, ResponseFunc on_done)
+void RpcClient::send_embedded_request(tr_variant&& req, ResponseFunc on_done)
 {
     if (verbose_) {
         fmt::print("{:s}:{:d} sending req:\n{:s}\n", __FILE__, __LINE__, tr_variant_serde::json().to_string(req));

--- a/libtransmission-app/rpc-client.h
+++ b/libtransmission-app/rpc-client.h
@@ -28,11 +28,11 @@ struct RpcResponse {
     std::shared_ptr<tr_variant> args;
     bool success = false;
     bool network_error = false; // true if no valid HTTP response
-    long http_status = 0; // HTTP status, or 0 for no response, or 200 for local
+    long http_status = 0; // HTTP status, or 0 for no response, or 200 for embedded
 };
 
-// RPC client which speaks either to in-process session (tr_rpc_request_exec)
-// or to a remote (tr_web). Every response callback and signal is delivered
+// RPC client which speaks either to an embedded (in-process) session
+// (tr_rpc_request_exec) or to a remote one (tr_web). Every response callback and signal is delivered
 // on the UI thread by way of the injected `run_on_ui_thread` hook,
 // so callers never see the libtransmission or curl worker threads.
 class RpcClient
@@ -53,7 +53,7 @@ public:
     RpcClient& operator=(RpcClient&&) = delete;
     RpcClient& operator=(RpcClient const&) = delete;
 
-    // Use an in-process session
+    // Use an embedded session
     void start(tr_session* session) noexcept;
 
     // Use the remote server at `url` (scheme://host:port/path).
@@ -73,7 +73,7 @@ public:
     sigslot::signal<> data_send_progress;
 
 private:
-    void send_local_request(tr_variant&& req, ResponseFunc on_done);
+    void send_embedded_request(tr_variant&& req, ResponseFunc on_done);
     void send_remote_request(std::string body, ResponseFunc on_done);
 
     [[nodiscard]] tr_web& web();

--- a/libtransmission-app/session.cc
+++ b/libtransmission-app/session.cc
@@ -5,22 +5,136 @@
 
 #include "libtransmission-app/session.h"
 
+#include "libtransmission/log.h"
 #include "libtransmission/macros.h"
 #include "libtransmission/quark.h"
+#include "libtransmission/transmission.h"
+#include "libtransmission/variant.h"
 
 #include "libtransmission-app/prefs.h"
+#include "libtransmission-app/rpc-client.h"
 
 namespace tr::app
 {
 
-Session::Session(Prefs& prefs)
+Session::Session(Prefs& prefs, RpcClient& rpc)
     : prefs_{ prefs }
+    , rpc_{ rpc }
 {
     prefs_connection_ = prefs_.observe_changes([this](tr_quark const key) {
         if (key == TR_KEY_inhibit_desktop_hibernation) {
             update_sleep_inhibit();
         }
+
+        if (prefs_is_core(key) && !importing_settings_) {
+            sync_pref_to_session(key);
+        }
     });
+}
+
+void Session::sync_pref_to_session(tr_quark const key)
+{
+    auto* const embedded = embedded_session_;
+
+    switch (key) {
+    // For security reasons, the RPC server's own settings can't be changed
+    // via RPC, so apply them directly when the session is embedded.
+    case TR_KEY_rpc_authentication_required:
+        if (embedded != nullptr) {
+            tr_sessionSetRPCPasswordEnabled(embedded, prefs_.get<bool>(key));
+        }
+        break;
+
+    case TR_KEY_rpc_enabled:
+        if (embedded != nullptr) {
+            tr_sessionSetRPCEnabled(embedded, prefs_.get<bool>(key));
+        }
+        break;
+
+    case TR_KEY_rpc_password:
+        if (embedded != nullptr) {
+            tr_sessionSetRPCPassword(embedded, prefs_.get<std::string>(key));
+        }
+        break;
+
+    case TR_KEY_rpc_port:
+        if (embedded != nullptr) {
+            tr_sessionSetRPCPort(embedded, static_cast<uint16_t>(prefs_.get<int>(key)));
+        }
+        break;
+
+    case TR_KEY_rpc_username:
+        if (embedded != nullptr) {
+            tr_sessionSetRPCUsername(embedded, prefs_.get<std::string>(key));
+        }
+        break;
+
+    case TR_KEY_rpc_whitelist:
+        if (embedded != nullptr) {
+            tr_sessionSetRPCWhitelist(embedded, prefs_.get<std::string>(key));
+        }
+        break;
+
+    case TR_KEY_rpc_whitelist_enabled:
+        if (embedded != nullptr) {
+            tr_sessionSetRPCWhitelistEnabled(embedded, prefs_.get<bool>(key));
+        }
+        break;
+
+    // The log level applies to this process's logger, not the session,
+    // so there is nothing to send over RPC.
+    case TR_KEY_message_level:
+        tr_logSetLevel(prefs_.get<tr_log_level>(key));
+        break;
+
+    default:
+        {
+            auto params = tr_variant::Map{ 1U };
+            params.insert_or_assign(key, prefs_.get<tr_variant>(key));
+            rpc_.exec(TR_KEY_session_set, std::move(params), {});
+
+            if (key == TR_KEY_download_dir) {
+                session_refresh_needed();
+            }
+        }
+        break;
+    }
+}
+
+void Session::import_session_settings(tr_variant::Map const& settings)
+{
+    importing_settings_ = true;
+
+    for (auto const& [key, value] : settings) {
+        if (prefs_is_core(key)) {
+            prefs_.set(key, value);
+        }
+    }
+
+    // For security reasons, the RPC server's own settings aren't in
+    // `session_get` responses; read them directly when the session is embedded.
+    if (auto* const embedded = embedded_session_; embedded != nullptr) {
+        prefs_.set(TR_KEY_rpc_authentication_required, tr_sessionIsRPCPasswordEnabled(embedded));
+        prefs_.set(TR_KEY_rpc_enabled, tr_sessionIsRPCEnabled(embedded));
+        prefs_.set(TR_KEY_rpc_password, tr_sessionGetRPCPassword(embedded));
+        // int, not uint16_t: Converter<uint16_t> is tr_mode_t's octal-string
+        // converter, which an integral pref field would silently reject
+        prefs_.set(TR_KEY_rpc_port, static_cast<int>(tr_sessionGetRPCPort(embedded)));
+        prefs_.set(TR_KEY_rpc_username, tr_sessionGetRPCUsername(embedded));
+        prefs_.set(TR_KEY_rpc_whitelist, tr_sessionGetRPCWhitelist(embedded));
+        prefs_.set(TR_KEY_rpc_whitelist_enabled, tr_sessionGetRPCWhitelistEnabled(embedded));
+    }
+
+    importing_settings_ = false;
+}
+
+std::optional<tr::Settings> Session::embedded_settings() const
+{
+    if (embedded_session_ != nullptr) {
+        return tr_sessionGetSettings(embedded_session_);
+    }
+
+    return {};
 }
 
 void Session::set_session_type(std::optional<Type> const type)

--- a/libtransmission-app/session.h
+++ b/libtransmission-app/session.h
@@ -12,22 +12,28 @@
 
 #include <woke/woke.hpp>
 
+#include "libtransmission/quark.h"
+#include "libtransmission/variant.h"
+
+struct tr_session;
+
 namespace tr::app
 {
 
 class Prefs;
+class RpcClient;
 
 class Session
 {
 public:
     // How the app reaches its `tr_session`:
     enum class Type : uint8_t {
-        InProcess, // the session runs inside this process
+        Embedded, // the session runs inside this process
         Local, // a separate daemon process on this machine
         Remote, // a daemon on another machine
     };
 
-    explicit Session(Prefs& prefs);
+    Session(Prefs& prefs, RpcClient& rpc);
     Session(Session&&) = delete;
     Session(Session const&) = delete;
     Session& operator=(Session&&) = delete;
@@ -42,19 +48,47 @@ public:
     // keep the machine awake: a local-filesystem session with active transfers
     [[nodiscard]] bool should_inhibit_sleep() const;
 
+    // returns true iff the session runs inside this process
+    [[nodiscard]] constexpr bool is_embedded() const noexcept
+    {
+        return session_type_ == Type::Embedded;
+    }
+
     // keep this process un-throttled: only when it hosts the session itself
     [[nodiscard]] bool should_inhibit_nap() const noexcept
     {
-        return session_type_ == Type::InProcess;
+        return is_embedded();
     }
+
+    // Copy the session's settings, e.g. a `session_get` response, into Prefs
+    // without echoing them back to the session. Also refreshes the RPC
+    // server settings, which for security reasons are only readable from
+    // an embedded session.
+    void import_session_settings(tr_variant::Map const& settings);
+
+    // The embedded session's settings, e.g. for `Prefs::save()`;
+    // nullopt when there is no embedded session.
+    [[nodiscard]] std::optional<tr::Settings> embedded_settings() const;
+
+    // Fired after syncing a pref whose change invalidates other session info,
+    // e.g. changing `download_dir` changes `session_get`'s freespace argument.
+    sigslot::signal<> session_refresh_needed;
 
 protected:
     void set_session_type(std::optional<Type> type);
     void set_has_busy_torrents(bool has_busy);
 
+    // The embedded session, or nullptr when there isn't one. Some settings,
+    // e.g. the RPC server's, can only be applied to an embedded session.
+    void set_embedded_session(tr_session* session) noexcept
+    {
+        embedded_session_ = session;
+    }
+
 private:
     void update_sleep_inhibit();
     void update_nap_inhibit();
+    void sync_pref_to_session(tr_quark key);
 
     [[nodiscard]] bool is_local_filesystem() const noexcept
     {
@@ -62,10 +96,13 @@ private:
     }
 
     Prefs& prefs_;
+    RpcClient& rpc_;
+    tr_session* embedded_session_ = nullptr;
     woke::SleepInhibitor sleep_inhibitor_;
     woke::NapInhibitor nap_inhibitor_;
     std::optional<Type> session_type_;
     bool has_busy_torrents_ = false;
+    bool importing_settings_ = false;
     sigslot::scoped_connection prefs_connection_;
 };
 

--- a/qt/AboutDialog.cc
+++ b/qt/AboutDialog.cc
@@ -26,7 +26,7 @@ AboutDialog::AboutDialog(Session& session, QWidget* parent)
 
     ui_.iconLabel->setPixmap(QApplication::windowIcon().pixmap(48));
 
-    if (session.isServer()) {
+    if (session.is_embedded()) {
         auto const title = QStringLiteral("<b style='font-size:x-large'>" TR_PROJ_APPNAME_CAPITALIZED " %1</b>")
                                .arg(QStringLiteral(LONG_VERSION_STRING));
         ui_.titleLabel->setText(title);

--- a/qt/Application.cc
+++ b/qt/Application.cc
@@ -435,9 +435,9 @@ void Application::addTorrent(AddData addme) const
 
 // ---
 
-std::optional<tr::Settings> Application::local_session_settings() const
+std::optional<tr::Settings> Application::embedded_session_settings() const
 {
-    return session_->local_settings();
+    return session_->embedded_settings();
 }
 
 // ---

--- a/qt/Application.h
+++ b/qt/Application.h
@@ -62,7 +62,7 @@ public:
 
     QString intern(QString const& in);
 
-    [[nodiscard]] std::optional<tr::Settings> local_session_settings() const;
+    [[nodiscard]] std::optional<tr::Settings> embedded_session_settings() const;
 
     [[nodiscard]] QPixmap find_favicon(QString const& sitename) const
     {

--- a/qt/MainWindow.cc
+++ b/qt/MainWindow.cc
@@ -269,7 +269,7 @@ void MainWindow::onSessionSourceChanged()
 {
     model_.clear();
 
-    if (session_.isServer()) {
+    if (session_.is_embedded()) {
         updateNetworkLabel();
         ui_.networkLabel->show();
         network_timer_.start(1000);

--- a/qt/Prefs.h
+++ b/qt/Prefs.h
@@ -41,11 +41,6 @@ public:
     Prefs& operator=(Prefs const&) = delete;
     ~Prefs() override = default;
 
-    [[nodiscard]] static constexpr bool isCore(tr_quark const key)
-    {
-        return tr::app::prefs_is_core(key);
-    }
-
 signals:
     void changed(tr_quark key);
 

--- a/qt/PrefsDialog.cc
+++ b/qt/PrefsDialog.cc
@@ -588,7 +588,7 @@ PrefsDialog::PrefsDialog(Session& session, Prefs& prefs, QWidget* parent)
     : BaseDialog{ parent }
     , session_{ session }
     , prefs_{ prefs }
-    , is_server_{ session.isServer() }
+    , is_embedded_{ session.is_embedded() }
     , is_local_fs_{ session_.isLocalFilesystem() }
 {
     ui_.setupUi(this);
@@ -617,7 +617,7 @@ PrefsDialog::PrefsDialog(Session& session, Prefs& prefs, QWidget* parent)
 
     // if it's a remote session, disable the preferences
     // that don't work in remote sessions
-    if (!is_server_) {
+    if (!is_embedded_) {
         for (QWidget* const w : unsupported_when_remote_) {
             w->setToolTip(tr("Not supported by remote sessions"));
             w->setEnabled(false);

--- a/qt/PrefsDialog.h
+++ b/qt/PrefsDialog.h
@@ -90,7 +90,7 @@ private:
 
     Ui::PrefsDialog ui_ = {};
 
-    bool const is_server_;
+    bool const is_embedded_;
     bool is_local_fs_ = {};
     std::array<PortTestStatus, Session::NUM_PORT_TEST_IP_PROTOCOL> port_test_status_ = {};
 

--- a/qt/RpcClient.h
+++ b/qt/RpcClient.h
@@ -44,6 +44,11 @@ public:
         return url_;
     }
 
+    [[nodiscard]] constexpr tr::app::RpcClient& impl() noexcept
+    {
+        return impl_;
+    }
+
     void stop();
     void start(tr_session* session);
     void start(QUrl const& url);

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -53,13 +53,6 @@ using ::trqt::variant_helpers::dictFind;
 ****
 ***/
 
-void Session::sessionSet(tr_quark const key, tr_variant val)
-{
-    auto params = tr_variant::Map{ 1U };
-    params.insert_or_assign(key, std::move(val));
-    exec(TR_KEY_session_set, std::move(params));
-}
-
 void Session::portTest(Session::PortTestIpProtocol const ip_protocol)
 {
     static auto constexpr IpStr = std::array{ "ipv4"sv, "ipv6"sv };
@@ -123,127 +116,17 @@ void Session::copyMagnetLinkToClipboard(int torrent_id)
         .run();
 }
 
-void Session::updatePref(tr_quark key)
-{
-    if (Prefs::isCore(key)) {
-        switch (key) {
-        case TR_KEY_alt_speed_down:
-        case TR_KEY_alt_speed_enabled:
-        case TR_KEY_alt_speed_time_begin:
-        case TR_KEY_alt_speed_time_day:
-        case TR_KEY_alt_speed_time_enabled:
-        case TR_KEY_alt_speed_time_end:
-        case TR_KEY_alt_speed_up:
-        case TR_KEY_blocklist_enabled:
-        case TR_KEY_blocklist_updates_enabled:
-        case TR_KEY_blocklist_url:
-        case TR_KEY_default_trackers:
-        case TR_KEY_dht_enabled:
-        case TR_KEY_download_queue_enabled:
-        case TR_KEY_download_queue_size:
-        case TR_KEY_speed_limit_down:
-        case TR_KEY_speed_limit_down_enabled:
-        case TR_KEY_encryption:
-        case TR_KEY_idle_seeding_limit:
-        case TR_KEY_idle_seeding_limit_enabled:
-        case TR_KEY_incomplete_dir:
-        case TR_KEY_incomplete_dir_enabled:
-        case TR_KEY_lpd_enabled:
-        case TR_KEY_peer_limit_global:
-        case TR_KEY_peer_limit_per_torrent:
-        case TR_KEY_peer_port:
-        case TR_KEY_peer_port_random_on_start:
-        case TR_KEY_queue_stalled_minutes:
-        case TR_KEY_pex_enabled:
-        case TR_KEY_port_forwarding_enabled:
-        case TR_KEY_rename_partial_files:
-        case TR_KEY_script_torrent_done_enabled:
-        case TR_KEY_script_torrent_done_filename:
-        case TR_KEY_script_torrent_done_seeding_enabled:
-        case TR_KEY_script_torrent_done_seeding_filename:
-        case TR_KEY_start_added_torrents:
-        case TR_KEY_trash_original_torrent_files:
-        case TR_KEY_seed_ratio_limit:
-        case TR_KEY_seed_ratio_limited:
-        case TR_KEY_speed_limit_up:
-        case TR_KEY_speed_limit_up_enabled:
-        case TR_KEY_utp_enabled:
-        case TR_KEY_torrent_complete_verify_enabled:
-            sessionSet(key, prefs_.get<tr_variant>(key));
-            break;
-
-        case TR_KEY_download_dir:
-            // this will change the 'freespace' argument, so refresh
-            sessionSet(key, prefs_.get<tr_variant>(key));
-            refreshSessionInfo();
-            break;
-
-        case TR_KEY_rpc_authentication_required:
-            if (session_ != nullptr) {
-                tr_sessionSetRPCPasswordEnabled(session_, prefs_.get<bool>(key));
-            }
-
-            break;
-
-        case TR_KEY_rpc_enabled:
-            if (session_ != nullptr) {
-                tr_sessionSetRPCEnabled(session_, prefs_.get<bool>(key));
-            }
-
-            break;
-
-        case TR_KEY_rpc_password:
-            if (session_ != nullptr) {
-                tr_sessionSetRPCPassword(session_, prefs_.get<QString>(key).toStdString());
-            }
-
-            break;
-
-        case TR_KEY_rpc_port:
-            if (session_ != nullptr) {
-                tr_sessionSetRPCPort(session_, static_cast<uint16_t>(prefs_.get<int>(key)));
-            }
-
-            break;
-
-        case TR_KEY_rpc_username:
-            if (session_ != nullptr) {
-                tr_sessionSetRPCUsername(session_, prefs_.get<QString>(key).toStdString());
-            }
-
-            break;
-
-        case TR_KEY_rpc_whitelist_enabled:
-            if (session_ != nullptr) {
-                tr_sessionSetRPCWhitelistEnabled(session_, prefs_.get<bool>(key));
-            }
-
-            break;
-
-        case TR_KEY_rpc_whitelist:
-            if (session_ != nullptr) {
-                tr_sessionSetRPCWhitelist(session_, prefs_.get<QString>(key).toStdString());
-            }
-
-            break;
-
-        default:
-            qWarning() << "unhandled pref:" << static_cast<int>(key);
-        }
-    }
-}
-
 /***
 ****
 ***/
 
 Session::Session(QString config_dir, Prefs& prefs, RpcClient& rpc)
-    : tr::app::Session{ prefs }
+    : tr::app::Session{ prefs, rpc.impl() }
     , config_dir_{ std::move(config_dir) }
     , prefs_{ prefs }
     , rpc_{ rpc }
 {
-    connect(&prefs_, qOverload<tr_quark>(&Prefs::changed), this, &Session::updatePref);
+    session_refresh_tag_ = session_refresh_needed.connect_scoped([this]() { refreshSessionInfo(); });
     connect(&rpc_, &RpcClient::httpAuthenticationRequired, this, &Session::httpAuthenticationRequired);
     connect(&rpc_, &RpcClient::dataReadProgress, this, &Session::dataReadProgress);
     connect(&rpc_, &RpcClient::dataSendProgress, this, &Session::dataSendProgress);
@@ -267,6 +150,7 @@ void Session::stop()
     rpc_.stop();
 
     if (session_ != nullptr) {
+        set_embedded_session(nullptr);
         tr_sessionClose(session_);
         session_ = nullptr;
     }
@@ -306,6 +190,7 @@ void Session::start()
         auto config_dir = config_dir_.toStdString();
         auto const settings = tr_sessionLoadSettings(config_dir);
         session_ = tr_sessionInit(config_dir, true, settings);
+        set_embedded_session(session_);
         updateType();
 
         rpc_.start(session_);
@@ -733,27 +618,8 @@ void Session::updateStats(tr_variant* dict)
 
 void Session::updateInfo(tr_variant* args_dict)
 {
-    disconnect(&prefs_, qOverload<tr_quark>(&Prefs::changed), this, &Session::updatePref);
-
     if (auto const* const settings = args_dict->get_if<tr_variant::Map>(); settings != nullptr) {
-        for (auto const& [key, value] : *settings) {
-            if (!Prefs::isCore(key)) {
-                continue;
-            }
-
-            prefs_.set(key, value);
-        }
-    }
-
-    /* Use the C API to get settings that, for security reasons, aren't supported by RPC */
-    if (session_ != nullptr) {
-        prefs_.set(TR_KEY_rpc_enabled, tr_sessionIsRPCEnabled(session_));
-        prefs_.set(TR_KEY_rpc_authentication_required, tr_sessionIsRPCPasswordEnabled(session_));
-        prefs_.set(TR_KEY_rpc_password, QString::fromStdString(tr_sessionGetRPCPassword(session_)));
-        prefs_.set(TR_KEY_rpc_port, tr_sessionGetRPCPort(session_));
-        prefs_.set(TR_KEY_rpc_username, QString::fromStdString(tr_sessionGetRPCUsername(session_)));
-        prefs_.set(TR_KEY_rpc_whitelist_enabled, tr_sessionGetRPCWhitelistEnabled(session_));
-        prefs_.set(TR_KEY_rpc_whitelist, QString::fromStdString(tr_sessionGetRPCWhitelist(session_)));
+        import_session_settings(*settings);
     }
 
     if (auto const size = dictFind<int>(args_dict, TR_KEY_blocklist_size); size && *size != blocklistSize()) {
@@ -769,8 +635,6 @@ void Session::updateInfo(tr_variant* args_dict)
     }
 
     updateType(dictFind<std::string>(args_dict, TR_KEY_session_id));
-
-    connect(&prefs_, qOverload<tr_quark>(&Prefs::changed), this, &Session::updatePref);
 
     emit sessionUpdated();
 }
@@ -930,7 +794,7 @@ void Session::launchWebInterface() const
         auto const root_path = prefs_.get<QString>(TR_KEY_remote_session_url_base_path);
         auto const relative_path = TrHttpServerWebRelativePath;
         url.setPath(root_path + Utils::qstringFromUtf8(relative_path));
-    } else // local session
+    } else // embedded session
     {
         url.setScheme(QStringLiteral("http"));
         url.setHost(QStringLiteral("localhost"));
@@ -938,17 +802,6 @@ void Session::launchWebInterface() const
     }
 
     QDesktopServices::openUrl(url);
-}
-
-// ---
-
-std::optional<tr::Settings> Session::local_settings() const
-{
-    if (session_) {
-        return tr_sessionGetSettings(session_);
-    }
-
-    return {};
 }
 
 /// ---
@@ -959,7 +812,7 @@ namespace
 std::optional<Session::Type> computeType(tr_session const* const session, std::optional<std::string> const& session_id)
 {
     if (session != nullptr) {
-        return Session::Type::InProcess;
+        return Session::Type::Embedded;
     }
 
     if (session_id) {

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -13,6 +13,8 @@
 #include <string>
 #include <type_traits>
 
+#include <sigslot/signal.hpp>
+
 #include <QtCore/QObject>
 #include <QtCore/QString>
 #include <QtCore/QTimer>
@@ -53,8 +55,6 @@ public:
     void stop();
     void restart();
 
-    [[nodiscard]] std::optional<tr::Settings> local_settings() const;
-
     [[nodiscard]] constexpr auto const& getRemoteUrl() const noexcept
     {
         return rpc_.url();
@@ -89,13 +89,7 @@ public:
 
     [[nodiscard]] bool portTestPending(PortTestIpProtocol ip_protocol) const noexcept;
 
-    // returns true iff the session is in-process
-    [[nodiscard]] constexpr bool isServer() const noexcept
-    {
-        return type() == Type::InProcess;
-    }
-
-    // returns true iff the session is in-process or known to be on this system
+    // returns true iff the session is embedded or known to be on this system
     [[nodiscard]] constexpr bool isLocalFilesystem() const noexcept
     {
         return type().value_or(Type::Remote) != Type::Remote;
@@ -139,7 +133,6 @@ public slots:
     void refreshSessionInfo();
     void refreshSessionStats();
     void removeTorrents(torrent_ids_t const& torrent_ids, bool delete_files = false);
-    void updatePref(tr_quark key);
 
 signals:
     void sourceChanged();
@@ -203,7 +196,6 @@ private:
     void updateType(std::optional<std::string> session_id = {});
 
     Tag torrentSetImpl(tr_variant::Map params);
-    void sessionSet(tr_quark key, tr_variant val);
     void sendTorrentRequest(tr_quark method, torrent_ids_t const& torrent_ids);
     void refreshTorrents(torrent_ids_t const& ids, TorrentProperties props);
 
@@ -220,6 +212,9 @@ private:
     QString session_version_;
     RpcClient& rpc_;
     Tag next_tag_ = {};
+
+    // changing some prefs (eg download_dir) invalidates cached session info
+    sigslot::scoped_connection session_refresh_tag_;
 
     static inline torrent_ids_t const RecentlyActiveIDs = { -1 };
 

--- a/qt/main.cc
+++ b/qt/main.cc
@@ -284,7 +284,7 @@ int tr_main(int argc, char** argv)
     auto const ret = QApplication::exec();
 
     // save prefs before exiting
-    prefs.save(config_dir.toStdString(), app.local_session_settings());
+    prefs.save(config_dir.toStdString(), app.embedded_session_settings());
 
     return ret;
 }

--- a/tests/libtransmission-app/prefs-test.cc
+++ b/tests/libtransmission-app/prefs-test.cc
@@ -16,6 +16,7 @@
 
 #include <libtransmission/quark.h>
 #include <libtransmission/session-settings.h> // tr::is_settings_key()
+#include <libtransmission/tr-assert.h> // TR_ENABLE_ASSERTS
 #include <libtransmission/transmission.h> // tr_encryption_mode, tr_sessionGetDefaultSettings()
 #include <libtransmission/variant.h>
 
@@ -211,14 +212,19 @@ TEST_F(PrefsTest, getSetRoundTripsDate)
     expect_sys_seconds_eq(prefs.get<std::chrono::sys_seconds>(TR_KEY_blocklist_date), b);
 }
 
-TEST_F(PrefsTest, getReturnsDefaultForUnknownKey)
+TEST_F(PrefsTest, getFailsLoudlyForUnregisteredKey)
 {
     auto const prefs = TestPrefs{};
 
-    // TR_KEY_reqq is a session-settings key but not a `Prefs` field, so it is
-    // absent and `get()` should fall back to a value-initialized result.
+    // TR_KEY_reqq is a session-settings key but not a `Prefs` field, so
+    // using it is a programming error: fatal in debug builds, a logged
+    // warning plus a value-initialized fallback otherwise.
+#ifdef TR_ENABLE_ASSERTS
+    EXPECT_DEATH((void)prefs.get<int>(TR_KEY_reqq), "registered");
+#else
     EXPECT_EQ(prefs.get<int>(TR_KEY_reqq), 0);
     EXPECT_EQ(prefs.get<std::string>(TR_KEY_reqq), std::string{});
+#endif
 }
 
 TEST_F(PrefsTest, getAsVariantReturnsUnderlyingValue)

--- a/tests/libtransmission-app/session-test.cc
+++ b/tests/libtransmission-app/session-test.cc
@@ -3,33 +3,76 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include <chrono>
+#include <functional>
+#include <string>
+#include <thread>
+
 #include <gtest/gtest.h>
 
+#include <libtransmission/log.h>
 #include <libtransmission/quark.h>
+#include <libtransmission/transmission.h>
+#include <libtransmission/variant.h>
 
 #include "libtransmission-app/prefs.h"
+#include "libtransmission-app/rpc-client.h"
 #include "libtransmission-app/session.h"
+
+#include "test-fixtures.h"
 
 namespace
 {
 
+using namespace std::literals;
 using namespace tr::app;
 
-// exposes the protected setters so the test can drive the two inputs directly
+// Run RpcClient continuations inline. These tests poll for observable
+// side effects, so they don't need a UI-thread event loop.
+[[nodiscard]] RpcClient::UiThreadFunc inline_marshaler()
+{
+    return [](std::function<void()> fn) {
+        fn();
+    };
+}
+
+// exposes the protected setters so the test can drive the inputs directly
 class TestSession : public Session
 {
 public:
     using Session::Session;
+    using Session::set_embedded_session;
     using Session::set_has_busy_torrents;
     using Session::set_session_type;
 };
 
+// Poll for a condition; RPC dispatch and session setters land asynchronously
+// on the session thread.
+template<typename Pred>
+[[nodiscard]] bool wait_for(Pred pred, std::chrono::milliseconds const timeout = 10'000ms)
+{
+    auto const deadline = std::chrono::steady_clock::now() + timeout;
+
+    for (;;) {
+        if (pred()) {
+            return true;
+        }
+
+        if (std::chrono::steady_clock::now() >= deadline) {
+            return false;
+        }
+
+        std::this_thread::sleep_for(5ms);
+    }
+}
+
 TEST(AppSessionTest, inhibitsSleepOnlyWhenLocalActiveAndEnabled)
 {
+    auto rpc = RpcClient{ inline_marshaler() };
     auto prefs = Prefs{};
     prefs.set(TR_KEY_inhibit_desktop_hibernation, true);
 
-    auto session = TestSession{ prefs };
+    auto session = TestSession{ prefs, rpc };
     EXPECT_FALSE(session.should_inhibit_sleep()); // unknown type, nothing active
 
     session.set_session_type(Session::Type::Local); // a local daemon
@@ -56,14 +99,15 @@ TEST(AppSessionTest, inhibitsSleepOnlyWhenLocalActiveAndEnabled)
 
 // App Nap should be inhibited only when the session runs in THIS process; a
 // remote-control UI (local or remote daemon) can be throttled while idle.
-TEST(AppSessionTest, inhibitsNapOnlyForInProcessSession)
+TEST(AppSessionTest, inhibitsNapOnlyForEmbeddedSession)
 {
+    auto rpc = RpcClient{ inline_marshaler() };
     auto prefs = Prefs{};
-    auto session = TestSession{ prefs };
+    auto session = TestSession{ prefs, rpc };
 
     EXPECT_FALSE(session.should_inhibit_nap()); // unknown type
 
-    session.set_session_type(Session::Type::InProcess);
+    session.set_session_type(Session::Type::Embedded);
     EXPECT_TRUE(session.should_inhibit_nap()); // we host the session
 
     session.set_session_type(Session::Type::Local);
@@ -71,6 +115,177 @@ TEST(AppSessionTest, inhibitsNapOnlyForInProcessSession)
 
     session.set_session_type(Session::Type::Remote);
     EXPECT_FALSE(session.should_inhibit_nap()); // remote daemon
+}
+
+// Changing a pref that invalidates cached session info, e.g. download_dir
+// changing session_get's freespace argument, should request a refresh.
+TEST(AppSessionTest, changingDownloadDirRequestsSessionRefresh)
+{
+    auto rpc = RpcClient{ inline_marshaler() };
+    auto prefs = Prefs{};
+    auto session = TestSession{ prefs, rpc };
+
+    auto refreshes = 0;
+    auto const tag = session.session_refresh_needed.connect_scoped([&refreshes]() { ++refreshes; });
+
+    prefs.set(TR_KEY_download_dir, "/some/new/dir"s);
+    EXPECT_EQ(1, refreshes);
+
+    prefs.set(TR_KEY_compact_view, true); // an app pref; not session-facing
+    EXPECT_EQ(1, refreshes);
+}
+
+// message_level applies to this process's logger rather than being
+// sent over RPC, so it works without any session at all.
+TEST(AppSessionTest, appliesMessageLevelToTheProcessLogger)
+{
+    auto rpc = RpcClient{ inline_marshaler() };
+    auto prefs = Prefs{};
+    auto session = TestSession{ prefs, rpc };
+
+    auto const old_level = tr_logGetLevel();
+    auto const new_level = old_level == TR_LOG_DEBUG ? TR_LOG_INFO : TR_LOG_DEBUG;
+
+    prefs.set(TR_KEY_message_level, new_level);
+    EXPECT_EQ(new_level, tr_logGetLevel());
+
+    tr_logSetLevel(old_level);
+}
+
+// Importing only covers the session's own settings; an app pref that
+// happens to be in the imported map must be left alone.
+TEST(AppSessionTest, importingSettingsIgnoresAppPrefs)
+{
+    auto rpc = RpcClient{ inline_marshaler() };
+    auto prefs = Prefs{};
+    auto session = TestSession{ prefs, rpc };
+
+    auto const old_statusbar = prefs.get<bool>(TR_KEY_show_statusbar);
+
+    auto settings = tr_variant::Map{ 2U };
+    settings.insert_or_assign(TR_KEY_show_statusbar, !old_statusbar);
+    settings.insert_or_assign(TR_KEY_peer_limit_global, 123);
+    session.import_session_settings(settings);
+
+    EXPECT_EQ(old_statusbar, prefs.get<bool>(TR_KEY_show_statusbar));
+    EXPECT_EQ(123U, prefs.get<size_t>(TR_KEY_peer_limit_global));
+}
+
+// Sync tests against a real embedded session.
+class AppSessionSyncTest : public SandboxedTest
+{
+protected:
+    void SetUp() override
+    {
+        auto settings = tr_sessionGetDefaultSettings();
+        for (auto const key : { TR_KEY_dht_enabled, TR_KEY_lpd_enabled, TR_KEY_port_forwarding_enabled, TR_KEY_utp_enabled }) {
+            settings.insert_or_assign(key, false);
+        }
+
+        session_ = tr_sessionInit(sandbox_dir(), false, settings);
+    }
+
+    void TearDown() override
+    {
+        tr_sessionClose(session_, 0.5);
+        session_ = nullptr;
+    }
+
+    tr_session* session_ = nullptr;
+};
+
+TEST_F(AppSessionSyncTest, syncsCorePrefsToTheSessionOverRpc)
+{
+    auto rpc = RpcClient{ inline_marshaler() };
+    rpc.start(session_);
+
+    auto prefs = Prefs{};
+    auto session = TestSession{ prefs, rpc };
+
+    auto const new_limit = size_t{ 111 };
+    ASSERT_NE(new_limit, tr_sessionGetPeerLimit(session_));
+
+    prefs.set(TR_KEY_peer_limit_global, new_limit);
+    EXPECT_TRUE(wait_for([this, new_limit]() { return tr_sessionGetPeerLimit(session_) == new_limit; }));
+}
+
+TEST_F(AppSessionSyncTest, appliesRpcServerPrefsWithTheCApi)
+{
+    auto rpc = RpcClient{ inline_marshaler() };
+    rpc.start(session_);
+
+    auto prefs = Prefs{};
+    auto session = TestSession{ prefs, rpc };
+    session.set_embedded_session(session_);
+
+    auto const new_port = 54321;
+    ASSERT_NE(new_port, tr_sessionGetRPCPort(session_));
+    prefs.set(TR_KEY_rpc_port, new_port);
+    EXPECT_TRUE(wait_for([this, new_port]() { return tr_sessionGetRPCPort(session_) == new_port; }));
+
+    prefs.set(TR_KEY_rpc_username, "alice"s);
+    EXPECT_TRUE(wait_for([this]() { return tr_sessionGetRPCUsername(session_) == "alice"; }));
+}
+
+TEST_F(AppSessionSyncTest, importingSettingsDoesNotEchoBackToTheSession)
+{
+    auto rpc = RpcClient{ inline_marshaler() };
+    rpc.start(session_);
+
+    auto prefs = Prefs{};
+    auto session = TestSession{ prefs, rpc };
+    session.set_embedded_session(session_);
+
+    auto const session_limit = uint16_t{ 99 };
+    tr_sessionSetPeerLimit(session_, session_limit);
+    ASSERT_TRUE(wait_for([this, session_limit]() { return tr_sessionGetPeerLimit(session_) == session_limit; }));
+
+    // an imported value lands in prefs but must not be pushed to the session
+    auto settings = tr_variant::Map{ 1U };
+    settings.insert_or_assign(TR_KEY_peer_limit_global, 250);
+    session.import_session_settings(settings);
+    EXPECT_EQ(250U, prefs.get<size_t>(TR_KEY_peer_limit_global));
+
+    // give any stray session_set echo a chance to land before checking
+    std::this_thread::sleep_for(200ms);
+    EXPECT_EQ(session_limit, tr_sessionGetPeerLimit(session_));
+
+    // ...and syncing works again once the import is done
+    prefs.set(TR_KEY_peer_limit_global, size_t{ 111 });
+    EXPECT_TRUE(wait_for([this]() { return tr_sessionGetPeerLimit(session_) == 111U; }));
+}
+
+TEST_F(AppSessionSyncTest, embeddedSettingsRequireAnEmbeddedSession)
+{
+    auto rpc = RpcClient{ inline_marshaler() };
+    rpc.start(session_);
+
+    auto prefs = Prefs{};
+    auto session = TestSession{ prefs, rpc };
+    EXPECT_FALSE(session.embedded_settings().has_value());
+
+    session.set_embedded_session(session_);
+    auto const settings = session.embedded_settings();
+    ASSERT_TRUE(settings.has_value());
+    EXPECT_TRUE(settings->contains(TR_KEY_download_dir));
+}
+
+TEST_F(AppSessionSyncTest, importingSettingsReadsRpcServerSettingsWhenEmbedded)
+{
+    auto rpc = RpcClient{ inline_marshaler() };
+    rpc.start(session_);
+
+    auto prefs = Prefs{};
+    auto session = TestSession{ prefs, rpc };
+    session.set_embedded_session(session_);
+
+    tr_sessionSetRPCUsername(session_, "alice");
+    ASSERT_TRUE(wait_for([this]() { return tr_sessionGetRPCUsername(session_) == "alice"; }));
+
+    // session_get responses omit the RPC server's settings,
+    // so import must read them from the session directly
+    session.import_session_settings(tr_variant::Map{});
+    EXPECT_EQ("alice", prefs.get<std::string>(TR_KEY_rpc_username));
 }
 
 } // namespace


### PR DESCRIPTION
## Description

Next in a series to share prefs/session/torrent/model/rpc code between the Qt and GTK clients for #82.

The GTK and Qt clients both need pref-and-session synchronization. This PR migrates the Qt client's approach into `tr::app::Session` so that it can be reused by both GTK and Qt clients:

* a changed core pref is sent to the session as a single-key `session_set` request (with C API special cases for the RPC server's own settings, which RPC can't change)

* import_session_settings() copies a `session_get` response into Prefs without echoing it back.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
