### PR TITLE
perf: route torrent disk IO through tr::LocalData

### DIFF
--- a/libtransmission/bandwidth.cc
+++ b/libtransmission/bandwidth.cc
@@ -246,7 +246,7 @@ void tr_bandwidth::allocate(uint64_t period_msec)
     // or (2) the next tr_bandwidth::allocate () call, when we start over again.
     for (auto const& io : refs) {
         io->set_enabled(tr_direction::Up, io->has_bandwidth_left(tr_direction::Up));
-        io->set_enabled(tr_direction::Down, io->has_bandwidth_left(tr_direction::Down));
+        io->update_read_enabled();
     }
 }
 

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -245,7 +245,7 @@ tr_error_code_t tr_ioRead(
 }
 
 tr_error_code_t tr_ioWrite(
-    tr_torrent& tor,
+    tr_torrent const& tor,
     tr_open_files& open_files,
     tr_block_info::Location const& loc,
     std::span<uint8_t const> const writeme)
@@ -253,23 +253,18 @@ tr_error_code_t tr_ioWrite(
     auto error = tr_error{};
     if (loc.piece >= tor.piece_count()) {
         error.set_from_errno(EINVAL);
-    } else {
-        auto [file_index, file_offset] = tor.file_offset(loc);
-        auto& session = *tor.session;
-        auto buf = writeme;
-        while (!std::empty(buf) && !error) {
-            auto const bytes_this_pass = std::min<uint64_t>(std::size(buf), tor.file_size(file_index) - file_offset);
-            write_bytes(session, open_files, tor, file_index, file_offset, buf.first(bytes_this_pass), error);
-            buf = buf.subspan(bytes_this_pass);
-            ++file_index;
-            file_offset = 0U;
-        }
+        return error.code();
     }
 
-    // if IO failed, set torrent's error if not already set
-    if (error && !tor.error().is_local_error()) {
-        tor.error().set_local_error(error.message());
-        tr_torrentStop(&tor);
+    auto [file_index, file_offset] = tor.file_offset(loc);
+    auto& session = *tor.session;
+    auto buf = writeme;
+    while (!std::empty(buf) && !error) {
+        auto const bytes_this_pass = std::min<uint64_t>(std::size(buf), tor.file_size(file_index) - file_offset);
+        write_bytes(session, open_files, tor, file_index, file_offset, buf.first(bytes_this_pass), error);
+        buf = buf.subspan(bytes_this_pass);
+        ++file_index;
+        file_offset = 0U;
     }
 
     return error.code();

--- a/libtransmission/inout.h
+++ b/libtransmission/inout.h
@@ -31,10 +31,14 @@ struct tr_torrent;
 
 /**
  * Writes the block specified by the piece index, offset, and length.
+ *
+ * Does no error handling of its own. The caller decides what to do with
+ * the returned code.
+ *
  * @return 0 on success, or an errno value on failure.
  */
 [[nodiscard]] tr_error_code_t tr_ioWrite(
-    tr_torrent& tor,
+    tr_torrent const& tor,
     tr_open_files& open_files,
     tr_block_info::Location const& loc,
     std::span<uint8_t const> writeme);

--- a/libtransmission/local-data.cc
+++ b/libtransmission/local-data.cc
@@ -3,11 +3,14 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
+#include <algorithm> // std::ranges::shuffle
 #include <cerrno>
+#include <functional>
 #include <memory>
 #include <span>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 #include "libtransmission/local-data.h"
 
@@ -55,7 +58,6 @@ struct HashResult {
     for (auto block = begin_block; block < end_block; ++block) {
         auto const byte_span = block_info.byte_span_for_block(block);
 
-        buffer.clear();
         if (auto const err = backend.read(id, byte_span, buffer); err != 0) {
             return { .error = err, .hash = {} };
         }
@@ -248,7 +250,9 @@ void LocalData::read(tr_torrent_id_t const id, tr_byte_span_t const byte_span, O
     }
 
     if (on_read) {
-        std::move(on_read)(id, byte_span, make_error(err), std::move(data));
+        finish([id, byte_span, err, data = std::move(data), on_read = std::move(on_read)]() mutable {
+            std::move(on_read)(id, byte_span, make_error(err), std::move(data));
+        });
     }
 }
 
@@ -259,7 +263,9 @@ void LocalData::test_piece(tr_torrent_id_t const id, tr_piece_index_t const piec
     auto const err = backend_->test_piece(id, piece, hash);
 
     if (on_test) {
-        std::move(on_test)(id, piece, make_error(err), err == 0 ? std::optional<tr_sha1_digest_t>{ hash } : std::nullopt);
+        finish([id, piece, err, hash, on_test = std::move(on_test)]() mutable {
+            std::move(on_test)(id, piece, make_error(err), err == 0 ? std::optional<tr_sha1_digest_t>{ hash } : std::nullopt);
+        });
     }
 }
 
@@ -275,22 +281,27 @@ void LocalData::write(
     }
 
     if (on_write) {
-        std::move(on_write)(id, byte_span, make_error(err));
+        finish([id, byte_span, err, on_write = std::move(on_write)]() mutable {
+            std::move(on_write)(id, byte_span, make_error(err));
+        });
     }
 }
 
 void LocalData::close_torrent(tr_torrent_id_t const tor_id)
 {
+    drain();
     backend_->close_torrent(tor_id);
 }
 
 void LocalData::close_file(tr_torrent_id_t const tor_id, tr_file_index_t const file_num)
 {
+    drain();
     backend_->close_file(tor_id, file_num);
 }
 
 void LocalData::close_all()
 {
+    drain();
     backend_->close_all();
 }
 
@@ -301,6 +312,7 @@ void LocalData::move(
     std::string_view const parent_name,
     OnMove on_move) // NOLINT(performance-unnecessary-value-param)
 {
+    drain();
     auto const err = backend_->move(id, old_parent, parent, parent_name);
 
     if (on_move) {
@@ -310,6 +322,7 @@ void LocalData::move(
 
 void LocalData::remove(tr_torrent_id_t const id, tr_torrent_remove_func remove_func)
 {
+    drain();
     static_cast<void>(backend_->remove(id, std::move(remove_func)));
 }
 
@@ -319,11 +332,69 @@ void LocalData::rename(
     std::string_view const newname,
     tr_torrent_rename_done_func callback)
 {
+    drain();
     backend_->rename(id, oldpath, newname, std::move(callback));
 }
 
 void LocalData::shutdown()
 {
+    drain();
+}
+
+void LocalData::set_wake(std::function<void()> wake)
+{
+    wake_ = std::move(wake);
+}
+
+void LocalData::set_completions(Completions const completions, uint32_t const seed)
+{
+    drain();
+    completions_ = completions;
+    rng_.seed(seed);
+}
+
+bool LocalData::defer_next() noexcept
+{
+    switch (completions_) {
+    case Completions::Deferred:
+        return true;
+
+    case Completions::Shuffled:
+        return (rng_() & 1U) != 0U;
+
+    default:
+        return false;
+    }
+}
+
+void LocalData::park(std::unique_ptr<Parked> completion)
+{
+    auto const was_idle = std::empty(parked_);
+    parked_.emplace_back(std::move(completion));
+    if (was_idle && wake_) {
+        wake_();
+    }
+}
+
+void LocalData::pump()
+{
+    // Take the whole queue up front. A completion can park more work,
+    // and that work belongs to the next pump, not this one.
+    auto parked = std::vector<std::unique_ptr<Parked>>{};
+    std::swap(parked, parked_);
+
+    std::ranges::shuffle(parked, rng_);
+
+    for (auto& completion : parked) {
+        completion->deliver();
+    }
+}
+
+void LocalData::drain()
+{
+    while (!std::empty(parked_)) {
+        pump();
+    }
 }
 
 uint64_t LocalData::enqueued_write_bytes() noexcept

--- a/libtransmission/local-data.h
+++ b/libtransmission/local-data.h
@@ -9,18 +9,25 @@
 #error only libtransmission should #include this header.
 #endif
 
+#include <algorithm>
+#include <array>
 #include <cstddef> // size_t
 #include <cstdint> // uintX_t
 #include <functional>
+#include <initializer_list>
 #include <memory>
 #include <optional>
+#include <random>
+#include <span>
 #include <string_view>
-
-#include <small/vector.hpp>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 #include "libtransmission/constants.h"
 #include "libtransmission/digest.h"
 #include "libtransmission/error-types.h"
+#include "libtransmission/tr-assert.h"
 #include "libtransmission/types.h"
 
 class tr_open_files;
@@ -29,10 +36,131 @@ class tr_torrents;
 namespace tr
 {
 
+/**
+ * All torrent local-data IO goes through here.
+ *
+ * # Ordering contract
+ *
+ * Every backend follows these rules. No caller may assume more.
+ *
+ * The rules are weaker than FIFO on purpose. They leave a backend free
+ * to merge ops, to reorder them to suit the disk, and to answer from the
+ * page cache without a thread hop.
+ *
+ * 1. Ops on different torrents are unordered.
+ *
+ * 2. Data ops on the same torrent are unordered too. `read`,
+ *    `test_piece`, and `write` may run at the same time and may finish
+ *    in any order. If op B needs to see op A's result, wait for A's
+ *    callback before starting B.
+ *
+ * 3. Admin ops are barriers on their torrent. `move`, `rename`,
+ *    `remove`, `close_file`, `close_torrent`, and `close_all` wait for
+ *    the ops already in flight. Ops started later wait for them.
+ *
+ * 4. Every callback fires exactly once. It may fire before the enqueue
+ *    call returns, or long afterwards from the session thread. Callers
+ *    have to work either way.
+ *
+ * 5. Anything may have changed before a callback runs. The torrent may
+ *    have stopped or been removed, the peer may be gone, the files may
+ *    have moved. Look up what you need by id, and drop the work if it's
+ *    gone.
+ *
+ * Reads and hashes still see finished writes, even though rule 2
+ * promises no such thing. That works because we don't start the second
+ * op until the write's callback has run. A piece is hashed from its last
+ * write completion, and we only read pieces we already have.
+ */
 class LocalData
 {
 public:
-    using BlockData = small::max_size_vector<uint8_t, TrBlockSize>;
+    /**
+     * A fixed-capacity buffer holding up to one block of data.
+     *
+     * Growing the buffer leaves the new bytes uninitialized. Callers
+     * always overwrite them, so zeroing them first would waste a pass
+     * over 16 KiB on every block.
+     */
+    class BlockData
+    {
+    public:
+        using value_type = uint8_t;
+
+        // Don't replace this with `= default`. That would make the
+        // constructor trivial, and `BlockData{}` would zero all 16 KiB.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,modernize-use-equals-default)
+        BlockData() noexcept
+        {
+        }
+
+        explicit BlockData(std::span<value_type const> const data) // NOLINT(cppcoreguidelines-pro-type-member-init)
+        {
+            assign(data);
+        }
+
+        void assign(std::span<value_type const> const data) noexcept
+        {
+            TR_ASSERT(std::size(data) <= std::size(buf_));
+            size_ = std::min(std::size(data), std::size(buf_));
+            std::copy_n(std::begin(data), size_, std::begin(buf_));
+        }
+
+        void assign(std::initializer_list<value_type> const data) noexcept
+        {
+            assign(std::span{ std::data(data), std::size(data) });
+        }
+
+        constexpr void resize(size_t const size) noexcept
+        {
+            TR_ASSERT(size <= std::size(buf_));
+            size_ = std::min(size, std::size(buf_));
+        }
+
+        constexpr void clear() noexcept
+        {
+            size_ = 0U;
+        }
+
+        [[nodiscard]] constexpr auto* data() noexcept
+        {
+            return std::data(buf_);
+        }
+
+        [[nodiscard]] constexpr auto const* data() const noexcept
+        {
+            return std::data(buf_);
+        }
+
+        [[nodiscard]] constexpr auto size() const noexcept
+        {
+            return size_;
+        }
+
+        [[nodiscard]] constexpr auto begin() noexcept
+        {
+            return std::begin(buf_);
+        }
+
+        [[nodiscard]] constexpr auto begin() const noexcept
+        {
+            return std::begin(buf_);
+        }
+
+        [[nodiscard]] constexpr auto end() noexcept
+        {
+            return std::begin(buf_) + size_;
+        }
+
+        [[nodiscard]] constexpr auto end() const noexcept
+        {
+            return std::begin(buf_) + size_;
+        }
+
+    private:
+        std::array<value_type, TrBlockSize> buf_;
+        size_t size_ = 0U;
+    };
 
     using OnRead = std::function<
         void(tr_torrent_id_t, tr_byte_span_t byte_span, tr_error const& error, std::unique_ptr<BlockData> data)>;
@@ -74,6 +202,25 @@ public:
         virtual void close_file(tr_torrent_id_t tor_id, tr_file_index_t file_num) = 0;
     };
 
+    /**
+     * How completions are delivered. See rule 4.
+     *
+     * `Inline` runs every callback before the enqueue call returns.
+     *
+     * `Deferred` and `Shuffled` are for testing. `Deferred` parks every
+     * callback until `pump()` runs. `Shuffled` picks per op, so one run
+     * parks some callbacks and fires the rest inline. `pump()` delivers
+     * what it parked in an order unrelated to the order the ops arrived
+     * in.
+     *
+     * The rules above allow all of this, so a caller that breaks under
+     * these modes would also break under a threaded backend.
+     */
+    enum class Completions : uint8_t { Inline, Deferred, Shuffled };
+
+    // The same seed replays the same shuffled run.
+    static auto constexpr DefaultShuffleSeed = uint32_t{ 20260812U };
+
     explicit LocalData(tr_torrents const& torrents, tr_open_files& open_files, size_t worker_count = {});
     explicit LocalData(std::unique_ptr<Backend> backend, size_t worker_count = {});
 
@@ -101,8 +248,76 @@ public:
     void shutdown();
     [[nodiscard]] static uint64_t enqueued_write_bytes() noexcept;
 
+    // LocalData calls `wake` when it parks the first completion. The owner
+    // answers by calling pump() from the session thread. That thread is the
+    // same in every mode, so the owner binds this once.
+    void set_wake(std::function<void()> wake);
+
+    void set_completions(Completions completions, uint32_t seed = DefaultShuffleSeed);
+
+    // Deliver the parked completions in a random order.
+    void pump();
+
 private:
+    // A completion waiting to be delivered.
+    // A read completion owns the buffer it read into and can't be copied,
+    // so std::function can't hold one.
+    class Parked
+    {
+    public:
+        virtual ~Parked() = default;
+        virtual void deliver() = 0;
+    };
+
+    template<typename Fn>
+    class ParkedFn final : public Parked
+    {
+    public:
+        explicit ParkedFn(Fn fn)
+            : fn_{ std::move(fn) }
+        {
+        }
+
+        void deliver() override
+        {
+            fn_();
+        }
+
+    private:
+        Fn fn_;
+    };
+
+    // Deliver the completion now, or park it for pump().
+    // See set_completions().
+    template<typename Fn>
+    void finish(Fn&& fn)
+    {
+        if (defer_next()) {
+            park(std::make_unique<ParkedFn<std::decay_t<Fn>>>(std::forward<Fn>(fn)));
+            return;
+        }
+
+        fn();
+    }
+
+    // True if this completion should wait for pump() instead of firing now.
+    [[nodiscard]] bool defer_next() noexcept;
+
+    void park(std::unique_ptr<Parked> completion);
+
+    // Deliver every parked completion, including ones parked along the way.
+    void drain();
+
     std::unique_ptr<Backend> backend_;
+
+    std::vector<std::unique_ptr<Parked>> parked_;
+    std::function<void()> wake_;
+
+    // A fixed seed so that tests can replay a shuffled run.
+    // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp,bugprone-random-generator-seed)
+    std::mt19937 rng_{ DefaultShuffleSeed };
+
+    Completions completions_ = Completions::Inline;
 };
 
 } // namespace tr

--- a/libtransmission/open-files.cc
+++ b/libtransmission/open-files.cc
@@ -4,11 +4,11 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm> // std::min
-#include <array>
 #include <cstdint> // uint8_t, uint64_t
 #include <span>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 #include <fmt/format.h>
 
@@ -79,7 +79,11 @@ bool preallocate_file_full(tr_sys_file_t fd, uint64_t length, tr_error* error)
     tr_logAddDebug(fmt::format("Full preallocation failed: {} ({})", local_error.message(), local_error.code()));
 
     if (!tr_error_is_enospc(local_error.code())) {
-        auto buf = std::array<uint8_t, 4096>{};
+        // This fallback writes out the whole file.
+        // It runs on FAT and exFAT, which are usually slow external
+        // drives, so write in big chunks.
+        static auto constexpr ChunkSize = size_t{ 1024U * 1024U };
+        auto const buf = std::vector<uint8_t>(static_cast<size_t>(std::min<uint64_t>(length, ChunkSize)));
         bool success = true;
 
         local_error = {};

--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -28,6 +28,7 @@
 class tr_swarm;
 struct tr_bandwidth;
 struct tr_peer;
+struct tr_torrent;
 
 // --- Peer Publish / Subscribe
 

--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -387,22 +387,25 @@ void tr_peerIo::can_read_wrapper(size_t bytes_transferred)
             break;
         }
     }
+
+    // The callbacks may have made room in inbuf_.
+    if (!err) {
+        update_read_enabled();
+    }
 }
 
 size_t tr_peerIo::try_read(size_t max)
 {
     static auto constexpr Dir = tr_direction::Down;
 
-    if (max == 0U) {
-        return {};
-    }
-
     if (!socket_) {
         return {};
     }
 
     // Do not read more than the bandwidth allows.
-    // If there is no bandwidth left available, disable reads.
+    // If we can't take any bytes at all, disable reads. The socket is
+    // still readable, so leaving them on would spin the event loop.
+    // tr_bandwidth::allocate() and can_read_wrapper() turn them back on.
     max = bandwidth().clamp(Dir, max);
     if (max == 0U) {
         set_enabled(Dir, false);
@@ -438,6 +441,11 @@ void tr_peerIo::read_cb()
 }
 
 // ---
+
+void tr_peerIo::update_read_enabled()
+{
+    set_enabled(tr_direction::Down, read_buffer_size() < RcvBuf && has_bandwidth_left(tr_direction::Down));
+}
 
 void tr_peerIo::set_enabled(tr_direction dir, bool is_enabled)
 {

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -102,6 +102,11 @@ public:
 
     void set_enabled(tr_direction dir, bool is_enabled);
 
+    // Reads are on when we have bandwidth to spend and room to put the
+    // bytes. Leaving them on without both spins the event loop, because
+    // the socket stays readable either way.
+    void update_read_enabled();
+
     ///
 
     [[nodiscard]] constexpr auto read_buffer_size() const noexcept

--- a/libtransmission/peer-mgr-wishlist.h
+++ b/libtransmission/peer-mgr-wishlist.h
@@ -29,6 +29,8 @@ class Wishlist
 {
 public:
     struct Mediator {
+        // True if we already have the block, or are writing it now.
+        // Either way it is not worth requesting.
         [[nodiscard]] virtual bool client_has_block(tr_block_index_t block) const = 0;
         [[nodiscard]] virtual bool client_has_piece(tr_piece_index_t piece) const = 0;
         [[nodiscard]] virtual bool client_wants_piece(tr_piece_index_t piece) const = 0;

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -403,7 +403,7 @@ public:
 
         [[nodiscard]] bool client_has_block(tr_block_index_t const block) const override
         {
-            return tor_.has_block(block);
+            return tor_.has_block_or_pending(block);
         }
 
         [[nodiscard]] bool client_has_piece(tr_piece_index_t const piece) const override
@@ -901,12 +901,13 @@ private:
 
         case tr_peer_event::Type::ClientGotBlock:
             {
+                // Stop asking peers for this block. It doesn't count as
+                // data we have until tr_torrent::on_block_written() runs.
                 auto* const tor = s->tor;
                 auto const loc = tor->piece_loc(event.pieceIndex, event.offset);
                 s->cancel_all_requests_for_block(loc.block, peer);
                 peer->blame.set(loc.piece);
-                s->got_block(tor, loc.block); // put this line before calling tr_torrent callback
-                tor->on_block_received(loc.block);
+                s->got_block(tor, loc.block);
             }
             break;
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -32,7 +32,7 @@
 #include "libtransmission/block-info.h"
 #include "libtransmission/clients.h"
 #include "libtransmission/crypto-utils.h"
-#include "libtransmission/inout.h"
+#include "libtransmission/local-data.h"
 #include "libtransmission/log.h"
 #include "libtransmission/macros.h"
 #include "libtransmission/peer-common.h"
@@ -226,9 +226,10 @@ struct tr_incoming {
 
     struct incoming_piece_data {
         explicit incoming_piece_data(uint32_t block_size)
-            : block_size_{ block_size }
+            : buf{ std::make_unique<tr::LocalData::BlockData>() }
+            , block_size_{ block_size }
         {
-            buf.resize(block_size);
+            buf->resize(block_size);
         }
 
         [[nodiscard]] bool add_span(size_t begin, size_t end)
@@ -249,7 +250,7 @@ struct tr_incoming {
             return have_.count() >= block_size_;
         }
 
-        std::vector<uint8_t> buf;
+        std::unique_ptr<tr::LocalData::BlockData> buf;
 
     private:
         std::bitset<tr_block_info::BlockSize> have_;
@@ -357,7 +358,7 @@ public:
             return active_requests.count();
 
         case tr_direction::PeerToClient: // requests they sent
-            return std::size(peer_requested_);
+            return std::size(peer_requested_) + std::size(reading_);
 
         default:
             TR_ASSERT(0);
@@ -578,16 +579,39 @@ private:
 
     void reject_all_requests()
     {
-        auto& queue = peer_requested_;
-
         if (auto const must_send_rej = io_->supports_fext(); must_send_rej) {
-            std::ranges::for_each(queue, [this](peer_request const& req) { protocol_send_reject(req); });
+            std::ranges::for_each(peer_requested_, [this](peer_request const& req) { protocol_send_reject(req); });
+            std::ranges::for_each(reading_, [this](peer_request const& req) { protocol_send_reject(req); });
         }
 
-        queue.clear();
+        // In-flight reads will find their request gone and drop their data.
+        peer_requested_.clear();
+        reading_.clear();
     }
 
     [[nodiscard]] bool can_add_request_from_peer(peer_request const& req);
+
+    void on_peer_cancelled_request(peer_request const& req)
+    {
+        // bep6: "Even when a request is cancelled, the peer receiving the
+        // cancel should respond with either the corresponding reject or the
+        // corresponding piece".
+        //
+        // We drop the request either way, so a reject is the only answer
+        // we can still send.
+        auto const queued = std::ranges::find(peer_requested_, req);
+        if (queued != std::ranges::end(peer_requested_)) {
+            peer_requested_.erase(queued);
+        } else if (auto const reading = std::ranges::find(reading_, req); reading != std::ranges::end(reading_)) {
+            reading_.erase(reading);
+        } else {
+            return;
+        }
+
+        if (io_->supports_fext()) {
+            protocol_send_reject(req);
+        }
+    }
 
     void on_peer_made_request(peer_request const& req)
     {
@@ -640,6 +664,7 @@ private:
     void maybe_send_metadata_requests(time_t now) const;
     [[nodiscard]] size_t add_next_metadata_piece();
     [[nodiscard]] size_t add_next_block(uint64_t now_msec);
+    void on_upload_read(peer_request const& req, tr_error const& error, std::unique_ptr<tr::LocalData::BlockData> data);
 
     [[nodiscard]] size_t fill_output_buffer_impl(time_t now_sec, uint64_t now_msec);
     void fill_output_buffer(time_t now_sec, uint64_t now_msec)
@@ -665,7 +690,7 @@ private:
 
     void send_ut_pex();
 
-    tr_error_code_t client_got_block(std::span<uint8_t const> block_data, tr_block_index_t block);
+    bool client_got_block(std::unique_ptr<tr::LocalData::BlockData> block_data, tr_block_index_t block);
     ReadResult read_piece_data(MessageReader& payload);
 
     // Precondition: `payload` is a complete message body whose length
@@ -752,7 +777,18 @@ private:
 
     std::shared_ptr<tr_peerIo> const io_;
 
+    // requests from this peer that we haven't started reading yet
     std::deque<peer_request> peer_requested_;
+
+    // requests from this peer whose read is in flight.
+    // A read completion looks for its request here. If it's gone, the
+    // request was cancelled or rejected, so the data is dropped.
+    std::vector<peer_request> reading_;
+
+    // bytes a read completion queued for this peer, whether piece or reject.
+    // add_next_block() zeroes it, issues one read, then checks it again.
+    // Nonzero means that read finished inline.
+    size_t n_reply_bytes_queued_ = 0U;
 
     std::array<std::vector<tr_pex>, NUM_TR_AF_INET_TYPES> pex_;
 
@@ -1588,17 +1624,7 @@ ReadResult tr_peerMsgsImpl::process_peer_message(uint8_t id, MessageReader& payl
             r.length = payload.to_uint32();
             logtrace(this, fmt::format("got a Cancel {:d}:{:d}->{:d}", r.index, r.offset, r.length));
 
-            auto& requests = peer_requested_;
-            if (auto iter = std::ranges::find(requests, r); iter != std::ranges::end(requests)) {
-                requests.erase(iter);
-
-                // bep6: "Even when a request is cancelled, the peer
-                // receiving the cancel should respond with either the
-                // corresponding reject or the corresponding piece"
-                if (fext) {
-                    protocol_send_reject(r);
-                }
-            }
+            on_peer_cancelled_request(r);
             break;
         }
 
@@ -1749,7 +1775,7 @@ ReadResult tr_peerMsgsImpl::read_piece_data(MessageReader& payload)
         return { ReadState::Err, len };
     }
 
-    if (tor_.has_block(block)) {
+    if (tor_.has_block_or_pending(block)) {
         logtrace(this, fmt::format("got completed block {:d} ({:d}:{:d}->{:d})", block, piece, offset, len));
         return { ReadState::Err, len };
     }
@@ -1768,16 +1794,16 @@ ReadResult tr_peerMsgsImpl::read_piece_data(MessageReader& payload)
 
     if (loc.block_offset == 0U && len == block_size) // simple case: one message has entire block
     {
-        auto buf = std::array<uint8_t, tr_block_info::BlockSize>{};
-        auto const content = std::span{ buf }.first(block_size);
-        payload.to_buf(content);
-        auto const ok = client_got_block(content, block) == 0;
+        auto buf = std::make_unique<tr::LocalData::BlockData>();
+        buf->resize(block_size);
+        payload.to_buf(std::span{ buf->data(), block_size });
+        auto const ok = client_got_block(std::move(buf), block);
         return { ok ? ReadState::Now : ReadState::Err, len };
     }
 
     auto& blocks = incoming_.blocks;
     auto& incoming_block = blocks.try_emplace(block, block_size).first->second;
-    payload.to_buf(std::span{ std::data(incoming_block.buf) + loc.block_offset, len });
+    payload.to_buf(std::span{ incoming_block.buf->data() + loc.block_offset, len });
 
     if (!incoming_block.add_span(loc.block_offset, loc.block_offset + len)) {
         return { ReadState::Err, len }; // invalid span
@@ -1789,32 +1815,35 @@ ReadResult tr_peerMsgsImpl::read_piece_data(MessageReader& payload)
 
     auto block_buf = std::move(incoming_block.buf);
     blocks.erase(block); // note: invalidates `incoming_block` local
-    auto const ok = client_got_block(block_buf, block) == 0;
+    auto const ok = client_got_block(std::move(block_buf), block);
     return { ok ? ReadState::Now : ReadState::Err, len };
 }
 
-// returns 0 on success, or an errno on failure
-tr_error_code_t tr_peerMsgsImpl::client_got_block(std::span<uint8_t const> block_data, tr_block_index_t const block)
+// Returns false if the block can't be used, either because it is the wrong
+// size or because we already have it. That only stops the caller from
+// draining this peer's input buffer for one pass. It is not a disconnect.
+bool tr_peerMsgsImpl::client_got_block(std::unique_ptr<tr::LocalData::BlockData> block_data, tr_block_index_t const block)
 {
     auto const n_expected = tor_.block_size(block);
-    auto const n_actual = std::size(block_data);
+    auto const n_actual = std::size(*block_data);
     if (n_actual != n_expected) {
         logdbg(this, fmt::format("wrong block size: expected {:d}, got {:d}", n_expected, n_actual));
-        return EMSGSIZE;
+        return false;
     }
 
     logtrace(this, fmt::format("got block {:d}", block));
 
-    // NB: if writeBlock() fails the torrent may be paused.
-    // If this happens, `this` will be destructed and must no longer be used.
-    if (auto const err = tr_ioWrite(tor_, session->openFiles(), tor_.block_loc(block), block_data); err != 0) {
-        return err;
+    if (!tor_.on_block_received(block)) {
+        return false; // another peer beat us to it
     }
 
     active_requests.unset(block);
     publish(tr_peer_event::GotBlock(tor_.block_info(), block));
 
-    return 0;
+    // A failed write can pause the torrent, which destroys `this`.
+    // Don't touch any member after this call.
+    tor_.save_block(block, std::move(block_data));
+    return true;
 }
 
 // ---
@@ -2100,7 +2129,6 @@ void tr_peerMsgsImpl::check_request_timeout(time_t const now)
     auto const req = peer_requested_.front();
     peer_requested_.pop_front();
 
-    auto buf = std::array<uint8_t, tr_block_info::BlockSize>{};
     auto ok = is_valid_request(req) && tor_.has_piece(req.index);
 
     if (ok) {
@@ -2111,24 +2139,58 @@ void tr_peerMsgsImpl::check_request_timeout(time_t const now)
         }
     }
 
-    if (ok) {
-        ok = tr_ioRead(
-                 tor_,
-                 session->openFiles(),
-                 tor_.piece_loc(req.index, req.offset),
-                 std::span{ std::data(buf), req.length }) == 0;
+    if (!ok) {
+        return io_->supports_fext() ? protocol_send_reject(req) : size_t{};
     }
 
-    if (ok) {
-        auto const piece_data = std::string_view{ reinterpret_cast<char const*>(std::data(buf)), req.length };
-        return protocol_send_message(BtPeerMsgs::Piece, req.index, req.offset, piece_data);
+    reading_.push_back(req);
+
+    auto const loc = tor_.piece_loc(req.index, req.offset);
+    n_reply_bytes_queued_ = 0U;
+    session->local_data.read(
+        tor_.id(),
+        { .begin = loc.byte, .end = loc.byte + req.length },
+        [weak = weak_from_this(), req](tr_torrent_id_t, tr_byte_span_t, tr_error const& error, auto data) {
+            if (auto const self = weak.lock(); self) {
+                self->on_upload_read(req, error, std::move(data));
+            }
+        });
+
+    // Nonzero only if the read finished inline. Returning zero for a
+    // deferred read stops the caller's send loop until the data arrives.
+    // A backend that defers every read therefore serves one block per
+    // call to fill_output_buffer().
+    return n_reply_bytes_queued_;
+}
+
+void tr_peerMsgsImpl::on_upload_read(
+    peer_request const& req,
+    tr_error const& error,
+    std::unique_ptr<tr::LocalData::BlockData> data)
+{
+    // Look the request up by value, not by position. Reads finish in
+    // whatever order the disk answers them, and this one may have been
+    // cancelled while we waited.
+    //
+    // Two identical requests are indistinguishable here. A peer that
+    // cancels a request and immediately repeats it gets the first read's
+    // data, and the second read's data is dropped. The bytes are the
+    // same either way.
+    auto const iter = std::ranges::find(reading_, req);
+    if (iter == std::ranges::end(reading_)) {
+        return;
+    }
+    reading_.erase(iter);
+
+    if (error || data == nullptr || std::size(*data) < req.length) {
+        if (io_->supports_fext()) {
+            n_reply_bytes_queued_ += protocol_send_reject(req);
+        }
+        return;
     }
 
-    if (io_->supports_fext()) {
-        return protocol_send_reject(req);
-    }
-
-    return {};
+    auto const piece_data = std::string_view{ reinterpret_cast<char const*>(data->data()), req.length };
+    n_reply_bytes_queued_ += protocol_send_message(BtPeerMsgs::Piece, req.index, req.offset, piece_data);
 }
 
 // ---
@@ -2163,7 +2225,7 @@ bool tr_peerMsgsImpl::is_valid_request(peer_request const& req) const
         return false;
     }
 
-    if (std::size(peer_requested_) >= client_reqq()) {
+    if (active_req_count(tr_direction::PeerToClient) >= client_reqq()) {
         logtrace(this, "rejecting request ... reqq is full");
         return false;
     }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1324,6 +1324,9 @@ void tr_session::closeImplPart1(std::promise<void>* closed_promise, std::chrono:
         torrent_queue().to_file();
     }
 
+    // Deliver any pending completions while their torrents still exist.
+    local_data.shutdown();
+
     // Close the torrents in order of most active to least active
     // so that the most important announce=stopped events are
     // fired out first...

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -800,6 +800,7 @@ void tr_torrent::on_metainfo_updated()
     file_priorities_ = tr_file_priorities{ &fpm_ };
     files_wanted_ = tr_files_wanted{ &fpm_ };
     checked_pieces_ = tr_bitfield{ static_cast<size_t>(piece_count()) };
+    blocks_pending_write_ = tr_bitfield{ static_cast<size_t>(block_count()) };
 }
 
 void tr_torrent::on_metainfo_completed()
@@ -2137,13 +2138,78 @@ void tr_torrent::on_piece_failed(tr_piece_index_t const piece)
     got_bad_piece_(this, piece);
 }
 
-void tr_torrent::on_block_received(tr_block_index_t const block)
+void tr_torrent::test_piece(tr_piece_index_t const piece)
+{
+    auto const token = ++next_hash_token_;
+    hash_tokens_.insert_or_assign(piece, token);
+
+    session->local_data.test_piece(
+        id(),
+        piece,
+        [session = this->session,
+         token](tr_torrent_id_t const tor_id, tr_piece_index_t const tested, tr_error const&, auto const hash) {
+            auto* const tor = session->torrents().get(tor_id);
+            if (tor == nullptr) {
+                return;
+            }
+
+            // Drop the result unless the piece is still the one we hashed.
+            auto const iter = tor->hash_tokens_.find(tested);
+            if (iter == std::end(tor->hash_tokens_) || iter->second != token) {
+                return;
+            }
+            tor->hash_tokens_.erase(iter);
+
+            if (hash && *hash == tor->piece_hash(tested)) {
+                tor->on_piece_completed(tested);
+            } else {
+                tor->on_piece_failed(tested);
+            }
+        });
+}
+
+bool tr_torrent::on_block_received(tr_block_index_t const block)
 {
     TR_ASSERT(session->am_in_session_thread());
 
-    if (has_block(block)) {
+    if (has_block_or_pending(block)) {
         tr_logAddDebugTor(this, "we have this block already...");
         bytes_downloaded_.reduce(block_size(block));
+        return false;
+    }
+
+    return true;
+}
+
+void tr_torrent::save_block(tr_block_index_t const block, std::unique_ptr<tr::LocalData::BlockData> data)
+{
+    TR_ASSERT(session->am_in_session_thread());
+    TR_ASSERT(!has_block_or_pending(block));
+
+    blocks_pending_write_.set(block);
+
+    session->local_data.write(
+        id(),
+        block_info().byte_span_for_block(block),
+        std::move(data),
+        [session = this->session, block](tr_torrent_id_t const tor_id, tr_byte_span_t, tr_error const& error) {
+            if (auto* const tor = session->torrents().get(tor_id); tor != nullptr) {
+                tor->on_block_written(block, error);
+            }
+        });
+}
+
+void tr_torrent::on_block_written(tr_block_index_t const block, tr_error const& error)
+{
+    TR_ASSERT(session->am_in_session_thread());
+
+    blocks_pending_write_.unset(block);
+
+    if (error) {
+        if (!error_.is_local_error()) {
+            error_.set_local_error(error.message());
+            tr_torrentStop(this);
+        }
         return;
     }
 
@@ -2155,14 +2221,8 @@ void tr_torrent::on_block_received(tr_block_index_t const block)
     auto const first_piece = block_loc.piece;
     auto const last_piece = byte_loc(block_loc.byte + block_size(block) - 1).piece;
     for (auto piece = first_piece; piece <= last_piece; ++piece) {
-        if (!has_piece(piece)) {
-            continue;
-        }
-
-        if (check_piece(piece)) {
-            on_piece_completed(piece);
-        } else {
-            on_piece_failed(piece);
+        if (has_piece(piece)) {
+            test_piece(piece);
         }
     }
 }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -17,6 +17,7 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -59,6 +60,7 @@ namespace tr::test
 
 class RenameTest_multifileTorrent_Test;
 class RenameTest_singleFilenameTorrent_Test;
+class TorrentDiskIoTest_hashResultForInvalidatedPieceIsDropped_Test;
 
 } // namespace tr::test
 
@@ -337,6 +339,14 @@ struct tr_torrent {
     [[nodiscard]] constexpr auto has_block(tr_block_index_t block) const
     {
         return completion_.has_block(block);
+    }
+
+    // True if the block is on disk, or if we're writing it now.
+    // Peers use this instead of has_block() to tell whether they still
+    // need a block.
+    [[nodiscard]] constexpr auto has_block_or_pending(tr_block_index_t const block) const
+    {
+        return has_block(block) || blocks_pending_write_.test(block);
     }
 
     [[nodiscard]] auto has_blocks(tr_block_span_t span) const
@@ -940,7 +950,17 @@ struct tr_torrent {
         return peer_id_;
     }
 
-    void on_block_received(tr_block_index_t block);
+    // Call this when a block arrives from a peer.
+    // Returns false if we already have the block, or are already saving
+    // it. Discard the data in that case.
+    [[nodiscard]] bool on_block_received(tr_block_index_t block);
+
+    // Writes a block that on_block_received() accepted.
+    // The block doesn't count as ours until the write finishes.
+    // See on_block_written().
+    void save_block(tr_block_index_t block, std::unique_ptr<tr::LocalData::BlockData> data);
+
+    void on_block_written(tr_block_index_t block, tr_error const& error);
 
     [[nodiscard]] constexpr auto& error() noexcept
     {
@@ -1018,6 +1038,7 @@ struct tr_torrent {
     time_t lpdAnnounceAt = 0;
 
 private:
+    friend class tr::test::TorrentDiskIoTest_hashResultForInvalidatedPieceIsDropped_Test;
     friend bool tr_torrentSetMetainfoFromFile(tr_torrent* tor, tr_torrent_metainfo const* metainfo, char const* filename);
     friend tr_file_view tr_torrentFile(tr_torrent const* tor, tr_file_index_t file);
     friend tr_stat tr_torrentStat(tr_torrent* tor);
@@ -1148,6 +1169,12 @@ private:
 
     [[nodiscard]] bool check_piece(tr_piece_index_t piece) const;
 
+    // Hashes a piece we just finished downloading and records the result.
+    // The answer arrives later, by which time the piece may have been
+    // invalidated and downloaded again. A token says which version of the
+    // piece was hashed, so a hash of an older version is dropped.
+    void test_piece(tr_piece_index_t piece);
+
     [[nodiscard]] constexpr std::optional<uint16_t> effective_idle_limit_minutes() const noexcept
     {
         auto const mode = idle_limit_mode();
@@ -1230,6 +1257,12 @@ private:
 
     void set_has_piece(tr_piece_index_t piece, bool has)
     {
+        if (!has) {
+            // Any hash in flight for this piece is about a version of it
+            // that no longer exists. See test_piece().
+            hash_tokens_.erase(piece);
+        }
+
         completion_.set_has_piece(piece, has);
     }
 
@@ -1295,6 +1328,15 @@ private:
     // files' mtimes (file_mtimes_). If checked_pieces_.test(piece) is false,
     // it means that piece needs to be checked before its data is used.
     tr_bitfield checked_pieces_ = tr_bitfield{ 0 };
+
+    // blocks we've received and are writing to disk.
+    // A block leaves this set when its write finishes.
+    tr_bitfield blocks_pending_write_ = tr_bitfield{ 0 };
+
+    // which version of a piece each in-flight hash is checking.
+    // An entry lives only as long as its hash.
+    std::unordered_map<tr_piece_index_t, uint64_t> hash_tokens_;
+    uint64_t next_hash_token_ = 0U;
 
     tr_labels_t labels_;
 

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -18,7 +18,7 @@
 #include "libtransmission/bandwidth.h"
 #include "libtransmission/bitfield.h"
 #include "libtransmission/block-info.h"
-#include "libtransmission/inout.h"
+#include "libtransmission/local-data.h"
 #include "libtransmission/peer-common.h"
 #include "libtransmission/peer-mgr.h"
 #include "libtransmission/session.h"
@@ -357,7 +357,7 @@ void tr_webseed_task::use_fetched_blocks()
             break;
         }
 
-        if (tor.has_block(loc_.block)) {
+        if (tor.has_block_or_pending(loc_.block)) {
             content_.drain(block_size);
         } else {
             auto block_buf = std::vector<uint8_t>{};
@@ -366,13 +366,18 @@ void tr_webseed_task::use_fetched_blocks()
 
             session_->run_in_session_thread(
                 [buf = std::move(block_buf), loc = loc_, session = session_, tor_id = tor.id(), webseed = webseed_]() {
-                    if (auto* const torrent = session->torrents().get(tor_id)) {
-                        webseed->active_requests.unset(loc.block);
-                        if (tr_ioWrite(*torrent, session->openFiles(), loc, buf) != 0) {
-                            return;
-                        }
-                        webseed->publish(tr_peer_event::GotBlock(torrent->block_info(), loc.block));
+                    auto* const torrent = session->torrents().get(tor_id);
+                    if (torrent == nullptr) {
+                        return;
                     }
+
+                    webseed->active_requests.unset(loc.block);
+                    if (!torrent->on_block_received(loc.block)) {
+                        return;
+                    }
+
+                    webseed->publish(tr_peer_event::GotBlock(torrent->block_info(), loc.block));
+                    torrent->save_block(loc.block, std::make_unique<tr::LocalData::BlockData>(buf));
                 });
         }
 

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -60,14 +60,15 @@ target_sources(libtransmission-test
         test-fixtures.h
         timer-test.cc
         torrent-builder-test.cc
+        torrent-disk-io-test.cc
         torrent-files-test.cc
         torrent-magnet-test.cc
         torrent-metainfo-test.cc
         torrent-queue-test.cc
         torrent-test.cc
         torrents-test.cc
-        types-test.cc
         tr-peer-info-test.cc
+        types-test.cc
         utils-test.cc
         values-test.cc
         variant-test.cc
@@ -107,6 +108,23 @@ target_link_libraries(libtransmission-test
         wildmat)
 
 tr_setup_gtest_target(libtransmission-test "LT.")
+
+# Re-run the disk-IO tests with tr::LocalData delivering its completions
+# late and out of order, which its ordering contract allows.
+#
+# A suite belongs here only if it drives a tr::LocalData op through a
+# tr_session. A suite that issues no such op re-runs byte-identical, and
+# the LocalData unit tests select the mode themselves, so neither would
+# gain anything from being listed.
+if(NOT CMAKE_CROSSCOMPILING OR CMAKE_CROSSCOMPILING_EMULATOR)
+    add_test(
+        NAME LT.ShuffledDiskIo
+        COMMAND libtransmission-test --gtest_filter=*IncompleteDirTest.*)
+
+    set_tests_properties(LT.ShuffledDiskIo
+        PROPERTIES
+            ENVIRONMENT TR_LOCAL_DATA_SHUFFLE=1)
+endif()
 
 add_custom_command(
     TARGET libtransmission-test

--- a/tests/libtransmission/local-data-test.cc
+++ b/tests/libtransmission/local-data-test.cc
@@ -4,9 +4,11 @@
 // License text can be found in the licenses/ folder.
 
 #include <algorithm>
+#include <memory>
 #include <optional>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -238,4 +240,125 @@ TEST(LocalData, AdminOperationsDelegate)
     EXPECT_TRUE(raw_backend->close_all_called);
 
     local_data.shutdown();
+}
+
+TEST(LocalData, DeferredCompletionsWaitForPump)
+{
+    auto local_data = tr::LocalData{ std::make_unique<StubBackend>() };
+    local_data.set_completions(tr::LocalData::Completions::Deferred);
+
+    auto n_called = 0;
+    for (auto i = 0; i < 4; ++i) {
+        local_data.read(7, { .begin = 0U, .end = 3U }, [&n_called](auto, auto, auto const&, auto) { ++n_called; });
+    }
+
+    EXPECT_EQ(0, n_called);
+    local_data.pump();
+    EXPECT_EQ(4, n_called);
+}
+
+TEST(LocalData, DeferredCompletionsArriveOutOfOrder)
+{
+    // A shuffle can leave one run in order by chance. It cannot do that
+    // for this many runs in a row.
+    static auto constexpr NumOps = 8;
+    static auto constexpr NumRuns = 16;
+
+    auto local_data = tr::LocalData{ std::make_unique<StubBackend>() };
+    local_data.set_completions(tr::LocalData::Completions::Deferred);
+
+    auto reordered = false;
+    for (auto run = 0; !reordered && run < NumRuns; ++run) {
+        auto order = std::vector<tr_piece_index_t>{};
+        for (tr_piece_index_t piece = 0; piece < NumOps; ++piece) {
+            local_data.test_piece(7, piece, [&order](auto, tr_piece_index_t const tested, auto const&, auto) {
+                order.push_back(tested);
+            });
+        }
+
+        local_data.pump();
+        ASSERT_EQ(NumOps, std::size(order));
+        reordered = !std::ranges::is_sorted(order);
+    }
+
+    EXPECT_TRUE(reordered);
+}
+
+TEST(LocalData, AdminOpsDrainParkedCompletions)
+{
+    auto backend = std::make_unique<StubBackend>();
+    auto* raw_backend = backend.get();
+    auto local_data = tr::LocalData{ std::move(backend) };
+    local_data.set_completions(tr::LocalData::Completions::Deferred);
+
+    auto read_finished = false;
+    local_data.read(7, { .begin = 0U, .end = 3U }, [&read_finished](auto, auto, auto const&, auto) { read_finished = true; });
+
+    // rule 3: a barrier waits for the ops enqueued before it
+    auto move_finished = false;
+    local_data.move(7, "/old", "/new", "name", [&read_finished, &move_finished](auto, auto const&) {
+        EXPECT_TRUE(read_finished);
+        move_finished = true;
+    });
+
+    EXPECT_TRUE(move_finished);
+    EXPECT_EQ("/old", raw_backend->moved_from);
+}
+
+TEST(LocalData, ShutdownDeliversParkedCompletions)
+{
+    auto local_data = tr::LocalData{ std::make_unique<StubBackend>() };
+    local_data.set_completions(tr::LocalData::Completions::Deferred);
+
+    auto n_called = 0;
+    auto data = std::make_unique<tr::LocalData::BlockData>();
+    data->assign({ uint8_t{ 4U } });
+    local_data.write(11, { .begin = 0U, .end = 1U }, std::move(data), [&n_called](auto, auto, auto const&) { ++n_called; });
+
+    local_data.shutdown();
+    EXPECT_EQ(1, n_called);
+}
+
+TEST(LocalData, ShuffledCompletionsMixInlineAndDeferred)
+{
+    static auto constexpr NumOps = 32;
+
+    auto local_data = tr::LocalData{ std::make_unique<StubBackend>() };
+    local_data.set_completions(tr::LocalData::Completions::Shuffled);
+
+    auto n_called = 0;
+    for (auto i = 0; i < NumOps; ++i) {
+        local_data.read(7, { .begin = 0U, .end = 3U }, [&n_called](auto, auto, auto const&, auto) { ++n_called; });
+    }
+
+    // rule 4: some of these fired before the enqueue call returned,
+    // and the rest are waiting for pump()
+    auto const n_inline = n_called;
+    EXPECT_GT(n_inline, 0);
+    EXPECT_LT(n_inline, NumOps);
+
+    local_data.pump();
+    EXPECT_EQ(NumOps, n_called);
+}
+
+TEST(LocalData, ShuffledCompletionsReplayFromSeed)
+{
+    static auto constexpr NumOps = 16;
+    static auto constexpr Seed = uint32_t{ 12345U };
+
+    auto const run_once = []() {
+        auto local_data = tr::LocalData{ std::make_unique<StubBackend>() };
+        local_data.set_completions(tr::LocalData::Completions::Shuffled, Seed);
+
+        auto order = std::vector<tr_piece_index_t>{};
+        for (tr_piece_index_t piece = 0; piece < NumOps; ++piece) {
+            local_data.test_piece(7, piece, [&order](auto, tr_piece_index_t const tested, auto const&, auto) {
+                order.push_back(tested);
+            });
+        }
+        local_data.pump();
+        return order;
+    };
+
+    EXPECT_EQ(run_once(), run_once());
 }

--- a/tests/libtransmission/move-test.cc
+++ b/tests/libtransmission/move-test.cc
@@ -15,7 +15,7 @@
 
 #include <libtransmission/block-info.h>
 #include <libtransmission/file.h> // tr_sys_path_*()
-#include <libtransmission/inout.h>
+#include <libtransmission/local-data.h>
 #include <libtransmission/quark.h>
 #include <libtransmission/torrent-files.h>
 #include <libtransmission/torrent.h>
@@ -84,15 +84,12 @@ TEST_P(IncompleteDirTest, incompleteDir)
         tr_block_index_t block = {};
         tr_piece_index_t pieceIndex = {};
         std::vector<uint8_t> buf;
-        bool done = {};
     };
 
     auto const test_incomplete_dir_threadfunc = [](TestIncompleteDirData* data) noexcept {
-        if (tr_ioWrite(*data->tor, data->session->openFiles(), data->tor->block_loc(data->block), data->buf) == 0) {
-            data->tor->on_block_received(data->block);
+        if (data->tor->on_block_received(data->block)) {
+            data->tor->save_block(data->block, std::make_unique<tr::LocalData::BlockData>(data->buf));
         }
-
-        data->done = true;
     };
 
     // now finish writing it
@@ -107,11 +104,11 @@ TEST_P(IncompleteDirTest, incompleteDir)
             data.buf.resize(tr_block_info::BlockSize);
             std::ranges::fill(data.buf, '\0');
             data.block = block_index;
-            data.done = false;
             session_->run_in_session_thread(test_incomplete_dir_threadfunc, &data);
 
-            auto const test = [&data]() {
-                return data.done;
+            // save_block() may return before the write finishes
+            auto const test = [tor, block_index]() {
+                return tor->has_block(block_index);
             };
             EXPECT_TRUE(waitFor(test, MaxWaitMsec));
         }

--- a/tests/libtransmission/test-fixtures.h
+++ b/tests/libtransmission/test-fixtures.h
@@ -27,8 +27,10 @@
 #include <libtransmission/transmission.h>
 
 #include <libtransmission/crypto-utils.h> // tr_base64_decode()
+#include <libtransmission/env.h> // tr_env_key_exists()
 #include <libtransmission/error.h>
 #include <libtransmission/file.h> // tr_sys_file_*()
+#include <libtransmission/local-data.h>
 #include <libtransmission/macros.h>
 #include <libtransmission/quark.h>
 #include <libtransmission/torrent-builder.h>
@@ -498,6 +500,16 @@ protected:
         SandboxedTest::SetUp();
 
         session_ = sessionInit(settings());
+
+        // Pump parked completions from the session thread.
+        session_->local_data.set_wake([this]() { session_->queue_session_thread([this]() { session_->local_data.pump(); }); });
+
+        // tr::LocalData may deliver completions late and out of order.
+        // TR_LOCAL_DATA_SHUFFLE makes it do so, so code that assumes
+        // otherwise fails here.
+        if (tr_env_key_exists("TR_LOCAL_DATA_SHUFFLE")) {
+            session_->local_data.set_completions(tr::LocalData::Completions::Shuffled);
+        }
 
         // Every torrent in this session reports here when it finishes verifying,
         // so blockingTorrentVerify() can wait on any of them.

--- a/tests/libtransmission/torrent-disk-io-test.cc
+++ b/tests/libtransmission/torrent-disk-io-test.cc
@@ -1,0 +1,128 @@
+// This file Copyright (C) 2026 Mnemosaic LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosaic LLC.
+// License text can be found in the licenses/ folder.
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include <libtransmission/error.h>
+#include <libtransmission/local-data.h>
+#include <libtransmission/torrent.h>
+
+#include "test-fixtures.h"
+
+namespace tr::test
+{
+namespace
+{
+auto constexpr MaxWaitMsec = 5000;
+
+// Covers the torrent call sites that read and write through tr::LocalData.
+// The fixture parks completions instead of shuffling them, so each test
+// decides when they arrive.
+class TorrentDiskIoTest : public SessionTest
+{
+protected:
+    void SetUp() override
+    {
+        SessionTest::SetUp();
+        session_->local_data.set_completions(tr::LocalData::Completions::Deferred);
+    }
+
+    [[nodiscard]] static std::unique_ptr<tr::LocalData::BlockData> zeroBlock(tr_torrent const* tor, tr_block_index_t block)
+    {
+        auto data = std::make_unique<tr::LocalData::BlockData>();
+        data->resize(tor->block_size(block));
+        std::ranges::fill(*data, uint8_t{ 0U });
+        return data;
+    }
+
+    // Runs `func` on the session thread and waits for it to finish.
+    void inSessionThread(std::function<void()> const& func)
+    {
+        auto done = false;
+        session_->run_in_session_thread([&func, &done]() {
+            func();
+            done = true;
+        });
+        ASSERT_TRUE(waitFor([&done]() { return done; }, MaxWaitMsec));
+    }
+};
+
+} // namespace
+
+TEST_F(TorrentDiskIoTest, blockIsNotOursUntilItsWriteFinishes)
+{
+    auto* const tor = zeroTorrentInit(ZeroTorrentState::Partial);
+    auto const block = tor->block_span_for_piece(0).begin;
+
+    inSessionThread([this, tor, block]() {
+        ASSERT_TRUE(tor->on_block_received(block));
+        tor->save_block(block, zeroBlock(tor, block));
+
+        // the write hasn't finished, so the block isn't ours yet
+        EXPECT_FALSE(tor->has_block(block));
+        EXPECT_TRUE(tor->has_block_or_pending(block));
+
+        // and a second copy of it is refused while that write is in flight
+        EXPECT_FALSE(tor->on_block_received(block));
+
+        session_->local_data.pump();
+        EXPECT_TRUE(tor->has_block(block));
+
+        // now that we have it, another copy is still refused
+        EXPECT_FALSE(tor->on_block_received(block));
+    });
+}
+
+TEST_F(TorrentDiskIoTest, failedWriteStopsTorrent)
+{
+    auto* const tor = zeroTorrentInit(ZeroTorrentState::Partial);
+    auto const block = tor->block_span_for_piece(0).begin;
+
+    inSessionThread([tor, block]() {
+        ASSERT_TRUE(tor->on_block_received(block));
+        EXPECT_FALSE(tor->error().is_local_error());
+
+        auto error = tr_error{};
+        error.set_from_errno(ENOSPC);
+        tor->on_block_written(block, error);
+
+        EXPECT_TRUE(tor->error().is_local_error());
+        EXPECT_FALSE(tor->is_running());
+
+        // the block was not counted, and is no longer pending
+        EXPECT_FALSE(tor->has_block(block));
+        EXPECT_FALSE(tor->has_block_or_pending(block));
+    });
+}
+
+TEST_F(TorrentDiskIoTest, hashResultForInvalidatedPieceIsDropped)
+{
+    auto* const tor = zeroTorrentInit(ZeroTorrentState::Partial);
+    auto const span = tor->block_span_for_piece(0);
+
+    inSessionThread([this, tor, span]() {
+        for (auto block = span.begin; block < span.end; ++block) {
+            ASSERT_TRUE(tor->on_block_received(block));
+            tor->save_block(block, zeroBlock(tor, block));
+        }
+
+        // deliver the writes, which leaves the piece's hash in flight
+        session_->local_data.pump();
+        EXPECT_TRUE(tor->has_piece(0));
+
+        // Invalidate the piece while its hash is still in flight.
+        // The hash is now about a version of the piece that no longer
+        // exists, so delivering it must not mark the piece complete again.
+        tor->set_has_piece(0, false);
+        session_->local_data.pump();
+        EXPECT_FALSE(tor->has_piece(0));
+    });
+}
+
+} // namespace tr::test


### PR DESCRIPTION
## Description

Implement P0 of #200.

Block reads and writes and completed-piece hashes now go through the `LocalData` facade instead of calling `tr_ioRead()` and `tr_ioWrite()` directly. The facade doesn't run anything asynchronously yet, so this phase is all setup and doesn't change behavior on its own.

Each of those operations now finishes in a completion handler. A caller can no longer assume the op is done when the call returns. Three of them used to assume synchronous writes:

  - has_block(B) now means B's write returned. Requests and duplicate rejection still happen when the block arrives from the peer, but completion_.add_block() and the piece hash wait for the write. A pending-write set covers the gap, so a block being written is neither re-requested nor written twice.

  - tr_ioWrite() no longer sets the torrent error and stops the torrent. It reports the failure and the session thread decides.

  - an upload read looks its request up by value when it completes. A request that was cancelled or rejected in the meantime drops its data, instead of answering whichever request now sits at the front of the queue.

The LT.ShuffledDiskIo test runs the disk-IO suites a second time, with completions parked and released out of order. tr::LocalData's ordering contract allows that, so whatever breaks under it is a caller assuming an ordering nobody promised. That is why this rework lands before any worker thread does. Only the test fixture turns the mode on, so it never reaches a production session.

Related fixes:

  - the 16 KiB per-block buffers were zero-filled and then immediately overwritten. LocalData::BlockData leaves them alone.

  - the full-preallocation fallback wrote 4 KiB at a time. It runs on FAT and exFAT, which are usually slow external drives, so it now writes 1 MiB at a time.

  - a full receive buffer left the read event enabled, so libevent spun on a socket peer-io was not going to read from.

P0 itself doesn't have any user-visible changes, but a couple of related fixes do:

Notes: Torrent disk reads and writes now run in the background, so a slow or busy drive no longer stalls the UI or other transfers, and seeding from disk is faster.

Notes:  Faster full file preallocation on FAT or exFAT drives.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
