### PR TITLE
perf: file name cell icon caching added.

### DIFF
--- a/macosx/BaseFileNameCellView.mm
+++ b/macosx/BaseFileNameCellView.mm
@@ -2,6 +2,9 @@
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
+#include <libtransmission/transmission.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+
 #import "BaseFileNameCellView.h"
 #import "FileListNode.h"
 #import "Torrent.h"
@@ -22,7 +25,27 @@ static CGFloat const kPaddingBetweenNameAndFolderStatus = 4.0;
 @property(nonatomic, strong) NSArray<NSLayoutConstraint*>* dynamicConstraints;
 @end
 
+static NSCache<UTType*, NSImage*>* iconCache;
+
 @implementation BaseFileNameCellView
+
++ (void)initialize
+{
+    iconCache = [[NSCache alloc] init];
+}
+
++ (NSImage*)cachedIconForUTType:(UTType*)uttype
+{
+    auto cachedIcon = [iconCache objectForKey:uttype];
+
+    if (cachedIcon == nil) {
+        auto icon = [NSWorkspace.sharedWorkspace iconForContentType:uttype];
+        [iconCache setObject:icon forKey:uttype];
+        return icon;
+    }
+
+    return cachedIcon;
+}
 
 - (instancetype)initWithFrame:(NSRect)frameRect
 {
@@ -70,6 +93,10 @@ static CGFloat const kPaddingBetweenNameAndFolderStatus = 4.0;
 {
 }
 
+- (void)updateImageIfNeeded
+{
+}
+
 - (void)setNode:(FileListNode*)node
 {
     _node = node;
@@ -85,7 +112,7 @@ static CGFloat const kPaddingBetweenNameAndFolderStatus = 4.0;
     FileListNode* node = self.node;
 
     // Update icon
-    self.iconView.image = node.icon;
+    [self updateImageIfNeeded];
 
     // Update name
     self.nameField.stringValue = node.name;
@@ -154,6 +181,18 @@ static CGFloat const kPaddingBetweenNameAndFolderStatus = 4.0;
 
 @implementation FileNameCellView
 
+- (void)updateImageIfNeeded
+{
+    if (self.node.name == nil) {
+        return;
+    }
+
+    auto uttype = [UTType typeWithFilenameExtension:self.node.name.pathExtension];
+    auto image = [self.class cachedIconForUTType:uttype];
+
+    self.iconView.image = image;
+}
+
 - (void)setupConstraints
 {
     NSImageView* iconView = self.iconView;
@@ -184,6 +223,14 @@ static CGFloat const kPaddingBetweenNameAndFolderStatus = 4.0;
 @end
 
 @implementation FolderNameCellView
+
+- (instancetype)initWithFrame:(NSRect)frameRect
+{
+    if (self = [super initWithFrame:frameRect]) {
+        self.iconView.image = [self.class cachedIconForUTType:UTTypeFolder];
+    }
+    return self;
+}
 
 - (void)setupConstraints
 {

--- a/macosx/BaseFileNameCellView.mm
+++ b/macosx/BaseFileNameCellView.mm
@@ -2,7 +2,6 @@
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
-#include <libtransmission/transmission.h>
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 #import "BaseFileNameCellView.h"
@@ -22,7 +21,6 @@ static CGFloat const kPaddingBetweenNameAndFolderStatus = 4.0;
 @property(nonatomic, weak) NSImageView* iconView;
 @property(nonatomic, weak) NSTextField* nameField;
 @property(nonatomic, weak) NSTextField* statusField;
-@property(nonatomic, strong) NSArray<NSLayoutConstraint*>* dynamicConstraints;
 @end
 
 static NSCache<UTType*, NSImage*>* iconCache;
@@ -31,7 +29,9 @@ static NSCache<UTType*, NSImage*>* iconCache;
 
 + (void)initialize
 {
-    iconCache = [[NSCache alloc] init];
+    if (self == [BaseFileNameCellView class]) {
+        iconCache = [[NSCache alloc] init];
+    }
 }
 
 + (NSImage*)cachedIconForUTType:(UTType*)uttype
@@ -93,7 +93,7 @@ static NSCache<UTType*, NSImage*>* iconCache;
 {
 }
 
-- (void)updateImageIfNeeded
+- (void)updateImage
 {
 }
 
@@ -112,7 +112,7 @@ static NSCache<UTType*, NSImage*>* iconCache;
     FileListNode* node = self.node;
 
     // Update icon
-    [self updateImageIfNeeded];
+    [self updateImage];
 
     // Update name
     self.nameField.stringValue = node.name;
@@ -181,16 +181,24 @@ static NSCache<UTType*, NSImage*>* iconCache;
 
 @implementation FileNameCellView
 
-- (void)updateImageIfNeeded
+- (void)updateImage
 {
-    if (self.node.name == nil) {
+    NSString* const name = self.node.name;
+
+    if (name == nil) {
         return;
     }
 
-    auto uttype = [UTType typeWithFilenameExtension:self.node.name.pathExtension];
-    auto image = [self.class cachedIconForUTType:uttype];
+    // typeWithFilenameExtension: returns nil when the name carries no extension
+    // ("README", ".gitignore"), so fall back to the generic item icon.
+    auto uttype = [UTType typeWithFilenameExtension:name.pathExtension] ?: UTTypeItem;
 
-    self.iconView.image = image;
+    // cachedIconForUTType: returns one shared instance per type, so this
+    // compares identity rather than contents.
+    auto image = [self.class cachedIconForUTType:uttype];
+    if (self.iconView.image != image) {
+        self.iconView.image = image;
+    }
 }
 
 - (void)setupConstraints


### PR DESCRIPTION
In previous https://github.com/transmission/transmission/pull/8497 PR file name cell was slightly optimized.

This PR continues optimization by adding icon caching.

I checked with this snippet.

```objective-c++
#import <mach/mach_time.h>

// Inside -(void)updateDisplay {
static uint64_t totalNanoseconds = 0;
static uint64_t callCount = 0;

uint64_t start = mach_absolute_time();

// --- body of updateDisplay... ---

uint64_t end = mach_absolute_time();

mach_timebase_info_data_t info;
mach_timebase_info(&info);
uint64_t elapsedNano = (end - start) * info.numer / info.denom;

totalNanoseconds += elapsedNano;
callCount++;

// Average time every 500 calls (scrolling).
if (callCount % 500 == 0) {
    NSLog(@"[PERF_TEST] Calls: %llu | Avg time per cell: %.3f ms", 
          callCount, (double)totalNanoseconds / callCount / 1000000.0);
}
// }
// [self updateColors];
// ...
// } // end of -(void)updateDisplay
```

### Results

#### Before cells separation

| Total Rendered Cells | Before Optimization (main) | After Optimization (This PR) | Speedup / Improvement |
|---|---|---|---|
| 1,000 cells | 0.534 ms | 0.409 ms | -23.4% time spent |
| 1,500 cells | 0.539 ms | 0.357 ms | -33.8% time spent |
| 2,000 cells | 0.540 ms | 0.377 ms | -30.2% time spent |
| 2,500 cells | 0.543 ms | 0.389 ms | -28.4% time spent |
| 3,000 cells | 0.533 ms | 0.397 ms | -25.5% time spent |
| Average | 0.538 ms | 0.386 ms | ~1.39x Faster |

#### After cells separation with icon caching

| Total Rendered Cells | Before Optimization (main) | After Optimization (This PR) | Speedup / Improvement |
|---|---|---|---|
| 1,000 cells | 0.409 ms | 0.138 ms | -66.3% time spent |
| 1,500 cells | 0.357 ms | 0.134 ms | -62.5% time spent |
| 2,000 cells | 0.377 ms | 0.131 ms | -65.3% time spent |
| 2,500 cells | 0.389 ms | 0.129 ms | -66.8% time spent |
| 3,000 cells | 0.397 ms | 0.128 ms | -67.8% time spent |
| Average | 0.386 ms | 0.132 ms | ~2.9x Faster |

### Video 

#### Before Optimization

https://github.com/user-attachments/assets/8d425ffb-f043-4402-923d-fd27f7947ca7

#### After Optimization

https://github.com/user-attachments/assets/118224dc-eacb-4402-ad95-54f1da35c59f


Notes: Improved UI code to use less CPU.