### PR TITLE
ci: run "new" label removal on PR approval

### DIFF
--- a/.github/workflows/pr-new-label-approved.yml
+++ b/.github/workflows/pr-new-label-approved.yml
@@ -1,0 +1,62 @@
+name: Remove the "new" label on approval
+
+# Removes the `new` label once a PR has been approved.
+#
+# The approval is detected by the `signal-approval` job in pr-new-label.yml,
+# which cannot remove the label itself: it sees the review event, but for PRs
+# from forks it runs with a read-only token. `workflow_run` is what carries
+# the news across that boundary, since it runs in the base repository's
+# context with a write-capable token.
+
+on:
+  workflow_run:
+    workflows: ['Label new pull requests']
+    types: [completed]
+
+permissions:
+  pull-requests: write
+
+env:
+  LABEL: new
+
+jobs:
+  remove-label:
+    # `signal-approval` is the only job that runs for a review, so a review-
+    # triggered run succeeds if and only if the review was an approval.
+    if: >-
+      github.event.workflow_run.event == 'pull_request_review' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const label = process.env.LABEL;
+            const { owner, repo } = context.repo;
+            const { head_sha } = context.payload.workflow_run;
+
+            // The triggering run carries no PR number: `workflow_run`
+            // populates `pull_requests` only for same-repo branches.
+            const { data: associated } =
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: head_sha,
+              });
+            const pr = associated.find((pr) => pr.head.sha === head_sha);
+            if (!pr) {
+              core.setFailed(`No pull request has ${head_sha} as its head.`);
+              return;
+            }
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: pr.number,
+                name: label,
+              });
+            } catch (error) {
+              // 404 just means the label was already gone; anything else is real.
+              if (error.status !== 404) throw error;
+            }

--- a/.github/workflows/pr-new-label-expiry.yml
+++ b/.github/workflows/pr-new-label-expiry.yml
@@ -5,9 +5,9 @@ name: Expire the "new" label on pull requests
 
 on:
   schedule:
-    # Run every 15 minutes.  The odd minutes are deliberate:
-    # GitHub delays or silently drops scheduled events under load,
-    # so we're avoiding the commonly-oversubscribed slots of 0,15,30,45.
+    # Best-effort: GitHub drops most scheduled events and dispatches the rest
+    # at arbitrary minutes, so this lands roughly hourly — fine for a timer
+    # measured in days.
     - cron: '7,22,37,52 * * * *' # every 15 minutes
 
 permissions:

--- a/.github/workflows/pr-new-label.yml
+++ b/.github/workflows/pr-new-label.yml
@@ -1,7 +1,9 @@
 name: Label new pull requests
 
-# Adds a `new` label when a PR is opened, and removes it once the PR is approved.
-# The label is also removed on a timer by pr-new-label-expiry.yml.
+# Adds a `new` label when a PR is opened.
+# The label is removed on approval by pr-new-label-approved.yml — which
+# subscribes to this workflow by the `name:` above — and on a timer by
+# pr-new-label-expiry.yml.
 
 on:
   # `pull_request_target` (rather than `pull_request`) so the GITHUB_TOKEN has
@@ -50,25 +52,15 @@ jobs:
               labels: [label],
             });
 
-  remove-on-approval:
+  # For PRs from forks, `pull_request_review` runs with a read-only token that
+  # cannot change labels, and no `permissions:` key can raise it. So this job
+  # only *reports* the approval: it runs for approvals and nothing else, which
+  # makes "this run succeeded" the signal pr-new-label-approved.yml acts on.
+  signal-approval:
     if: >-
       github.event_name == 'pull_request_review' &&
       github.event.review.state == 'approved'
     runs-on: ubuntu-slim
+    permissions: {}
     steps:
-      - uses: actions/github-script@v9
-        with:
-          script: |
-            const label = process.env.LABEL;
-            const { owner, repo } = context.repo;
-            try {
-              await github.rest.issues.removeLabel({
-                owner,
-                repo,
-                issue_number: context.payload.pull_request.number,
-                name: label,
-              });
-            } catch (error) {
-              // 404 just means the label was already gone; anything else is real.
-              if (error.status !== 404) throw error;
-            }
+      - run: 'true'


### PR DESCRIPTION
## Description

Fix a CI bug that prevented the `new` label from being removed when a PR from a fork was approved.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
