### PR TITLE
refactor: use std::filesystem for tr_sys_dir_get_current()

### DIFF
--- a/libtransmission/file-posix.cc
+++ b/libtransmission/file-posix.cc
@@ -757,29 +757,6 @@ bool tr_sys_file_lock([[maybe_unused]] tr_sys_file_t handle, [[maybe_unused]] in
     return *result;
 }
 
-std::string tr_sys_dir_get_current(tr_error* error)
-{
-    auto buf = std::vector<char>{};
-    buf.resize(PATH_MAX);
-
-    for (;;) {
-        if (char const* const ret = getcwd(std::data(buf), std::size(buf)); ret != nullptr) {
-            return ret;
-        }
-
-        if (errno == ERANGE) {
-            buf.resize(std::size(buf) * 2U);
-            continue;
-        }
-
-        if (error != nullptr) {
-            error->set_from_errno(errno);
-        }
-
-        return {};
-    }
-}
-
 bool tr_sys_dir_create_temp(char* path_template, tr_error* error)
 {
     TR_ASSERT(path_template != nullptr);

--- a/libtransmission/file-win32.cc
+++ b/libtransmission/file-win32.cc
@@ -693,22 +693,6 @@ bool tr_sys_file_lock(tr_sys_file_t handle, int operation, tr_error* error)
     return ret;
 }
 
-std::string tr_sys_dir_get_current(tr_error* error)
-{
-    if (auto const size = GetCurrentDirectoryW(0, nullptr); size != 0) {
-        auto wide_ret = std::wstring{};
-        wide_ret.resize(size);
-        if (GetCurrentDirectoryW(std::size(wide_ret), std::data(wide_ret)) != 0) {
-            // `size` includes the terminating '\0'; remove it from `wide_ret`
-            wide_ret.resize(std::size(wide_ret) - 1);
-            return tr_win32_native_to_utf8(wide_ret);
-        }
-    }
-
-    set_system_error(error, GetLastError());
-    return {};
-}
-
 bool tr_sys_dir_create_temp(char* path_template, tr_error* error)
 {
     TR_ASSERT(path_template != nullptr);

--- a/libtransmission/file.cc
+++ b/libtransmission/file.cc
@@ -285,3 +285,15 @@ std::optional<tr_sys_path_capacity> tr_sys_path_get_capacity(std::string_view co
     maybe_set_error(error, ec);
     return {};
 }
+
+std::string tr_sys_dir_get_current(tr_error* error)
+{
+    auto ec = std::error_code{};
+    auto const current_path = std::filesystem::current_path(ec);
+    if (!ec) {
+        return tr_u8string(current_path);
+    }
+
+    maybe_set_error(error, ec);
+    return {};
+}


### PR DESCRIPTION
## Description

No behavioral changes.

Use `std::filesystem` to implement `tr_sys_dir_get_current()` so that we only need one implementation instead of two (POSIX, Win32).

No new tests needed; existing coverage works for this

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
