### PR TITLE
fix: process `HAVE` messages after receiving metainfo for magnet link

### DIFF
--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -214,6 +214,57 @@ void tr_bitfield::decrement_true_count(size_t dec) noexcept
     set_true_count(true_count_ - dec);
 }
 
+void tr_bitfield::unset_excess_bits() noexcept
+{
+    if (std::empty(flags_) || std::size(flags_) != tr_bytes_needed(bit_count_)) {
+        return;
+    }
+
+    auto const excess_bit_count = calc_excess_bits(bit_count_);
+    TR_ASSERT(excess_bit_count <= 7U);
+    flags_.back() &= std::byte{ 0xff } << excess_bit_count;
+}
+
+bool tr_bitfield::init_size(size_t const bit_count) noexcept
+{
+    if (bit_count == 0U || bit_count_ != 0U) {
+        return false;
+    }
+
+    bit_count_ = bit_count;
+
+    if (have_all_hint_) {
+        set_has_all(); // update true_count_
+    }
+
+    TR_ASSERT(is_valid());
+    return true;
+}
+
+bool tr_bitfield::shrink_to(size_t const bit_count) noexcept
+{
+    if (bit_count == 0U || !is_size_known() || bit_count > size()) {
+        return false;
+    }
+
+    if (bit_count == size()) {
+        return true;
+    }
+
+    bit_count_ = bit_count;
+
+    if (have_all_hint_) {
+        set_has_all(); // update true_count_
+    } else if (!has_none()) {
+        flags_.resize(std::min(std::size(flags_), tr_bytes_needed(bit_count_)));
+        unset_excess_bits();
+        rebuild_true_count();
+    }
+
+    TR_ASSERT(is_valid());
+    return true;
+}
+
 // ---
 
 tr_bitfield::tr_bitfield(size_t bit_count)
@@ -255,15 +306,7 @@ bool tr_bitfield::set_raw(std::span<std::byte const> const raw)
     flags_.assign(raw.begin(), raw.end());
 
     // ensure any excess bits at the end of the array are set to '0'.
-    if (raw.size() == tr_bytes_needed(bit_count_)) {
-        auto const excess_bit_count = (raw.size() * 8) - bit_count_;
-
-        TR_ASSERT(excess_bit_count <= 7);
-
-        if (excess_bit_count != 0) {
-            flags_.back() &= std::byte{ 0xff } << excess_bit_count;
-        }
-    }
+    unset_excess_bits();
 
     rebuild_true_count();
     // rebuild_true_count() already asserts is_valid(), so we don't need it here
@@ -316,16 +359,14 @@ bool tr_bitfield::set(size_t const nth, bool const value)
 #endif
 
     if (value) {
-        ++true_count_;
+        increment_true_count(1);
         TR_ASSERT(old_byte_pop + 1 == new_byte_pop);
     } else {
-        --true_count_;
+        decrement_true_count(1);
         TR_ASSERT(new_byte_pop + 1 == old_byte_pop);
     }
-    have_all_hint_ = true_count_ == bit_count_;
-    have_none_hint_ = true_count_ == 0;
 
-    TR_ASSERT(is_valid());
+    // (de|in)crement_true_count() already asserts is_valid(), so we don't need it here
     return true;
 }
 

--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -246,6 +246,8 @@ bool tr_bitfield::set_size(size_t const bit_count) noexcept
         flags_.resize(std::min(std::size(flags_), tr_bytes_needed(bit_count_)));
         unset_excess_bits();
         rebuild_true_count();
+    } else {
+        TR_ASSERT(std::empty(flags_));
     }
 
     TR_ASSERT(is_valid());

--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -11,16 +11,12 @@
 
 #include "libtransmission/bitfield.h"
 #include "libtransmission/tr-assert.h" // TR_ASSERT, TR_ENABLE_ASSERTS
+#include "libtransmission/utils.h"
 
 // ---
 
 namespace
 {
-
-[[nodiscard]] constexpr size_t getBytesNeeded(size_t const bit_count) noexcept
-{
-    return (bit_count >> 3) + ((bit_count & 7) != 0 ? 1 : 0);
-}
 
 [[nodiscard]] constexpr uint8_t calc_excess_bits(size_t const bit_count) noexcept
 {
@@ -34,7 +30,7 @@ namespace
 void setAllTrue(std::span<std::byte> bytes, size_t const bit_count)
 {
     static auto constexpr Val = std::byte{ 0xFF };
-    auto const n = getBytesNeeded(bit_count);
+    auto const n = tr_bytes_needed(bit_count);
 
     TR_ASSERT(bytes.size() >= n);
     if (n <= 0U || bytes.size() < n) {
@@ -134,7 +130,7 @@ bool tr_bitfield::is_valid() const
         return std::empty(flags_) && true_count_ == 0U && have_all_hint_ != have_none_hint_;
     }
 
-    auto const bytes_needed = getBytesNeeded(bit_count_);
+    auto const bytes_needed = tr_bytes_needed(bit_count_);
     auto const flags_size = std::size(flags_);
     auto const excess_bits_mask = ~(std::byte{ 0xFFU } << calc_excess_bits(bit_count_));
     return true_count_ <= bit_count_ &&
@@ -144,7 +140,7 @@ bool tr_bitfield::is_valid() const
 
 std::vector<std::byte> tr_bitfield::raw() const
 {
-    auto const n = getBytesNeeded(bit_count_);
+    auto const n = tr_bytes_needed(bit_count_);
     auto raw = std::vector<std::byte>(n);
 
     if (has_all()) {
@@ -168,7 +164,7 @@ bool tr_bitfield::ensure_bits_alloced(size_t const n)
     }
 
     auto const has_all = this->has_all();
-    auto const bytes_needed = getBytesNeeded(has_all ? std::max(n, true_count_) : n);
+    auto const bytes_needed = tr_bytes_needed(has_all ? std::max(n, true_count_) : n);
 
     if (std::size(flags_) < bytes_needed) {
         flags_.resize(bytes_needed);
@@ -252,14 +248,14 @@ bool tr_bitfield::set_raw(std::span<std::byte const> const raw)
         return false;
     }
 
-    if (auto const bytes_needed = getBytesNeeded(bit_count_); std::size(raw) > bytes_needed) {
+    if (auto const bytes_needed = tr_bytes_needed(bit_count_); std::size(raw) > bytes_needed) {
         return false;
     }
 
     flags_.assign(raw.begin(), raw.end());
 
     // ensure any excess bits at the end of the array are set to '0'.
-    if (raw.size() == getBytesNeeded(bit_count_)) {
+    if (raw.size() == tr_bytes_needed(bit_count_)) {
         auto const excess_bit_count = (raw.size() * 8) - bit_count_;
 
         TR_ASSERT(excess_bit_count <= 7);
@@ -280,7 +276,7 @@ bool tr_bitfield::set_from_bools(std::span<bool const> const flags)
         return false;
     }
 
-    flags_.assign(getBytesNeeded(flags.size()), {});
+    flags_.assign(tr_bytes_needed(flags.size()), {});
 
     size_t true_count = 0;
     for (size_t i = 0; i < flags.size(); ++i) {

--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -225,29 +225,15 @@ void tr_bitfield::unset_excess_bits() noexcept
     flags_.back() &= std::byte{ 0xff } << excess_bit_count;
 }
 
-bool tr_bitfield::init_size(size_t const bit_count) noexcept
+bool tr_bitfield::set_size(size_t const bit_count) noexcept
 {
-    if (bit_count == 0U || bit_count_ != 0U) {
+    // 0 is reserved for "unknown size", so it is never a valid destination.
+    // Once the size is known it can only narrow.
+    if (bit_count == 0U || (is_size_known() && bit_count > bit_count_)) {
         return false;
     }
 
-    bit_count_ = bit_count;
-
-    if (have_all_hint_) {
-        set_has_all(); // update true_count_
-    }
-
-    TR_ASSERT(is_valid());
-    return true;
-}
-
-bool tr_bitfield::shrink_to(size_t const bit_count) noexcept
-{
-    if (bit_count == 0U || !is_size_known() || bit_count > size()) {
-        return false;
-    }
-
-    if (bit_count == size()) {
+    if (bit_count == bit_count_) {
         return true;
     }
 

--- a/libtransmission/bitfield.cc
+++ b/libtransmission/bitfield.cc
@@ -133,7 +133,8 @@ bool tr_bitfield::is_valid() const
     auto const bytes_needed = tr_bytes_needed(bit_count_);
     auto const flags_size = std::size(flags_);
     auto const excess_bits_mask = ~(std::byte{ 0xFFU } << calc_excess_bits(bit_count_));
-    return true_count_ <= bit_count_ &&
+    return true_count_ <= bit_count_ && have_all_hint_ == (true_count_ == bit_count_) &&
+        have_none_hint_ == (true_count_ == 0U) &&
         (flags_size < bytes_needed || (flags_size == bytes_needed && (flags_.back() & excess_bits_mask) == std::byte{})) &&
         (std::empty(flags_) || true_count_ == count_flags());
 }

--- a/libtransmission/bitfield.h
+++ b/libtransmission/bitfield.h
@@ -99,6 +99,9 @@ public:
         return bit_count_;
     }
 
+    bool init_size(size_t bit_count) noexcept;
+    bool shrink_to(size_t bit_count) noexcept;
+
     [[nodiscard]] constexpr bool is_size_known() const noexcept
     {
         return size() != 0;
@@ -148,6 +151,8 @@ private:
         // move-assign to ensure the reserve memory is cleared
         flags_ = std::vector<std::byte>{};
     }
+
+    void unset_excess_bits() noexcept;
 
     void increment_true_count(size_t inc) noexcept;
     void decrement_true_count(size_t dec) noexcept;

--- a/libtransmission/bitfield.h
+++ b/libtransmission/bitfield.h
@@ -99,12 +99,18 @@ public:
         return bit_count_;
     }
 
-    bool init_size(size_t bit_count) noexcept;
-    bool shrink_to(size_t bit_count) noexcept;
-
     [[nodiscard]] constexpr bool is_size_known() const noexcept
     {
         return size() != 0;
+    }
+
+    [[nodiscard]] bool init_size(size_t const bit_count) noexcept
+    {
+        return !is_size_known() && set_size(bit_count);
+    }
+    [[nodiscard]] bool shrink_to(size_t const bit_count) noexcept
+    {
+        return is_size_known() && set_size(bit_count);
     }
 
     [[nodiscard]] bool is_valid() const;
@@ -153,6 +159,7 @@ private:
     }
 
     void unset_excess_bits() noexcept;
+    [[nodiscard]] bool set_size(size_t bit_count) noexcept;
 
     void increment_true_count(size_t inc) noexcept;
     void decrement_true_count(size_t dec) noexcept;

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -414,6 +414,8 @@ public:
             [[maybe_unused]] auto const shrink_to_res = have_.shrink_to(tor_.piece_count());
             TR_ASSERT(shrink_to_res);
         }
+
+        peer_info->set_seed(is_seed());
     }
 
     void cancel_block_request(tr_block_index_t block)

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -390,13 +390,7 @@ public:
 
         // Torrent piece count was not known before this point,
         // and this sets the bitfield size to the piece count.
-        // - If the peer sent "have all", then this line will preserve
-        //   the "have all".
-        // - If the peer sent "bitfield", then `have_.init_size()` is no-op,
-        //   and `have_.shrink_to()` will adjust the bitfield size instead.
         if (!have_.init_size(tor_.piece_count())) {
-            // If the peer sent us a bitfield msg, then have_'s size is already initialized.
-            // Check if the bitfield's size is valid.
             auto const peer_bitfield_bytes = tr_bytes_needed(have_.size());
             auto const actual_bitfield_bytes = tr_bytes_needed(tor_.piece_count());
             if (peer_bitfield_bytes != actual_bitfield_bytes) {
@@ -410,7 +404,6 @@ public:
                 return;
             }
 
-            // Now that we know the exact piece count, we need to shrink the bitfield to the correct size.
             [[maybe_unused]] auto const shrink_to_res = have_.shrink_to(tor_.piece_count());
             TR_ASSERT(shrink_to_res);
         }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -48,6 +48,7 @@
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/tr-buffer.h"
 #include "libtransmission/types.h"
+#include "libtransmission/utils.h"
 #include "libtransmission/variant.h"
 #include "libtransmission/version.h"
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -392,8 +392,8 @@ public:
         // and this sets the bitfield size to the piece count.
         // - If the peer sent "have all", then this line will preserve
         //   the "have all".
-        // - If the peer sent "bitfield", then this line is a no-op,
-        //   since the bitfield size was already initialized.
+        // - If the peer sent "bitfield", then `have_.init_size()` is no-op,
+        //   and `have_.shrink_to()` will adjust the bitfield size instead.
         if (!have_.init_size(tor_.piece_count())) {
             // If the peer sent us a bitfield msg, then have_'s size is already initialized.
             // Check if the bitfield's size is valid.

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -415,7 +415,11 @@ public:
             TR_ASSERT(shrink_to_res);
         }
 
-        peer_info->set_seed(is_seed());
+        // Neither init_size() nor shrink_to() can turn "have all" off, so writing
+        // `false` here could only discard what an earlier connection told us.
+        if (is_seed()) {
+            peer_info->set_seed();
+        }
     }
 
     void cancel_block_request(tr_block_index_t block)

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -779,7 +779,7 @@ private:
         return len == 5U;
 
     case BtPeerMsgs::Bitfield:
-        return !tor.has_metainfo() || len == 1 + ((tor.piece_count() + 7U) / 8U);
+        return !tor.has_metainfo() || len == 1 + tr_bytes_needed(tor.piece_count());
 
     case BtPeerMsgs::Request:
     case BtPeerMsgs::Cancel:

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -384,6 +384,35 @@ public:
         // A peer may not be interesting to us anymore after
         // sending us metadata, so do a status update
         update_active();
+
+        TR_ASSERT(tor_.has_metainfo());
+
+        // Torrent piece count was not known before this point,
+        // and this sets the bitfield size to the piece count.
+        // - If the peer sent "have all", then this line will preserve
+        //   the "have all".
+        // - If the peer sent "bitfield", then this line is a no-op,
+        //   since the bitfield size was already initialized.
+        if (!have_.init_size(tor_.piece_count())) {
+            // If the peer sent us a bitfield msg, then have_'s size is already initialized.
+            // Check if the bitfield's size is valid.
+            auto const peer_bitfield_bytes = tr_bytes_needed(have_.size());
+            auto const actual_bitfield_bytes = tr_bytes_needed(tor_.piece_count());
+            if (peer_bitfield_bytes != actual_bitfield_bytes) {
+                logdbg(
+                    this,
+                    fmt::format(
+                        "peer sent bitfield with {} bytes, but a valid bitfield should take {} bytes, disconnecting",
+                        peer_bitfield_bytes,
+                        actual_bitfield_bytes));
+                disconnect_soon();
+                return;
+            }
+
+            // Now that we know the exact piece count, we need to shrink the bitfield to the correct size.
+            [[maybe_unused]] auto const shrink_to_res = have_.shrink_to(tor_.piece_count());
+            TR_ASSERT(shrink_to_res);
+        }
     }
 
     void cancel_block_request(tr_block_index_t block)

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -77,6 +77,16 @@ template<typename T>
 // ---
 
 /**
+ * Calculates the number of bytes needed to store `bit_count` bits.
+ */
+[[nodiscard]] constexpr size_t tr_bytes_needed(size_t const bit_count) noexcept
+{
+    return (bit_count >> 3U) + ((bit_count & 7U) != 0U ? 1U : 0U);
+}
+
+// ---
+
+/**
  * Folds `b` into the running hash `a`, so a sequence of values can be
  * hashed one at a time. Order-sensitive: the same values in a different
  * order give a different hash.

--- a/tests/libtransmission/bitfield-test.cc
+++ b/tests/libtransmission/bitfield-test.cc
@@ -486,9 +486,10 @@ TEST(Bitfield, deferredSize)
 
 TEST(Bitfield, shrinkTo)
 {
-    // 0 is reserved for "unknown size", so shrinking to it always fails
+    // shrinking an "unknown size" bitfield is never allowed
     auto unknown_size = tr_bitfield{ 0 };
     EXPECT_FALSE(unknown_size.shrink_to(0U));
+    EXPECT_FALSE(unknown_size.shrink_to(1U));
 
     auto bf = tr_bitfield{ 20 };
     ASSERT_TRUE(bf.set_span(4U, 16U)); // bits [4,16) true, count == 12

--- a/tests/libtransmission/bitfield-test.cc
+++ b/tests/libtransmission/bitfield-test.cc
@@ -449,6 +449,133 @@ TEST(Bitfield, deferredSize)
     EXPECT_FALSE(have_none.set_span(0U, 1U));
     EXPECT_FALSE(have_none.set_raw(Raw));
     EXPECT_FALSE(have_none.set_from_bools(Flags));
+
+    EXPECT_FALSE(have_none.init_size(0U));
+    EXPECT_FALSE(have_none.is_size_known());
+    EXPECT_TRUE(have_none.init_size(10U));
+    EXPECT_TRUE(have_none.is_size_known());
+    EXPECT_TRUE(have_none.has_none());
+    EXPECT_EQ(10U, have_none.size());
+    EXPECT_EQ(0U, have_none.count());
+    EXPECT_TRUE(have_none.is_valid());
+
+    auto have_all = tr_bitfield{ 0 };
+    have_all.set_has_all();
+    EXPECT_FALSE(have_all.is_size_known());
+    EXPECT_TRUE(have_all.has_all());
+    EXPECT_FALSE(have_all.has_none());
+    EXPECT_TRUE(have_all.is_valid());
+    EXPECT_EQ(10U, have_all.count(0U, 10U));
+    EXPECT_EQ(15U, have_all.count(5U, 20U));
+    EXPECT_FLOAT_EQ(1.0F, have_all.percent());
+
+    EXPECT_TRUE(have_all.init_size(10U));
+    EXPECT_TRUE(have_all.is_size_known());
+    EXPECT_TRUE(have_all.has_all());
+    EXPECT_EQ(10U, have_all.count());
+    EXPECT_EQ(5U, have_all.count(5U, 20U));
+    EXPECT_EQ((std::vector<std::byte>{ std::byte{ 0xff }, std::byte{ 0xc0 } }), have_all.raw());
+    for (size_t i = 0U; i < have_all.size(); ++i) {
+        EXPECT_TRUE(have_all.test(i));
+    }
+
+    EXPECT_FALSE(have_all.init_size(20U));
+    EXPECT_EQ(10U, have_all.size());
+    EXPECT_TRUE(have_all.is_valid());
+}
+
+TEST(Bitfield, shrinkTo)
+{
+    // 0 is reserved for "unknown size", so shrinking to it always fails
+    auto unknown_size = tr_bitfield{ 0 };
+    EXPECT_FALSE(unknown_size.shrink_to(0U));
+
+    auto bf = tr_bitfield{ 20 };
+    ASSERT_TRUE(bf.set_span(4U, 16U)); // bits [4,16) true, count == 12
+
+    // growing is not allowed
+    EXPECT_FALSE(bf.shrink_to(21U));
+    EXPECT_EQ(20U, bf.size());
+
+    // 0 is reserved for "unknown size", so shrinking to it fails even for a
+    // bitfield with a known size and some true bits
+    EXPECT_FALSE(bf.shrink_to(0U));
+    EXPECT_EQ(20U, bf.size());
+    EXPECT_TRUE(bf.is_valid());
+
+    // shrinking to the current size is a no-op success
+    EXPECT_TRUE(bf.shrink_to(20U));
+    EXPECT_EQ(20U, bf.size());
+    EXPECT_EQ(12U, bf.count());
+
+    // shrinking drops bits beyond the new size and keeps the rest
+    EXPECT_TRUE(bf.shrink_to(10U));
+    EXPECT_EQ(10U, bf.size());
+    EXPECT_EQ(6U, bf.count()); // bits [4,10) remain true; [10,16) are dropped
+    for (size_t i = 0U; i < 10U; ++i) {
+        EXPECT_EQ(i >= 4U, bf.test(i));
+    }
+    EXPECT_TRUE(bf.is_valid());
+
+    // shrinking a have-all bitfield stays have-all at the new size
+    auto have_all = tr_bitfield{ 20 };
+    have_all.set_has_all();
+    EXPECT_TRUE(have_all.shrink_to(10U));
+    EXPECT_EQ(10U, have_all.size());
+    EXPECT_TRUE(have_all.has_all());
+    EXPECT_EQ(10U, have_all.count());
+    EXPECT_TRUE(have_all.is_valid());
+
+    // shrinking a have-none bitfield stays have-none at the new size
+    auto have_none = tr_bitfield{ 20 };
+    have_none.set_has_none();
+    EXPECT_TRUE(have_none.shrink_to(10U));
+    EXPECT_EQ(10U, have_none.size());
+    EXPECT_TRUE(have_none.has_none());
+    EXPECT_EQ(0U, have_none.count());
+    EXPECT_TRUE(have_none.is_valid());
+}
+
+TEST(Bitfield, shrinkToRecomputesTrueCount)
+{
+    // The true count after shrink_to() must reflect only the bits that
+    // remain in the new, smaller range -- even when the pre-shrink count
+    // happens to equal the new size, as it does here (count == 8, new
+    // size == 8) while none of the surviving bits [0,8) are actually set.
+    auto bf = tr_bitfield{ 16 };
+    ASSERT_TRUE(bf.set_span(8U, 16U)); // bits [8,16) true, count == 8
+    ASSERT_EQ(8U, bf.count());
+
+    ASSERT_TRUE(bf.shrink_to(8U));
+    EXPECT_EQ(8U, bf.size());
+    EXPECT_FALSE(bf.has_all());
+    EXPECT_TRUE(bf.has_none());
+    EXPECT_EQ(0U, bf.count());
+    for (size_t i = 0U; i < 8U; ++i) {
+        EXPECT_FALSE(bf.test(i));
+    }
+    EXPECT_TRUE(bf.is_valid());
+}
+
+TEST(Bitfield, shrinkToAfterIndividualUnset)
+{
+    // has_none() can become true either via set_has_none() or by set()
+    // clearing the last true bit. shrink_to() must produce a correctly
+    // sized buffer either way.
+    auto bf = tr_bitfield{ 16 };
+    ASSERT_TRUE(bf.set(15U));
+    ASSERT_TRUE(bf.set(15U, false));
+    ASSERT_TRUE(bf.has_none());
+
+    ASSERT_TRUE(bf.shrink_to(8U));
+    EXPECT_EQ(8U, bf.size());
+    EXPECT_TRUE(bf.has_none());
+    EXPECT_EQ(0U, bf.count());
+    EXPECT_TRUE(bf.is_valid());
+
+    auto const raw = bf.raw();
+    EXPECT_EQ(1U, std::size(raw)); // sized for the new bit count, not the old one
+    EXPECT_EQ(std::byte{}, raw[0]);
 }
 
 TEST(Bitfield, percent)

--- a/tests/libtransmission/bitfield-test.cc
+++ b/tests/libtransmission/bitfield-test.cc
@@ -534,6 +534,16 @@ TEST(Bitfield, shrinkTo)
     EXPECT_TRUE(have_none.has_none());
     EXPECT_EQ(0U, have_none.count());
     EXPECT_TRUE(have_none.is_valid());
+
+    // shrinking a partially set bitfield to a size that includes all the true bits makes it have-all
+    bf = tr_bitfield{ 20 };
+    ASSERT_TRUE(bf.set_span(0U, 15U));
+    EXPECT_EQ(15U, bf.count());
+    EXPECT_FALSE(bf.has_all());
+    EXPECT_TRUE(bf.shrink_to(15U));
+    EXPECT_EQ(15U, bf.size());
+    EXPECT_EQ(15U, bf.count());
+    EXPECT_TRUE(bf.has_all());
 }
 
 TEST(Bitfield, shrinkToRecomputesTrueCount)

--- a/tests/libtransmission/bitfield-test.cc
+++ b/tests/libtransmission/bitfield-test.cc
@@ -537,14 +537,16 @@ TEST(Bitfield, shrinkTo)
     EXPECT_TRUE(have_none.is_valid());
 
     // shrinking a partially set bitfield to a size that includes all the true bits makes it have-all
-    bf = tr_bitfield{ 20 };
-    ASSERT_TRUE(bf.set_span(0U, 15U));
-    EXPECT_EQ(15U, bf.count());
-    EXPECT_FALSE(bf.has_all());
-    EXPECT_TRUE(bf.shrink_to(15U));
-    EXPECT_EQ(15U, bf.size());
-    EXPECT_EQ(15U, bf.count());
-    EXPECT_TRUE(bf.has_all());
+    auto promoted = tr_bitfield{ 20 };
+    ASSERT_TRUE(promoted.set_span(0U, 15U));
+    EXPECT_EQ(15U, promoted.count());
+    EXPECT_FALSE(promoted.has_all());
+    EXPECT_TRUE(promoted.shrink_to(15U));
+    EXPECT_EQ(15U, promoted.size());
+    EXPECT_EQ(15U, promoted.count());
+    EXPECT_TRUE(promoted.has_all());
+    EXPECT_EQ((std::vector<std::byte>{ std::byte{ 0xff }, std::byte{ 0xfe } }), promoted.raw());
+    EXPECT_TRUE(promoted.is_valid());
 }
 
 TEST(Bitfield, shrinkToRecomputesTrueCount)


### PR DESCRIPTION
## Description

This PR does 2 things:
- Set the size of the `tr_peerMsgImpl::have_` bitfields after receiving metainfo for a magnet link.
- If the peer sent a `BITFIELD` message that is not the right size before the client received metainfo, disconnect the peer as soon as the client received the metainfo.

No release notes needed because the loose nature of `tr_bitfield` before #215 allowed the code to work anyway (intentional? fluke? I don't know).

---

`tr_peerMsgsImpl::have_` of peers that were connected before the client received the metainfo for a magnet link was constructed with size 0 `tr_bitfield{ 0 }`. In this state, `have_.set(piece, true)` invocations is a no-op.

This is fine before the client receives the metainfo, because the client had no way to determine if the `HAVE` message carried a valid piece index, so ignoring the operations was the only thing we could do.

However, after receiving the metainfo, the current code does not set the bitfield size accordingly, so `HAVE` messages are now silently ignored.

https://github.com/retransmission/retransmission/blob/541ea54ae12c6f2d278a6f91bc9c837288199447/libtransmission/peer-msgs.cc#L1412

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
