### PR TITLE
ci(netbsd): use stock gcc12

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1829,7 +1829,6 @@ jobs:
             done
           run: |
             set -ex
-            export TMPDIR=/var/tmp # gcc's LTO takes up a lot of space in TMPDIR, and /tmp is too small
             export PATH="/usr/pkg/bin:/usr/pkg/sbin${PATH:+:${PATH}}"
             mkdir src && tar xf transmission*.tar.* -C src --strip-components 1
             cmake \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1816,7 +1816,6 @@ jobs:
               cmake \
               fast_float \
               fmtlib \
-              gcc14 \
               libevent \
               libpsl \
               miniupnpc \
@@ -1838,9 +1837,6 @@ jobs:
               -B obj \
               -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_CXX_COMPILER='/usr/pkg/gcc14/bin/g++' \
-              -DCMAKE_C_COMPILER='/usr/pkg/gcc14/bin/gcc' \
-              -DCMAKE_BUILD_RPATH='/usr/pkg/gcc14/lib' \
               -DCMAKE_INSTALL_PREFIX=pfx \
               -DCMAKE_PREFIX_PATH='/usr/pkg' \
               -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \


### PR DESCRIPTION
## Description

Now that NetBSD 11 is released and the stock gcc is updated from 10 to 12, we can use the stock gcc without running into C++20 support issues.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
