### PR TITLE
fix: discard old value in `tr_bitfield::set_from_bools`

### DIFF
--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -271,7 +271,7 @@ void tr_bitfield::set_from_bools(std::span<bool const> const flags)
     size_t true_count = 0;
 
     free_array();
-    ensure_bits_alloced(flags.size());
+    flags_.resize(getBytesNeeded(flags.size()));
 
     for (size_t i = 0; i < flags.size(); ++i) {
         if (flags[i]) {

--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -270,8 +270,7 @@ void tr_bitfield::set_from_bools(std::span<bool const> const flags)
 {
     size_t true_count = 0;
 
-    free_array();
-    flags_.resize(getBytesNeeded(flags.size()));
+    flags_.assign(getBytesNeeded(flags.size()), {});
 
     for (size_t i = 0; i < flags.size(); ++i) {
         if (flags[i]) {

--- a/tests/libtransmission/bitfield-test.cc
+++ b/tests/libtransmission/bitfield-test.cc
@@ -85,6 +85,23 @@ TEST(Bitfield, ctorFromFlagArray)
     }
 }
 
+TEST(Bitfield, setFromBoolsAfterHaveAll)
+{
+    auto constexpr Flags = std::to_array<bool>({ true, false, true, false, false, true, false, true, false, false });
+
+    auto bf = tr_bitfield(std::size(Flags));
+    bf.set_has_all();
+    bf.set_from_bools(Flags);
+
+    EXPECT_FALSE(bf.has_all());
+    EXPECT_FALSE(bf.has_none());
+    EXPECT_EQ(4U, bf.count());
+
+    for (size_t i = 0; i < std::size(Flags); ++i) {
+        EXPECT_EQ(Flags[i], bf.test(i));
+    }
+}
+
 TEST(Bitfield, setRaw)
 {
     auto constexpr TestByte = std::byte{ 10 };


### PR DESCRIPTION
## Description

`tr_bitfield::set_from_bools` should discard any old values before setting values from the Boolean array.

Production code does not trigger this, so I'm marking as `notes:none`.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
