### PR TITLE
perf: remove reloadVisibleRows on selection did change in torrents and files table views

### DIFF
--- a/macosx/FileOutlineController.mm
+++ b/macosx/FileOutlineController.mm
@@ -256,7 +256,6 @@ typedef NS_ENUM(NSUInteger, FilePriorityMenuTag) { //
 
 - (void)outlineViewSelectionDidChange:(NSNotification*)notification
 {
-    [self reloadVisibleRows];
     if ([QLPreviewPanel sharedPreviewPanelExists] && [QLPreviewPanel sharedPreviewPanel].visible) {
         [[QLPreviewPanel sharedPreviewPanel] reloadData];
     }

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -6,7 +6,6 @@
 #import "ProgressBarView.h"
 #import "ProgressGradients.h"
 #import "Torrent.h"
-#import "NSImageAdditions.h"
 
 @implementation TorrentCell
 
@@ -21,9 +20,7 @@
 
         // set priority icon
         if (torrent.priority != TR_PRI_NORMAL) {
-            NSColor* priorityColor = self.backgroundStyle == NSBackgroundStyleEmphasized ? NSColor.whiteColor : NSColor.labelColor;
-            NSImage* priorityImage = [[NSImage imageNamed:(torrent.priority == TR_PRI_HIGH ? @"PriorityHighTemplate" : @"PriorityLowTemplate")]
-                imageWithColor:priorityColor];
+            NSImage* priorityImage = [NSImage imageNamed:(torrent.priority == TR_PRI_HIGH ? @"PriorityHighTemplate" : @"PriorityLowTemplate")];
 
             self.fTorrentPriorityView.image = priorityImage;
 
@@ -40,6 +37,14 @@
 - (BOOL)isFlipped
 {
     return YES;
+}
+
+- (void)setBackgroundStyle:(NSBackgroundStyle)backgroundStyle
+{
+    [super setBackgroundStyle:backgroundStyle];
+
+    NSColor* priorityColor = backgroundStyle == NSBackgroundStyleEmphasized ? NSColor.whiteColor : NSColor.labelColor;
+    self.fTorrentPriorityView.contentTintColor = priorityColor;
 }
 
 @end

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -71,8 +71,6 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
 @property(nonatomic) NSDictionary* fHoverEventDict;
 
-@property(nonatomic) NSMutableIndexSet* fPendingSelectionReloadRows;
-
 @end
 
 @implementation TorrentTableView
@@ -397,35 +395,6 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
     } else {
         return [self.dataSource outlineView:outlineView objectValueForTableColumn:[self tableColumnWithIdentifier:@"Group"]
                                      byItem:item];
-    }
-}
-
-- (void)outlineViewSelectionDidChange:(NSNotification*)notification
-{
-    NSIndexSet* oldSelection = self.fSelectedRowIndexes ?: [NSIndexSet indexSet];
-    NSIndexSet* newSelection = self.selectedRowIndexes;
-    self.fSelectedRowIndexes = newSelection;
-
-    NSIndexSet* changedRows = [oldSelection symmetricDifference:newSelection];
-    if (changedRows.count > 0) {
-        if (!self.fPendingSelectionReloadRows) {
-            self.fPendingSelectionReloadRows = [[NSMutableIndexSet alloc] init];
-            [self performSelector:@selector(flushSelectionReload) withObject:nil afterDelay:0 inModes:@[ NSRunLoopCommonModes ]];
-        }
-
-        [self.fPendingSelectionReloadRows addIndexes:changedRows];
-    }
-}
-
-- (void)flushSelectionReload
-{
-    NSMutableIndexSet* rows = self.fPendingSelectionReloadRows;
-    self.fPendingSelectionReloadRows = nil;
-
-    NSInteger const numberOfRows = self.numberOfRows;
-    [rows removeIndexesInRange:NSMakeRange(numberOfRows, NSIntegerMax - numberOfRows)];
-    if (rows.count > 0) {
-        [self reloadDataForRowIndexes:rows columnIndexes:[NSIndexSet indexSetWithIndex:0]];
     }
 }
 

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -28,28 +28,6 @@ static CGFloat const kErrorImageSize = 20.0;
 
 static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
-@interface NSIndexSet (Transmission)
-- (NSIndexSet*)symmetricDifference:(NSIndexSet*)otherSet;
-@end
-
-@implementation NSIndexSet (Transmission)
-
-- (NSIndexSet*)symmetricDifference:(NSIndexSet*)otherSet
-{
-    NSMutableIndexSet* result = [self mutableCopy];
-    [result addIndexes:otherSet];
-
-    [self enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL*) {
-        if ([otherSet containsIndex:idx]) {
-            [result removeIndex:idx];
-        }
-    }];
-
-    return [result copy];
-}
-
-@end
-
 @interface TorrentTableView ()
 
 @property(nonatomic) IBOutlet Controller* fController;
@@ -60,8 +38,6 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
 @property(nonatomic) IBOutlet NSMenu* fContextRow;
 @property(nonatomic) IBOutlet NSMenu* fContextNoRow;
-
-@property(nonatomic) NSIndexSet* fSelectedRowIndexes;
 
 @property(nonatomic) CGFloat piecesBarPercent;
 @property(nonatomic) NSAnimation* fPiecesBarAnimation;


### PR DESCRIPTION
Notes: Improved UI code to use less CPU.

These methods don't do anything except "reload visible cells" one more time.
But Controller already did it every second.

I checked with this snippet

```objective-c++
// Inside -(void)outlineViewSelectionDidChange {
static uint64_t totalNanoseconds = 0;
static uint64_t callCount = 0;

uint64_t start = mach_absolute_time();

// --- body of outlineViewSelectionDidChange... ---

[self reloadVisibleRows]; // comment out this line for "native" approach.

uint64_t end = mach_absolute_time();

mach_timebase_info_data_t info;
mach_timebase_info(&info);
uint64_t elapsedNano = (end - start) * info.numer / info.denom;

totalNanoseconds += elapsedNano;
callCount++;

// Average time every 10 calls (select and press and hold down arrow).
if (callCount % 10 == 0) {
    NSLog(@"[PERF_TEST] Calls: %llu | Avg time per cell: %.3f ms",
          callCount, (double)totalNanoseconds / callCount / 1000000.0);
}
```

### Results

| Selection Ticks / Calls | Before Optimization (main) | After Optimization (This PR) | Speedup / Improvement |
|---|---|---|---|
| 130 ticks | 15.826 ms | 0.000 ms | Instant (O(1)) |
| 140 ticks | 15.788 ms | 0.000 ms | Instant (O(1)) |
| 150 ticks | 15.836 ms | 0.000 ms | Instant (O(1)) |
| 160 ticks | 15.839 ms | 0.000 ms | Instant (O(1)) |
| 170 ticks | 15.886 ms | 0.000 ms | Instant (O(1)) |
| 180 ticks | 15.860 ms | 0.000 ms | Instant (O(1)) |
| 190 ticks | 15.813 ms | 0.000 ms | Instant (O(1)) |
| 200 ticks | 15.806 ms | 0.000 ms | Instant (O(1)) |
| 210 ticks | 15.832 ms | 0.000 ms | Instant (O(1)) |
| Average | 15.832 ms | 0.000 ms | Pure Native Speed |

### Key Takeaway:
Spending ~15.8 ms of main thread time on a single click or keyboard tick is dangerously high (nearly dropping a frame at 60 FPS). When a user holds down the arrow keys to scroll through torrents, this creates an enormous rendering bottleneck, explaining the high CPU reports on macOS.
With this PR, the overhead is reduced to 0.000 ms because AppKit natively handles row highlighting states via CoreAnimation layers without forcing full cell view modernizations. No data is lost or delayed since the 1-second background timer still ensures text/progress values are perfectly accurate.