### PR TITLE
refactor: extract torrent cell from xib.

### DIFF
--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -16,6 +16,7 @@
 {
     if (self = [super initWithFrame:frameRect]) {
         [self configureViews];
+        [self configurePriorities];
         [self setupConstraints];
     }
     return self;
@@ -34,7 +35,6 @@
 
     auto torrentTitleField = [[NSTextField alloc] init];
     torrentTitleField.textColor = NSColor.labelColor;
-    torrentTitleField.backgroundColor = NSColor.textBackgroundColor;
     torrentTitleField.font = [NSFont systemFontOfSize:12.0 weight:NSFontWeightRegular];
 
     auto torrentPriorityView = [[NSImageView alloc] init];
@@ -44,12 +44,10 @@
 
     auto torrentProgressField = [[NSTextField alloc] init];
     torrentProgressField.textColor = NSColor.secondaryLabelColor;
-    torrentProgressField.backgroundColor = NSColor.textBackgroundColor;
     torrentProgressField.font = [NSFont systemFontOfSize:10.0 weight:NSFontWeightRegular];
 
     auto torrentStatusField = [[NSTextField alloc] init];
     torrentStatusField.textColor = NSColor.secondaryLabelColor;
-    torrentStatusField.backgroundColor = NSColor.textBackgroundColor;
     torrentStatusField.font = [NSFont systemFontOfSize:10.0 weight:NSFontWeightRegular];
 
     auto torrentProgressBarView = [[NSView alloc] init];
@@ -66,6 +64,7 @@
         textField.selectable = NO;
         textField.bordered = NO;
         textField.drawsBackground = NO;
+        textField.lineBreakMode = NSLineBreakByTruncatingMiddle;
     }
 
     for (NSButton* button in @[ actionButton, controlButton, revealButton ]) {
@@ -102,6 +101,46 @@
     self.fTorrentProgressBarView = torrentProgressBarView;
     self.fControlButton = controlButton;
     self.fRevealButton = revealButton;
+}
+
+- (void)configurePriorities
+{
+    auto groupIndicatorView = self.fGroupIndicatorView;
+    auto iconView = self.fIconView;
+    auto actionButton = self.fActionButton;
+    auto torrentTitleField = self.fTorrentTitleField;
+    auto torrentPriorityView = self.fTorrentPriorityView;
+    auto torrentProgressField = self.fTorrentProgressField;
+    auto torrentStatusField = self.fTorrentStatusField;
+    auto controlButton = self.fControlButton;
+    auto revealButton = self.fRevealButton;
+
+    // left items
+    for (NSView* leftView in @[ groupIndicatorView, iconView ]) {
+        [leftView setContentHuggingPriority:NSLayoutPriorityDefaultLow + 1 forOrientation:NSLayoutConstraintOrientationHorizontal];
+        [leftView setContentHuggingPriority:NSLayoutPriorityDefaultLow + 1 forOrientation:NSLayoutConstraintOrientationVertical];
+    }
+
+    [actionButton setContentHuggingPriority:NSLayoutPriorityDefaultHigh forOrientation:NSLayoutConstraintOrientationVertical];
+
+    /// middle items
+    [torrentTitleField setContentHuggingPriority:NSLayoutPriorityRequired forOrientation:NSLayoutConstraintOrientationHorizontal];
+    [torrentTitleField setContentHuggingPriority:NSLayoutPriorityDefaultHigh forOrientation:NSLayoutConstraintOrientationVertical];
+    [torrentPriorityView setContentHuggingPriority:NSLayoutPriorityRequired forOrientation:NSLayoutConstraintOrientationHorizontal];
+    [torrentPriorityView setContentHuggingPriority:NSLayoutPriorityDefaultLow + 1 forOrientation:NSLayoutConstraintOrientationVertical];
+
+    for (NSView* middleView in @[ torrentProgressField, torrentStatusField ]) {
+        [middleView setContentHuggingPriority:NSLayoutPriorityDefaultLow + 1 forOrientation:NSLayoutConstraintOrientationHorizontal];
+        [middleView setContentHuggingPriority:NSLayoutPriorityDefaultHigh forOrientation:NSLayoutConstraintOrientationVertical];
+    }
+
+    // right items
+    for (NSView* rightView in @[ controlButton, revealButton ]) {
+        [rightView setContentHuggingPriority:NSLayoutPriorityRequired forOrientation:NSLayoutConstraintOrientationHorizontal];
+        [rightView setContentHuggingPriority:NSLayoutPriorityDefaultHigh forOrientation:NSLayoutConstraintOrientationVertical];
+        [rightView setContentCompressionResistancePriority:NSLayoutPriorityRequired
+                                            forOrientation:NSLayoutConstraintOrientationHorizontal];
+    }
 }
 
 - (void)setupConstraints
@@ -153,7 +192,7 @@
         [torrentStatusField.bottomAnchor constraintEqualToAnchor:self.bottomAnchor constant:-1],
 
         // torrentProgressBarView
-        [torrentProgressBarView.centerYAnchor constraintEqualToAnchor:torrentProgressBarView.centerYAnchor],
+        [torrentProgressBarView.topAnchor constraintEqualToAnchor:torrentProgressField.bottomAnchor constant:1],
         [torrentProgressBarView.heightAnchor constraintEqualToConstant:14],
 
         // controlButton

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -6,8 +6,170 @@
 #import "ProgressBarView.h"
 #import "ProgressGradients.h"
 #import "Torrent.h"
+#import "TorrentCellControlButton.h"
+#import "TorrentCellActionButton.h"
+#import "TorrentCellRevealButton.h"
 
 @implementation TorrentCell
+
+- (instancetype)initWithFrame:(NSRect)frameRect
+{
+    if (self = [super initWithFrame:frameRect]) {
+        [self configureViews];
+        [self setupConstraints];
+    }
+    return self;
+}
+
+- (void)configureViews
+{
+    auto groupIndicatorView = [[NSImageView alloc] init];
+
+    auto iconView = [[NSImageView alloc] init];
+    auto actionButton = [[TorrentCellActionButton alloc] init];
+
+    auto stackView = [[NSStackView alloc] init];
+    stackView.distribution = NSStackViewDistributionFill;
+    stackView.spacing = 4;
+
+    auto torrentTitleField = [[NSTextField alloc] init];
+    torrentTitleField.textColor = NSColor.labelColor;
+    torrentTitleField.backgroundColor = NSColor.textBackgroundColor;
+    torrentTitleField.font = [NSFont systemFontOfSize:12.0 weight:NSFontWeightRegular];
+
+    auto torrentPriorityView = [[NSImageView alloc] init];
+
+    [stackView addArrangedSubview:torrentTitleField];
+    [stackView addArrangedSubview:torrentPriorityView];
+
+    auto torrentProgressField = [[NSTextField alloc] init];
+    torrentProgressField.textColor = NSColor.secondaryLabelColor;
+    torrentProgressField.backgroundColor = NSColor.textBackgroundColor;
+    torrentProgressField.font = [NSFont systemFontOfSize:10.0 weight:NSFontWeightRegular];
+
+    auto torrentStatusField = [[NSTextField alloc] init];
+    torrentStatusField.textColor = NSColor.secondaryLabelColor;
+    torrentStatusField.backgroundColor = NSColor.textBackgroundColor;
+    torrentStatusField.font = [NSFont systemFontOfSize:10.0 weight:NSFontWeightRegular];
+
+    auto torrentProgressBarView = [[NSView alloc] init];
+
+    auto controlButton = [[TorrentCellControlButton alloc] init];
+    auto revealButton = [[TorrentCellRevealButton alloc] init];
+
+    for (NSImageView* imageView in @[ groupIndicatorView, iconView, torrentPriorityView ]) {
+        imageView.imageScaling = NSImageScaleProportionallyDown;
+    }
+
+    for (NSTextField* textField in @[ torrentTitleField, torrentProgressField, torrentStatusField ]) {
+        textField.editable = NO;
+        textField.selectable = NO;
+        textField.bordered = NO;
+        textField.drawsBackground = NO;
+    }
+
+    for (NSButton* button in @[ actionButton, controlButton, revealButton ]) {
+        button.imagePosition = NSImageOnly;
+        button.imageScaling = NSImageScaleProportionallyDown;
+        [button setButtonType:NSButtonTypeMomentaryPushIn];
+        [button setBezelStyle:NSBezelStyleRegularSquare];
+        button.bordered = NO;
+    }
+
+    for (NSView* view in @[
+             groupIndicatorView,
+             iconView,
+             actionButton,
+             stackView,
+             torrentProgressField,
+             torrentStatusField,
+             torrentProgressBarView,
+             controlButton,
+             revealButton,
+         ]) {
+        view.translatesAutoresizingMaskIntoConstraints = NO;
+        [self addSubview:view];
+    }
+
+    self.fGroupIndicatorView = groupIndicatorView;
+    self.fIconView = iconView;
+    self.fActionButton = actionButton;
+    self.fStackView = stackView;
+    self.fTorrentTitleField = torrentTitleField;
+    self.fTorrentPriorityView = torrentPriorityView;
+    self.fTorrentProgressField = torrentProgressField;
+    self.fTorrentStatusField = torrentStatusField;
+    self.fTorrentProgressBarView = torrentProgressBarView;
+    self.fControlButton = controlButton;
+    self.fRevealButton = revealButton;
+}
+
+- (void)setupConstraints
+{
+    auto groupIndicatorView = self.fGroupIndicatorView;
+    auto iconView = self.fIconView;
+    auto actionButton = self.fActionButton;
+    auto stackView = self.fStackView;
+    auto torrentProgressField = self.fTorrentProgressField;
+    auto torrentStatusField = self.fTorrentStatusField;
+    auto torrentProgressBarView = self.fTorrentProgressBarView;
+    auto controlButton = self.fControlButton;
+    auto revealButton = self.fRevealButton;
+
+    [NSLayoutConstraint activateConstraints:@[
+        // groupIndicatorView
+        [groupIndicatorView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+        [groupIndicatorView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [groupIndicatorView.widthAnchor constraintEqualToConstant:10],
+        [groupIndicatorView.heightAnchor constraintEqualToConstant:10],
+
+        // iconView
+        [iconView.leadingAnchor constraintEqualToAnchor:groupIndicatorView.trailingAnchor constant:3],
+        [iconView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [iconView.widthAnchor constraintEqualToConstant:36],
+        [iconView.heightAnchor constraintEqualToConstant:36],
+
+        // actionButton
+        [actionButton.centerXAnchor constraintEqualToAnchor:iconView.centerXAnchor],
+        [actionButton.centerYAnchor constraintEqualToAnchor:iconView.centerYAnchor],
+        [actionButton.widthAnchor constraintEqualToConstant:16],
+        [actionButton.heightAnchor constraintEqualToConstant:16],
+
+        // stackView
+        [stackView.leadingAnchor constraintEqualToAnchor:iconView.trailingAnchor constant:16],
+        [stackView.trailingAnchor constraintLessThanOrEqualToAnchor:torrentProgressBarView.trailingAnchor],
+        [stackView.topAnchor constraintEqualToAnchor:self.topAnchor constant:3],
+        [stackView.leadingAnchor constraintEqualToAnchor:torrentProgressField.leadingAnchor],
+
+        // torrentProgressField
+        [torrentProgressField.leadingAnchor constraintEqualToAnchor:torrentProgressBarView.leadingAnchor],
+        [torrentProgressField.trailingAnchor constraintEqualToAnchor:torrentProgressBarView.trailingAnchor],
+        [torrentProgressField.topAnchor constraintEqualToAnchor:stackView.bottomAnchor constant:1],
+
+        // torrentStatusField
+        [torrentStatusField.leadingAnchor constraintEqualToAnchor:torrentProgressBarView.leadingAnchor],
+        [torrentStatusField.trailingAnchor constraintEqualToAnchor:torrentProgressBarView.trailingAnchor],
+        [torrentStatusField.topAnchor constraintEqualToAnchor:torrentProgressBarView.bottomAnchor constant:1],
+        [torrentStatusField.bottomAnchor constraintEqualToAnchor:self.bottomAnchor constant:-1],
+
+        // torrentProgressBarView
+        [torrentProgressBarView.centerYAnchor constraintEqualToAnchor:torrentProgressBarView.centerYAnchor],
+        [torrentProgressBarView.heightAnchor constraintEqualToConstant:14],
+
+        // controlButton
+        [controlButton.leadingAnchor constraintEqualToAnchor:torrentProgressBarView.trailingAnchor constant:14],
+        [controlButton.centerYAnchor constraintEqualToAnchor:torrentProgressBarView.centerYAnchor],
+        [controlButton.widthAnchor constraintEqualToConstant:14],
+        [controlButton.heightAnchor constraintEqualToConstant:14],
+
+        // revealButton
+        [revealButton.leadingAnchor constraintEqualToAnchor:controlButton.trailingAnchor constant:3],
+        [revealButton.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-8],
+        [revealButton.centerYAnchor constraintEqualToAnchor:controlButton.centerYAnchor],
+        [revealButton.widthAnchor constraintEqualToConstant:14],
+        [revealButton.heightAnchor constraintEqualToConstant:14],
+    ]];
+}
 
 - (void)drawRect:(NSRect)dirtyRect
 {

--- a/macosx/TorrentCellActionButton.h
+++ b/macosx/TorrentCellActionButton.h
@@ -4,5 +4,7 @@
 
 #import <Cocoa/Cocoa.h>
 
+@class TorrentCell;
 @interface TorrentCellActionButton : NSButton
+@property(nonatomic, weak) IBOutlet TorrentCell* torrentCell;
 @end

--- a/macosx/TorrentCellActionButton.mm
+++ b/macosx/TorrentCellActionButton.mm
@@ -11,7 +11,6 @@
 @property(nonatomic) NSTrackingArea* fTrackingArea;
 @property(nonatomic) NSImage* fImage;
 @property(nonatomic) NSImage* fAlternativeImage;
-@property(nonatomic, weak) IBOutlet TorrentCell* torrentCell;
 @property(nonatomic, readonly) TorrentTableView* torrentTableView;
 @property(nonatomic) NSUserDefaults* fDefaults;
 @end
@@ -35,6 +34,22 @@
 
     // disable button click highlighting
     [self.cell setHighlightsBy:NSNoCellMask];
+}
+
+- (instancetype)initWithFrame:(NSRect)frameRect
+{
+    if (self = [super initWithFrame:frameRect]) {
+        self.fDefaults = NSUserDefaults.standardUserDefaults;
+        self.fImage = [NSImage imageNamed:@"ActionHover"];
+
+        // hide image by default and show only on hover
+        self.fAlternativeImage = [[NSImage alloc] init];
+        self.image = self.fAlternativeImage;
+
+        // disable button click highlighting
+        [self.cell setHighlightsBy:NSNoCellMask];
+    }
+    return self;
 }
 
 - (void)mouseEntered:(NSEvent*)event

--- a/macosx/TorrentCellControlButton.h
+++ b/macosx/TorrentCellControlButton.h
@@ -4,8 +4,10 @@
 
 #import <Cocoa/Cocoa.h>
 
+@class TorrentCell;
 @interface TorrentCellControlButton : NSButton
 
+@property(nonatomic, weak) IBOutlet TorrentCell* torrentCell;
 - (void)resetImage;
 
 @end

--- a/macosx/TorrentCellControlButton.mm
+++ b/macosx/TorrentCellControlButton.mm
@@ -10,7 +10,6 @@
 @interface TorrentCellControlButton ()
 @property(nonatomic) NSTrackingArea* fTrackingArea;
 @property(nonatomic, copy) NSString* controlImageSuffix;
-@property(nonatomic, weak) IBOutlet TorrentCell* torrentCell;
 @property(nonatomic, readonly) TorrentTableView* torrentTableView;
 @end
 
@@ -27,6 +26,15 @@
 
     self.controlImageSuffix = @"Off";
     [self updateImage];
+}
+
+- (instancetype)initWithFrame:(NSRect)frameRect
+{
+    if (self = [super initWithFrame:frameRect]) {
+        self.controlImageSuffix = @"Off";
+        [self updateImage];
+    }
+    return self;
 }
 
 - (void)resetImage

--- a/macosx/TorrentCellRevealButton.h
+++ b/macosx/TorrentCellRevealButton.h
@@ -4,5 +4,7 @@
 
 #import <Cocoa/Cocoa.h>
 
+@class TorrentCell;
 @interface TorrentCellRevealButton : NSButton
+@property(nonatomic, weak) IBOutlet TorrentCell* torrentCell;
 @end

--- a/macosx/TorrentCellRevealButton.mm
+++ b/macosx/TorrentCellRevealButton.mm
@@ -9,7 +9,6 @@
 @interface TorrentCellRevealButton ()
 @property(nonatomic) NSTrackingArea* fTrackingArea;
 @property(nonatomic, copy) NSString* revealImageString;
-@property(nonatomic, weak) IBOutlet TorrentCell* torrentCell;
 @property(nonatomic, readonly) TorrentTableView* torrentTableView;
 @end
 
@@ -26,6 +25,15 @@
 
     self.revealImageString = @"RevealOff";
     [self updateImage];
+}
+
+- (instancetype)initWithFrame:(NSRect)frameRect
+{
+    if (self = [super initWithFrame:frameRect]) {
+        self.revealImageString = @"RevealOff";
+        [self updateImage];
+    }
+    return self;
 }
 
 - (void)mouseEntered:(NSEvent*)event

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -233,8 +233,9 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
             // TODO(lolgear): Remove torrent cell from xib.
             torrentCell = [outlineView makeViewWithIdentifier:@"NewTorrentCell" owner:self];
             if (!torrentCell) {
-                torrentCell = [[TorrentCell alloc] initWithFrame:NSZeroRect];
+                torrentCell = [[TorrentCell alloc] initWithFrame:NSMakeRect(0, 0, NSWidth(outlineView.bounds), self.rowHeight)];
                 torrentCell.identifier = @"NewTorrentCell";
+                [torrentCell layoutSubtreeIfNeeded];
             }
 
             ((TorrentCellControlButton*)torrentCell.fControlButton).torrentCell = torrentCell;

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -230,7 +230,17 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
                 torrentCell.fRevealButton.hidden = YES;
             }
         } else {
-            torrentCell = [outlineView makeViewWithIdentifier:@"TorrentCell" owner:self];
+            // TODO(lolgear): Remove torrent cell from xib.
+            torrentCell = [outlineView makeViewWithIdentifier:@"NewTorrentCell" owner:self];
+            if (!torrentCell) {
+                torrentCell = [[TorrentCell alloc] initWithFrame:NSZeroRect];
+                torrentCell.identifier = @"NewTorrentCell";
+            }
+
+            ((TorrentCellControlButton*)torrentCell.fControlButton).torrentCell = torrentCell;
+            ((TorrentCellRevealButton*)torrentCell.fRevealButton).torrentCell = torrentCell;
+            ((TorrentCellActionButton*)torrentCell.fActionButton).torrentCell = torrentCell;
+
             torrentCell.fTorrentProgressField.stringValue = torrent.progressString;
 
             // set torrent icon and error badge


### PR DESCRIPTION
To increase flexibility when editing the torrent cell.

Extracting the cell from the XIB unlocks:
1. Encapsulating static data inside the cell (e.g., `NSLocalizedString` or custom colors).
2. Implementing a proper `ProgressView` using `CALayer` to improve performance by offloading computations to the GPU.

### Results

This PR changes the behavior related to multiple invocations of `awakeFromNib` in `TorrentTableView` according to the [Apple documentation](https://apple.com).

> This method is usually called by the delegate in [tableView(_:viewFor:row:)](https://apple.com), but it can also be overridden to provide custom views for the identifier. Note that [awakeFromNib()](https://apple.com) is called each time this method is called, meaning that `awakeFromNib()` will trigger for the owner bundle repeatedly if the owner is passed down during instantiation.

### Before

<img width="694" height="208" alt="Снимок экрана 2026-02-17 в 21 36 41" src="https://github.com/user-attachments/assets/2a2de278-06ba-477b-a466-450a854c100e" />

### After

<img width="694" height="208" alt="Снимок экрана 2026-02-17 в 21 35 40" src="https://github.com/user-attachments/assets/0699ed63-0a01-43cb-ae5a-820a918785eb" />