### PR TITLE
fix: regression in zero-byte files support in `.resume` files

### DIFF
--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -3,7 +3,7 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#include <algorithm> // std::min
+#include <algorithm> // std::min, std::ranges::adjacent_find, std::ranges::sort
 #include <cstdint>
 #include <cstring>
 #include <ctime>
@@ -431,13 +431,46 @@ tr_resume::fields_t load_filenames(tr_variant::Map const& map, tr_torrent* tor)
         return {};
     }
 
+    // The pathname each file would end up with. The mapping is built in full
+    // before any of it is applied, since a duplicate can turn up at any
+    // position and the entries before it would already be on their files.
+    auto subpaths = std::vector<std::string_view>{};
+    subpaths.reserve(n_files);
     for (tr_file_index_t i = 0, pos = 0; i < n_files; ++i) {
-        if (!file_has_list_entry(tor, alignment, i)) {
-            continue;
+        // A file with no entry, or whose entry isn't a usable pathname,
+        // keeps the pathname its metainfo gave it.
+        auto subpath = std::string_view{ tor->file_subpath(i) };
+
+        if (file_has_list_entry(tor, alignment, i)) {
+            if (auto const sv = (*list)[pos++].value_if<std::string_view>(); sv && !std::empty(*sv)) {
+                subpath = *sv;
+            }
         }
 
-        if (auto const sv = (*list)[pos++].value_if<std::string_view>(); sv && !std::empty(*sv)) {
-            tor->set_file_subpath(i, *sv);
+        subpaths.push_back(subpath);
+    }
+
+    // Two files sharing a pathname share one file on disk, but the open-file
+    // cache keys on file index, so each gets its own descriptor and they
+    // write over each other. A torrent's own file list can't name a file
+    // twice, so a duplicate is the saved list's, and the rest of that list is
+    // no more trustworthy than the part that collided.
+    auto sorted = subpaths;
+    std::ranges::sort(sorted);
+    if (auto const dupe = std::ranges::adjacent_find(sorted); dupe != std::end(sorted)) {
+        tr_logAddWarnTor(
+            tor,
+            fmt::format(
+                "Not using the filenames saved for this torrent: they give '{:s}' to more than one file. "
+                "Using the filenames from the torrent instead; the saved ones are in '{:s}' until it is written over.",
+                *dupe,
+                tor->resume_file()));
+        return {};
+    }
+
+    for (tr_file_index_t i = 0; i < n_files; ++i) {
+        if (auto const subpath = subpaths[i]; subpath != tor->file_subpath(i)) {
+            tor->set_file_subpath(i, subpath);
         }
     }
 

--- a/libtransmission/resume.cc
+++ b/libtransmission/resume.cc
@@ -43,6 +43,54 @@ constexpr auto MaxRememberedPeers = 200U;
 
 // ---
 
+// How a saved per-file list's entries line up with a torrent's files.
+enum class FileListAlignment : uint8_t {
+    ByIndex, // one entry per file, in file order
+    SkipEmptyFiles, // one entry per nonempty file, in file order
+    Unusable, // no reading pairs the entries up with the files
+};
+
+[[nodiscard]] FileListAlignment file_list_alignment(tr_torrent const* const tor, size_t const n_list)
+{
+    auto const n_files = tor->file_count();
+
+    if (n_list == n_files) {
+        return FileListAlignment::ByIndex;
+    }
+
+    // Resume files written before zero-length files were part of a torrent's
+    // file list are short by exactly those files, so each entry after an
+    // omitted one sits at a lower position in the list than its file index.
+    // Skipping the zero-length files while walking the list realigns them.
+    auto n_empty_files = size_t{};
+    for (tr_file_index_t i = 0; i < n_files; ++i) {
+        if (tor->file_size(i) == 0U) {
+            ++n_empty_files;
+        }
+    }
+
+    if (n_list + n_empty_files == n_files) {
+        return FileListAlignment::SkipEmptyFiles;
+    }
+
+    // A list of any other length can't be paired up with the files, so none
+    // of it can be applied: a partial mapping would give file indices other
+    // files' settings.
+    return FileListAlignment::Unusable;
+}
+
+// Whether a list with this alignment has an entry for this file. Zero-length
+// files have none in a list that was written without them.
+[[nodiscard]] bool file_has_list_entry(
+    tr_torrent const* const tor,
+    FileListAlignment const alignment,
+    tr_file_index_t const file_index)
+{
+    return alignment != FileListAlignment::SkipEmptyFiles || tor->file_size(file_index) != 0U;
+}
+
+// ---
+
 void save_peers(tr_variant::Map& map, tr_torrent const* tor)
 {
     if (auto const pex = tr_peerMgrGetPeers(tor, TR_AF_INET, TR_PEERS_INTERESTING, MaxRememberedPeers); !std::empty(pex)) {
@@ -157,14 +205,10 @@ tr_resume::fields_t load_dnd(tr_variant::Map const& map, tr_torrent* tor)
     }
 
     auto const n = tor->file_count();
-    if (std::size(*list) != n) {
-        tr_logAddDebugTor(
-            tor,
-            fmt::format(
-                "Couldn't load DND flags. DND list {} has {} children; torrent has {} files",
-                fmt::ptr(list),
-                std::size(*list),
-                n));
+    auto const n_list = std::size(*list);
+    auto const alignment = file_list_alignment(tor, n_list);
+
+    if (alignment == FileListAlignment::Unusable) {
         return {};
     }
 
@@ -173,12 +217,15 @@ tr_resume::fields_t load_dnd(tr_variant::Map const& map, tr_torrent* tor)
     wanted.reserve(n);
     unwanted.reserve(n);
 
-    for (tr_file_index_t i = 0; i < n; ++i) {
-        if ((*list)[i].value_if<bool>().value_or(false)) {
-            unwanted.push_back(i);
-        } else {
-            wanted.push_back(i);
+    for (tr_file_index_t i = 0, pos = 0; i < n; ++i) {
+        // A file with no entry is wanted: it is zero-length, so there is no
+        // download to opt out of, and that is what a fresh torrent gives it.
+        auto dnd = false;
+        if (file_has_list_entry(tor, alignment, i)) {
+            dnd = (*list)[pos++].value_if<bool>().value_or(false);
         }
+
+        (dnd ? unwanted : wanted).push_back(i);
     }
 
     tor->init_files_wanted(unwanted, false);
@@ -203,13 +250,25 @@ void save_file_priorities(tr_variant::Map& map, tr_torrent const* tor)
 tr_resume::fields_t load_file_priorities(tr_variant::Map const& map, tr_torrent* tor)
 {
     auto const* const list = map.find_if<tr_variant::Vector>(TR_KEY_priority);
-    auto const n = tor->file_count();
-    if (list == nullptr || std::size(*list) != n) {
+    if (list == nullptr) {
         return {};
     }
 
-    for (tr_file_index_t i = 0; i < n; ++i) {
-        if (auto const priority = (*list)[i].value_if<int64_t>(); priority) {
+    auto const n = tor->file_count();
+    auto const n_list = std::size(*list);
+    auto const alignment = file_list_alignment(tor, n_list);
+
+    if (alignment == FileListAlignment::Unusable) {
+        return {};
+    }
+
+    // A file with no entry keeps the priority a fresh torrent gives it.
+    for (tr_file_index_t i = 0, pos = 0; i < n; ++i) {
+        if (!file_has_list_entry(tor, alignment, i)) {
+            continue;
+        }
+
+        if (auto const priority = (*list)[pos++].value_if<int64_t>(); priority) {
             tor->set_file_priority(i, static_cast<tr_priority_t>(*priority));
         }
     }
@@ -366,8 +425,18 @@ tr_resume::fields_t load_filenames(tr_variant::Map const& map, tr_torrent* tor)
 
     auto const n_files = tor->file_count();
     auto const n_list = std::size(*list);
-    for (tr_file_index_t i = 0; i < n_files && i < n_list; ++i) {
-        if (auto const sv = (*list)[i].value_if<std::string_view>(); sv && !std::empty(*sv)) {
+    auto const alignment = file_list_alignment(tor, n_list);
+
+    if (alignment == FileListAlignment::Unusable) {
+        return {};
+    }
+
+    for (tr_file_index_t i = 0, pos = 0; i < n_files; ++i) {
+        if (!file_has_list_entry(tor, alignment, i)) {
+            continue;
+        }
+
+        if (auto const sv = (*list)[pos++].value_if<std::string_view>(); sv && !std::empty(*sv)) {
             tor->set_file_subpath(i, *sv);
         }
     }
@@ -510,6 +579,22 @@ tr_resume::fields_t load_progress(tr_variant::Map const& map, tr_torrent* tor, t
 
             mtimes.push_back(time_checked);
         }
+    }
+
+    // A file whose mtime we take from the entry saved for some other file
+    // has its pieces dropped from the checked set, so a legacy-length list
+    // costs a rehash of everything after its first zero-length file unless
+    // its entries are moved back to their own files first.
+    if (auto const alignment = file_list_alignment(tor, std::size(mtimes)); alignment == FileListAlignment::SkipEmptyFiles) {
+        // Zero-length files get 0, marking their pieces untested: their
+        // entries are the ones the saved list left out.
+        auto aligned = std::vector<time_t>(n_files, time_t{});
+        for (tr_file_index_t i = 0, pos = 0; i < n_files; ++i) {
+            if (file_has_list_entry(tor, alignment, i)) {
+                aligned[i] = mtimes[pos++];
+            }
+        }
+        mtimes = std::move(aligned);
     }
 
     if (std::size(mtimes) != n_files) {

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -329,6 +329,11 @@ struct tr_torrent {
         return completion_.has_piece(piece);
     }
 
+    [[nodiscard]] constexpr bool is_piece_checked(tr_piece_index_t const piece) const
+    {
+        return checked_pieces_.test(piece);
+    }
+
     [[nodiscard]] constexpr auto has_block(tr_block_index_t block) const
     {
         return completion_.has_block(block);
@@ -1139,11 +1144,6 @@ private:
         }
 
         return n_secs;
-    }
-
-    [[nodiscard]] constexpr bool is_piece_checked(tr_piece_index_t piece) const
-    {
-        return checked_pieces_.test(piece);
     }
 
     [[nodiscard]] bool check_piece(tr_piece_index_t piece) const;

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -42,6 +42,7 @@ target_sources(libtransmission-test
         quark-test.cc
         remove-test.cc
         rename-test.cc
+        resume-test.cc
         rpc-test.cc
         serializer-tests.cc
         session-alt-speeds-test.cc

--- a/tests/libtransmission/resume-test.cc
+++ b/tests/libtransmission/resume-test.cc
@@ -278,6 +278,31 @@ TEST_F(ResumeTest, savedFilenamesListLongerThanFileCount)
     expectSubpaths(torrentInit(builder, file_sizes, savedFilenames(saved)), canonicalSubpaths(std::size(file_sizes)));
 }
 
+// A client that applied a legacy-length list by position saved the result back
+// at full length, so the last pathname went to two files. Its length says
+// nothing; the duplicate is what gives it away. None of the list is applied,
+// not even the entries ahead of the duplicate: whatever produced one wrong
+// pathname leaves no reason to trust the others.
+TEST_F(ResumeTest, savedFilenamesFullLengthListWithDuplicate)
+{
+    auto const file_sizes = std::vector<uint64_t>{ 1U, 0U, 1U, 1U };
+    auto const saved = std::vector<std::string>{ "root/renamed", "root/f2", "root/f3", "root/f3" };
+
+    auto builder = tr_torrent_builder{ session_ };
+    expectSubpaths(torrentInit(builder, file_sizes, savedFilenames(saved)), canonicalSubpaths(std::size(file_sizes)));
+}
+
+// A file with no entry of its own still holds the pathname its metainfo gave
+// it, so an entry that names that pathname collides with it.
+TEST_F(ResumeTest, savedFilenamesEntryCollidingWithUnlistedFile)
+{
+    auto const file_sizes = std::vector<uint64_t>{ 1U, 0U, 1U, 1U };
+    auto const saved = std::vector<std::string>{ "root/f1", "root/f2", "root/f3" };
+
+    auto builder = tr_torrent_builder{ session_ };
+    expectSubpaths(torrentInit(builder, file_sizes, savedFilenames(saved)), canonicalSubpaths(std::size(file_sizes)));
+}
+
 // An entry that isn't a usable pathname leaves that one file alone. It still
 // holds a position, so the entries after it keep their alignment.
 TEST_F(ResumeTest, savedFilenamesUnusableEntry)

--- a/tests/libtransmission/resume-test.cc
+++ b/tests/libtransmission/resume-test.cc
@@ -1,0 +1,433 @@
+// This file Copyright © Mnemosaic LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosaic LLC.
+// License text can be found in the licenses/ folder.
+
+#include <cstddef> // size_t
+#include <cstdint> // int64_t, uint32_t, uint64_t
+#include <ctime> // time_t
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include <gtest/gtest.h>
+
+#include <libtransmission/transmission.h>
+
+#include <libtransmission/file.h>
+#include <libtransmission/quark.h>
+#include <libtransmission/session.h>
+#include <libtransmission/torrent-builder.h>
+#include <libtransmission/torrent.h>
+#include <libtransmission/tr-strbuf.h>
+#include <libtransmission/variant.h>
+
+#include "test-fixtures.h"
+
+using namespace std::literals;
+
+namespace tr::test
+{
+namespace
+{
+auto constexpr PieceSize = uint32_t{ 32768U };
+auto constexpr Sha1Len = size_t{ 20U };
+
+[[nodiscard]] std::string bencStr(std::string_view const sv)
+{
+    return fmt::format("{:d}:{:s}", std::size(sv), sv);
+}
+
+[[nodiscard]] std::string subpath(size_t const i)
+{
+    return fmt::format("root/f{:d}", i);
+}
+
+// A torrent named "root" whose files are "root/f0", "root/f1", ... with the
+// given sizes. Nothing here hashes the payload, so the piece hashes are filler.
+[[nodiscard]] std::string makeTorrentBenc(std::vector<uint64_t> const& file_sizes)
+{
+    auto files = std::string{};
+    auto total_size = uint64_t{};
+    for (size_t i = 0, n = std::size(file_sizes); i < n; ++i) {
+        files += fmt::format("d6:lengthi{:d}e4:pathl{:s}ee", file_sizes[i], bencStr(fmt::format("f{:d}", i)));
+        total_size += file_sizes[i];
+    }
+
+    auto const n_pieces = (total_size + PieceSize - 1U) / PieceSize;
+    auto const pieces = std::string(n_pieces * Sha1Len, 'A');
+
+    return fmt::format(
+        "d4:infod5:filesl{:s}e4:name4:root12:piece lengthi{:d}e6:pieces{:s}ee",
+        files,
+        PieceSize,
+        bencStr(pieces));
+}
+
+[[nodiscard]] std::vector<std::string> canonicalSubpaths(size_t const n_files)
+{
+    auto ret = std::vector<std::string>{};
+    ret.reserve(n_files);
+    for (size_t i = 0; i < n_files; ++i) {
+        ret.emplace_back(subpath(i));
+    }
+    return ret;
+}
+
+// The filename list saved by a Transmission that left zero-length files out of
+// a torrent's file list.
+[[nodiscard]] std::vector<std::string> legacySubpaths(std::vector<uint64_t> const& file_sizes)
+{
+    auto ret = std::vector<std::string>{};
+    for (size_t i = 0, n = std::size(file_sizes); i < n; ++i) {
+        if (file_sizes[i] != 0U) {
+            ret.emplace_back(subpath(i));
+        }
+    }
+    return ret;
+}
+
+[[nodiscard]] tr_variant::Map savedFilenames(std::vector<std::string> const& subpaths)
+{
+    auto list = tr_variant::Vector{};
+    list.reserve(std::size(subpaths));
+    for (auto const& subpath : subpaths) {
+        list.emplace_back(subpath);
+    }
+
+    auto map = tr_variant::Map{ 1U };
+    map.try_emplace(TR_KEY_files, std::move(list));
+    return map;
+}
+
+[[nodiscard]] tr_variant::Vector dndList(std::vector<bool> const& dnd)
+{
+    auto ret = tr_variant::Vector{};
+    ret.reserve(std::size(dnd));
+    for (auto const flag : dnd) {
+        ret.emplace_back(flag);
+    }
+    return ret;
+}
+
+struct Layout {
+    std::string_view name;
+    std::vector<uint64_t> file_sizes;
+};
+
+// The ways a torrent's zero-length files can sit among its other files.
+[[nodiscard]] std::vector<Layout> layouts()
+{
+    return {
+        { .name = "zero-length file first"sv, .file_sizes = { 0U, 1U, 1U, 1U } },
+        { .name = "zero-length file in the middle"sv, .file_sizes = { 1U, 0U, 1U, 1U } },
+        { .name = "zero-length file last, so nothing shifts"sv, .file_sizes = { 1U, 1U, 1U, 0U } },
+        { .name = "two adjacent zero-length files"sv, .file_sizes = { 1U, 0U, 0U, 1U } },
+        { .name = "two zero-length files apart"sv, .file_sizes = { 0U, 1U, 0U, 1U } },
+    };
+}
+
+[[nodiscard]] tr_variant::Vector priorityList(std::vector<tr_priority_t> const& priorities)
+{
+    auto ret = tr_variant::Vector{};
+    ret.reserve(std::size(priorities));
+    for (auto const priority : priorities) {
+        ret.emplace_back(static_cast<int64_t>(priority));
+    }
+    return ret;
+}
+
+class ResumeTest : public SessionTest
+{
+protected:
+    // Add a torrent with the given file sizes, having first written `resume`
+    // as its .resume file.
+    [[nodiscard]] tr_torrent* torrentInit(
+        tr_torrent_builder& builder,
+        std::vector<uint64_t> const& file_sizes,
+        tr_variant::Map&& resume) const
+    {
+        auto const benc = makeTorrentBenc(file_sizes);
+        builder.set_paused(true);
+        EXPECT_TRUE(builder.set_metainfo(benc));
+
+        auto serde = tr_variant_serde::benc();
+        auto const filename = builder.metainfo().resume_file(session_->resumeDir());
+        EXPECT_TRUE(serde.to_file(tr_variant{ std::move(resume) }, filename)) << serde.error_;
+
+        auto* const tor = tr_torrentNew(&builder, nullptr);
+        EXPECT_NE(nullptr, tor);
+        return tor;
+    }
+
+    static void expectSubpaths(tr_torrent const* tor, std::vector<std::string> const& expected)
+    {
+        ASSERT_EQ(std::size(expected), tor->file_count());
+        for (tr_file_index_t i = 0, n = tor->file_count(); i < n; ++i) {
+            EXPECT_EQ(expected[i], tor->file_subpath(i)) << " at file " << i;
+        }
+    }
+
+    static void expectWantedAndPriorities(
+        tr_torrent const* tor,
+        std::vector<bool> const& wanted,
+        std::vector<tr_priority_t> const& priorities)
+    {
+        ASSERT_EQ(std::size(wanted), tor->file_count());
+        ASSERT_EQ(std::size(priorities), tor->file_count());
+        for (tr_file_index_t i = 0, n = tor->file_count(); i < n; ++i) {
+            auto const file = tr_torrentFile(tor, i);
+            EXPECT_EQ(wanted[i], file.wanted) << " at file " << i;
+            EXPECT_EQ(priorities[i], file.priority) << " at file " << i;
+        }
+    }
+
+    // Write each file to the download dir and return its mtime, so that a
+    // resume file can name the mtimes the files on disk actually have.
+    [[nodiscard]] std::vector<time_t> createFiles(std::vector<uint64_t> const& file_sizes) const
+    {
+        auto ret = std::vector<time_t>{};
+        ret.reserve(std::size(file_sizes));
+
+        for (size_t i = 0, n = std::size(file_sizes); i < n; ++i) {
+            auto const path = tr_pathbuf{ session_->downloadDir(), '/', subpath(i) };
+            createFileWithContents(path, std::string(static_cast<size_t>(file_sizes[i]), 'x'));
+            auto const info = tr_sys_path_get_info(path);
+            EXPECT_TRUE(info) << path.c_str();
+            ret.push_back(info ? info->last_modified_at : 0);
+        }
+
+        return ret;
+    }
+};
+} // namespace
+
+// A full-length list is the ordinary case: apply it verbatim. This is also
+// what we save for a torrent that has zero-length files, so the zero-length
+// files here must not send it down the realigning path below.
+TEST_F(ResumeTest, savedFilenamesFullLengthList)
+{
+    auto const file_sizes = std::vector<uint64_t>{ 1U, 0U, 1U, 1U };
+    auto saved = canonicalSubpaths(std::size(file_sizes));
+    saved[2] = "root/renamed";
+
+    auto builder = tr_torrent_builder{ session_ };
+    expectSubpaths(torrentInit(builder, file_sizes, savedFilenames(saved)), saved);
+}
+
+// Transmission 4.0.x omitted zero-length files from a torrent's file list, so
+// the list it saved is short by exactly those files and every pathname after
+// an omitted one sits at a lower position than its file index. Applying such a
+// list by position shifts the names onto the wrong files and leaves the last
+// name assigned to two file indices.
+TEST_F(ResumeTest, savedFilenamesListWrittenWithoutZeroLengthFiles)
+{
+    for (auto const& [name, file_sizes] : layouts()) {
+        SCOPED_TRACE(name);
+
+        // Rename the list's last entry. It belongs to the last non-empty
+        // file, which is the one a positional application of a short list
+        // would leave duplicated onto an earlier file.
+        auto saved = legacySubpaths(file_sizes);
+        saved.back() = "root/renamed";
+
+        auto expected = canonicalSubpaths(std::size(file_sizes));
+        for (size_t i = std::size(file_sizes); i > 0U; --i) {
+            if (file_sizes[i - 1U] != 0U) {
+                expected[i - 1U] = "root/renamed";
+                break;
+            }
+        }
+
+        auto builder = tr_torrent_builder{ session_ };
+        expectSubpaths(torrentInit(builder, file_sizes, savedFilenames(saved)), expected);
+    }
+}
+
+// Without zero-length files to account for, a short list has no reading that
+// pairs it up with the files, so none of it is applied.
+TEST_F(ResumeTest, savedFilenamesShortListWithoutZeroLengthFiles)
+{
+    auto const file_sizes = std::vector<uint64_t>{ 1U, 1U, 1U, 1U };
+    auto const saved = std::vector<std::string>{ "root/renamed", "root/also-renamed", "root/f2" };
+
+    auto builder = tr_torrent_builder{ session_ };
+    expectSubpaths(torrentInit(builder, file_sizes, savedFilenames(saved)), canonicalSubpaths(std::size(file_sizes)));
+}
+
+// Nor is a list applied when it's short by more than the zero-length files: a
+// partial mapping would point file indices at other files' data.
+TEST_F(ResumeTest, savedFilenamesListOfUnusableLength)
+{
+    auto const file_sizes = std::vector<uint64_t>{ 1U, 0U, 1U, 1U };
+    auto const saved = std::vector<std::string>{ "root/renamed", "root/also-renamed" };
+
+    auto builder = tr_torrent_builder{ session_ };
+    expectSubpaths(torrentInit(builder, file_sizes, savedFilenames(saved)), canonicalSubpaths(std::size(file_sizes)));
+}
+
+// A list longer than the file count is unusable too.
+TEST_F(ResumeTest, savedFilenamesListLongerThanFileCount)
+{
+    auto const file_sizes = std::vector<uint64_t>{ 1U, 0U, 1U };
+    auto const saved = std::vector<std::string>{ "root/renamed", "root/f1", "root/f2", "root/f3" };
+
+    auto builder = tr_torrent_builder{ session_ };
+    expectSubpaths(torrentInit(builder, file_sizes, savedFilenames(saved)), canonicalSubpaths(std::size(file_sizes)));
+}
+
+// An entry that isn't a usable pathname leaves that one file alone. It still
+// holds a position, so the entries after it keep their alignment.
+TEST_F(ResumeTest, savedFilenamesUnusableEntry)
+{
+    auto const file_sizes = std::vector<uint64_t>{ 1U, 0U, 1U, 1U };
+
+    auto list = tr_variant::Vector{};
+    list.emplace_back("root/renamed"); // -> f0
+    list.emplace_back(int64_t{ 0 }); // not a pathname; f2 keeps its own
+    list.emplace_back("root/also-renamed"); // -> f3
+    auto map = tr_variant::Map{ 1U };
+    map.try_emplace(TR_KEY_files, std::move(list));
+
+    auto expected = canonicalSubpaths(std::size(file_sizes));
+    expected[0] = "root/renamed";
+    expected[3] = "root/also-renamed";
+
+    auto builder = tr_torrent_builder{ session_ };
+    expectSubpaths(torrentInit(builder, file_sizes, std::move(map)), expected);
+}
+
+// Full-length dnd and priority lists are the ordinary case: apply them
+// verbatim. The zero-length file here must not send them down the realigning
+// path, so it gets back the settings saved for it.
+TEST_F(ResumeTest, savedDndAndPrioritiesFullLengthLists)
+{
+    auto const file_sizes = std::vector<uint64_t>{ 1U, 0U, 1U, 1U };
+
+    auto map = savedFilenames(canonicalSubpaths(std::size(file_sizes)));
+    map.try_emplace(TR_KEY_dnd, dndList({ false, true, false, true }));
+    map.try_emplace(TR_KEY_priority, priorityList({ TR_PRI_NORMAL, TR_PRI_HIGH, TR_PRI_LOW, TR_PRI_NORMAL }));
+
+    auto builder = tr_torrent_builder{ session_ };
+    expectWantedAndPriorities(
+        torrentInit(builder, file_sizes, std::move(map)),
+        { true, false, true, false },
+        { TR_PRI_NORMAL, TR_PRI_HIGH, TR_PRI_LOW, TR_PRI_NORMAL });
+}
+
+// The dnd and priority lists in a 4.0.x resume file are short by the same
+// zero-length files as its filename list, and realign the same way. A file
+// with no entry keeps what a fresh torrent gives it: wanted, normal priority.
+TEST_F(ResumeTest, savedDndAndPrioritiesListsWrittenWithoutZeroLengthFiles)
+{
+    for (auto const& [name, file_sizes] : layouts()) {
+        SCOPED_TRACE(name);
+
+        // "don't download the last file, and give it high priority", as 4.0.x
+        // would have saved it: one entry per nonempty file. Those settings
+        // belong to the last nonempty file, which is the one a positional
+        // application of a short list would leave on an earlier file.
+        auto dnd = std::vector<bool>{};
+        auto priorities = std::vector<tr_priority_t>{};
+        for (auto const file_size : file_sizes) {
+            if (file_size != 0U) {
+                dnd.push_back(false);
+                priorities.push_back(TR_PRI_NORMAL);
+            }
+        }
+        dnd.back() = true;
+        priorities.back() = TR_PRI_HIGH;
+
+        auto expected_wanted = std::vector<bool>(std::size(file_sizes), true);
+        auto expected_priorities = std::vector<tr_priority_t>(std::size(file_sizes), TR_PRI_NORMAL);
+        for (size_t i = std::size(file_sizes); i > 0U; --i) {
+            if (file_sizes[i - 1U] != 0U) {
+                expected_wanted[i - 1U] = false;
+                expected_priorities[i - 1U] = TR_PRI_HIGH;
+                break;
+            }
+        }
+
+        auto map = savedFilenames(legacySubpaths(file_sizes));
+        map.try_emplace(TR_KEY_dnd, dndList(dnd));
+        map.try_emplace(TR_KEY_priority, priorityList(priorities));
+
+        auto builder = tr_torrent_builder{ session_ };
+        expectWantedAndPriorities(torrentInit(builder, file_sizes, std::move(map)), expected_wanted, expected_priorities);
+    }
+}
+
+// Without zero-length files to account for, short dnd and priority lists have
+// no reading that pairs them up with the files, so none of them is applied.
+TEST_F(ResumeTest, savedDndAndPrioritiesShortListsWithoutZeroLengthFiles)
+{
+    auto const file_sizes = std::vector<uint64_t>{ 1U, 1U, 1U, 1U };
+
+    auto map = savedFilenames(canonicalSubpaths(std::size(file_sizes)));
+    map.try_emplace(TR_KEY_dnd, dndList({ false, true, false }));
+    map.try_emplace(TR_KEY_priority, priorityList({ TR_PRI_HIGH, TR_PRI_HIGH, TR_PRI_HIGH }));
+
+    auto builder = tr_torrent_builder{ session_ };
+    expectWantedAndPriorities(
+        torrentInit(builder, file_sizes, std::move(map)),
+        { true, true, true, true },
+        { TR_PRI_NORMAL, TR_PRI_NORMAL, TR_PRI_NORMAL, TR_PRI_NORMAL });
+}
+
+// Nor are they applied when they're short by more than the zero-length files.
+TEST_F(ResumeTest, savedDndAndPrioritiesListsOfUnusableLength)
+{
+    auto const file_sizes = std::vector<uint64_t>{ 1U, 0U, 1U, 1U };
+
+    auto map = savedFilenames(canonicalSubpaths(std::size(file_sizes)));
+    map.try_emplace(TR_KEY_dnd, dndList({ false, true }));
+    map.try_emplace(TR_KEY_priority, priorityList({ TR_PRI_HIGH, TR_PRI_HIGH }));
+
+    auto builder = tr_torrent_builder{ session_ };
+    expectWantedAndPriorities(
+        torrentInit(builder, file_sizes, std::move(map)),
+        { true, true, true, true },
+        { TR_PRI_NORMAL, TR_PRI_NORMAL, TR_PRI_NORMAL, TR_PRI_NORMAL });
+}
+
+// The mtimes list in a resume file written without zero-length files realigns
+// like the others. A file checked against another file's mtime looks changed,
+// so applying such a list by position throws away the checked state of every
+// piece after the torrent's first zero-length file and rehashes it.
+TEST_F(ResumeTest, savedMtimesListWrittenWithoutZeroLengthFiles)
+{
+    // One piece per nonempty file, so that each file's mtime decides one
+    // piece. The zero-length file has no piece of its own; it shares the one
+    // that begins where it does, which is f2's.
+    auto const file_sizes = std::vector<uint64_t>{ PieceSize, 0U, PieceSize, PieceSize, PieceSize };
+    auto const mtimes = createFiles(file_sizes);
+
+    // Save f4's real mtime and nobody else's: a file whose saved mtime is 0
+    // counts as untested, so f4's piece is the only one that can stay checked,
+    // and only if f4's entry lands back on f4.
+    auto mtime_list = tr_variant::Vector{};
+    mtime_list.emplace_back(int64_t{ 0 }); // f0
+    mtime_list.emplace_back(int64_t{ 0 }); // f2
+    mtime_list.emplace_back(int64_t{ 0 }); // f3
+    mtime_list.emplace_back(int64_t{ mtimes.back() }); // f4
+
+    auto progress = tr_variant::Map{ 3U };
+    progress.try_emplace(TR_KEY_mtimes, std::move(mtime_list));
+    progress.try_emplace(TR_KEY_pieces, tr_variant::unmanaged_string("all"sv));
+    progress.try_emplace(TR_KEY_blocks, tr_variant::unmanaged_string("all"sv));
+
+    auto map = savedFilenames(legacySubpaths(file_sizes));
+    map.try_emplace(TR_KEY_progress, std::move(progress));
+
+    auto builder = tr_torrent_builder{ session_ };
+    auto const* const tor = torrentInit(builder, file_sizes, std::move(map));
+
+    EXPECT_FALSE(tor->is_piece_checked(0)); // f0
+    EXPECT_FALSE(tor->is_piece_checked(1)); // f1 and f2
+    EXPECT_FALSE(tor->is_piece_checked(2)); // f3
+    EXPECT_TRUE(tor->is_piece_checked(3)); // f4
+}
+
+} // namespace tr::test


### PR DESCRIPTION
## Description

If a resume list is short by exactly the number of the torrent's zero-length files, realign the list while walking. This is to preserve any renames from 4.0.x. New regression tests by Claude.

Fixes #203.

Notes: Fixed a Transmission 4.1.0 regression that could cause torrents with zero-byte files to be handled incorrectly, sometimes losing downloaded progress.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
