### PR TITLE
fix: disconnect peer if we got oversized bitfield

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1422,7 +1422,7 @@ ReadResult tr_peerMsgsImpl::process_peer_message(uint8_t id, MessageReader& payl
 
     case BtPeerMsgs::Bitfield:
         logtrace(this, "got a bitfield");
-        have_ = tr_bitfield{ tor_.has_metainfo() ? tor_.piece_count() : std::size(payload) * 8 };
+        have_.init_size(std::size(payload) * 8);
         have_.set_raw(payload);
         peer_info->set_seed(is_seed());
         publish(tr_peer_event::GotBitfield(&have_));

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1423,7 +1423,11 @@ ReadResult tr_peerMsgsImpl::process_peer_message(uint8_t id, MessageReader& payl
     case BtPeerMsgs::Bitfield:
         logtrace(this, "got a bitfield");
         have_.init_size(std::size(payload) * 8);
-        have_.set_raw(payload);
+        if (!have_.set_raw(payload)) {
+            logdbg(this, "bitfield too big, disconnecting");
+            disconnect_soon();
+            return { ReadState::Err, {} };
+        }
         peer_info->set_seed(is_seed());
         publish(tr_peer_event::GotBitfield(&have_));
 


### PR DESCRIPTION
## Description

Notes: Reject peer `bitfield` messages that are too big and disconnect the peer.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
