### PR TITLE
fix: OOB read/write in `tr_file_priorities::priorities_`

### DIFF
--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -140,32 +140,40 @@ tr_file_piece_map::file_offset_t tr_file_piece_map::file_offset(uint64_t const o
 
 // ---
 
-void tr_file_priorities::set(tr_file_index_t const file, tr_priority_t const new_priority)
+bool tr_file_priorities::set(tr_file_index_t const file, tr_priority_t const new_priority)
 {
+    if (file >= fpm_->file_count()) {
+        return false;
+    }
+
     if (std::empty(priorities_)) {
         if (new_priority == TR_PRI_NORMAL) {
-            return;
+            return false;
         }
 
         priorities_.assign(fpm_->file_count(), TR_PRI_NORMAL);
         priorities_.shrink_to_fit();
     }
 
-    priorities_[file] = new_priority;
+    return std::exchange(priorities_[file], new_priority) != new_priority;
 }
 
-void tr_file_priorities::set(std::span<tr_file_index_t const> const files, tr_priority_t const new_priority)
+bool tr_file_priorities::set(std::span<tr_file_index_t const> const files, tr_priority_t const new_priority)
 {
-    for (auto const file : files) {
-        set(file, new_priority);
+    if (std::ranges::any_of(files, [n_files = fpm_->file_count()](tr_file_index_t file) { return file >= n_files; })) {
+        return false;
     }
+
+    auto ret = false;
+    for (auto const file : files) {
+        ret |= set(file, new_priority);
+    }
+    return ret;
 }
 
 tr_priority_t tr_file_priorities::file_priority(tr_file_index_t const file) const
 {
-    TR_ASSERT(file < fpm_->file_count());
-
-    if (std::empty(priorities_)) {
+    if (file >= priorities_.size()) {
         return TR_PRI_NORMAL;
     }
 

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -79,7 +79,7 @@ void tr_file_piece_map::reset(tr_torrent_metainfo const& tm)
     for (tr_file_index_t i = 0U; i < n; ++i) {
         file_sizes[i] = tm.file_size(i);
     }
-    reset({ tm.total_size(), tm.piece_size() }, file_sizes);
+    reset(tm.block_info(), file_sizes);
 }
 
 namespace

--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <iterator>
+#include <utility> // std::exchange()
 #include <vector>
 
 #include <small/set.hpp>

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -87,8 +87,8 @@ public:
     {
     }
 
-    void set(tr_file_index_t file, tr_priority_t priority);
-    void set(std::span<tr_file_index_t const> files, tr_priority_t priority);
+    [[nodiscard]] bool set(tr_file_index_t file, tr_priority_t priority);
+    [[nodiscard]] bool set(std::span<tr_file_index_t const> files, tr_priority_t priority);
 
     [[nodiscard]] tr_priority_t file_priority(tr_file_index_t file) const;
     [[nodiscard]] tr_priority_t piece_priority(tr_piece_index_t piece) const;

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -87,6 +87,7 @@ public:
     {
     }
 
+    // returns true if any file's priority changed.
     [[nodiscard]] bool set(tr_file_index_t file, tr_priority_t priority);
     [[nodiscard]] bool set(std::span<tr_file_index_t const> files, tr_priority_t priority);
 

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1542,8 +1542,8 @@ bool isCurlURL(std::string_view url)
     auto files = std::vector<tr_file_index_t>{};
     files.reserve(n_files);
     for (auto const& idx_var : idx_vec) {
-        if (auto const val = idx_var.value_if<int64_t>()) {
-            files.emplace_back(static_cast<tr_file_index_t>(*val));
+        if (auto const val = idx_var.value_if<tr_file_index_t>()) {
+            files.emplace_back(*val);
         }
     }
     return files;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1907,6 +1907,8 @@ tr_block_span_t tr_torrent::block_span_for_file(tr_file_index_t const file) cons
 
 void tr_torrent::set_file_priorities(std::span<tr_file_index_t const> const files, tr_priority_t priority)
 {
+    auto const lock = unique_lock();
+
     if (file_priorities_.set(files, priority)) {
         priority_changed_(this, files, priority);
         set_dirty();

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1907,10 +1907,7 @@ tr_block_span_t tr_torrent::block_span_for_file(tr_file_index_t const file) cons
 
 void tr_torrent::set_file_priorities(std::span<tr_file_index_t const> const files, tr_priority_t priority)
 {
-    if (std::ranges::any_of(files, [this, priority](tr_file_index_t file) {
-            return priority != file_priorities_.file_priority(file);
-        })) {
-        file_priorities_.set(files, priority);
+    if (file_priorities_.set(files, priority)) {
         priority_changed_(this, files, priority);
         set_dirty();
         mark_changed();

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -429,11 +429,7 @@ struct tr_torrent {
 
     void set_file_priority(tr_file_index_t file, tr_priority_t priority)
     {
-        if (file_priorities_.set(file, priority)) {
-            priority_changed_(this, std::span{ &file, 1U }, priority);
-            set_dirty();
-            mark_changed();
-        }
+        set_file_priorities(std::span{ &file, 1U }, priority);
     }
 
     /// LOCATION

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -429,8 +429,7 @@ struct tr_torrent {
 
     void set_file_priority(tr_file_index_t file, tr_priority_t priority)
     {
-        if (priority != file_priorities_.file_priority(file)) {
-            file_priorities_.set(file, priority);
+        if (file_priorities_.set(file, priority)) {
             priority_changed_(this, std::span{ &file, 1U }, priority);
             set_dirty();
             mark_changed();

--- a/tests/libtransmission/file-piece-map-test.cc
+++ b/tests/libtransmission/file-piece-map-test.cc
@@ -172,7 +172,7 @@ TEST_F(FilePieceMapTest, priorities)
     // since this begins and ends on a piece boundary,
     // this shouldn't affect any other files' pieces
     auto pri = TR_PRI_HIGH;
-    file_priorities.set(0U, pri);
+    EXPECT_TRUE(file_priorities.set(0U, pri));
     expected_file_priorities[0] = pri;
     for (size_t i = 0U; i < 5U; ++i) {
         expected_piece_priorities[i] = pri;
@@ -187,13 +187,13 @@ TEST_F(FilePieceMapTest, priorities)
     //
     // first test setting file #5...
     pri = TR_PRI_HIGH;
-    file_priorities.set(5U, pri);
+    EXPECT_TRUE(file_priorities.set(5U, pri));
     expected_file_priorities[5] = pri;
     expected_piece_priorities[5] = pri;
     mark_file_endpoints_as_high_priority();
     compare_to_expected();
     // ...and that shared piece should still be the same when both are high...
-    file_priorities.set(6U, pri);
+    EXPECT_TRUE(file_priorities.set(6U, pri));
     expected_file_priorities[6] = pri;
     expected_piece_priorities[5] = pri;
     expected_piece_priorities[6] = pri;
@@ -201,7 +201,7 @@ TEST_F(FilePieceMapTest, priorities)
     compare_to_expected();
     // ...and that shared piece should still be the same when only 6 is high...
     pri = TR_PRI_NORMAL;
-    file_priorities.set(5U, pri);
+    EXPECT_TRUE(file_priorities.set(5U, pri));
     expected_file_priorities[5] = pri;
     mark_file_endpoints_as_high_priority();
     compare_to_expected();
@@ -209,7 +209,7 @@ TEST_F(FilePieceMapTest, priorities)
     // setup for the next test: set all files to low priority
     pri = TR_PRI_LOW;
     for (tr_file_index_t i = 0U; i < n_files; ++i) {
-        file_priorities.set(i, pri);
+        EXPECT_TRUE(file_priorities.set(i, pri));
     }
     std::ranges::fill(expected_file_priorities, pri);
     std::ranges::fill(expected_piece_priorities, pri);
@@ -220,7 +220,7 @@ TEST_F(FilePieceMapTest, priorities)
     // Since it's the highest priority in the piece, piecePriority() should return its value.
     // file #8: byte [6.5P+10, 6.5P+19) piece [6, 7)
     pri = TR_PRI_NORMAL;
-    file_priorities.set(8U, pri);
+    EXPECT_TRUE(file_priorities.set(8U, pri));
     expected_file_priorities[8] = pri;
     expected_piece_priorities[6] = pri;
     mark_file_endpoints_as_high_priority();
@@ -229,7 +229,7 @@ TEST_F(FilePieceMapTest, priorities)
     // Since _it_ now has the highest priority in the piece, piecePriority should return _its_ value.
     // file #9: byte [6.5P+19, 6.5P+27) piece [6, 7)
     pri = TR_PRI_HIGH;
-    file_priorities.set(9U, pri);
+    EXPECT_TRUE(file_priorities.set(9U, pri));
     expected_file_priorities[9] = pri;
     expected_piece_priorities[6] = pri;
     mark_file_endpoints_as_high_priority();
@@ -238,7 +238,7 @@ TEST_F(FilePieceMapTest, priorities)
     // Prep for the next test: set all files to normal priority
     pri = TR_PRI_NORMAL;
     for (tr_file_index_t i = 0U; i < n_files; ++i) {
-        file_priorities.set(i, pri);
+        EXPECT_EQ(i != 8U, file_priorities.set(i, pri));
     }
     std::ranges::fill(expected_file_priorities, pri);
     std::ranges::fill(expected_piece_priorities, pri);
@@ -254,14 +254,14 @@ TEST_F(FilePieceMapTest, priorities)
     // Check that even zero-sized files can change a piece's priority
     // file #1: byte [5P, 5P) piece [5, 6)
     pri = TR_PRI_HIGH;
-    file_priorities.set(1U, pri);
+    EXPECT_TRUE(file_priorities.set(1U, pri));
     expected_file_priorities[1] = pri;
     expected_piece_priorities[5] = pri;
     mark_file_endpoints_as_high_priority();
     compare_to_expected();
     // Check that zero-sized files at the end of a torrent change the last piece's priority.
     // file #16 byte [10P, 10P) piece [9, 10)
-    file_priorities.set(16U, pri);
+    EXPECT_TRUE(file_priorities.set(16U, pri));
     expected_file_priorities[16] = pri;
     expected_piece_priorities[9] = pri;
     mark_file_endpoints_as_high_priority();
@@ -271,17 +271,42 @@ TEST_F(FilePieceMapTest, priorities)
     auto file_indices = std::vector<tr_file_index_t>(n_files);
     std::iota(std::begin(file_indices), std::end(file_indices), 0U);
     pri = TR_PRI_HIGH;
-    file_priorities.set(file_indices, pri);
+    EXPECT_TRUE(file_priorities.set(file_indices, pri));
     std::ranges::fill(expected_file_priorities, pri);
     std::ranges::fill(expected_piece_priorities, pri);
     mark_file_endpoints_as_high_priority();
     compare_to_expected();
     pri = TR_PRI_LOW;
-    file_priorities.set(file_indices, pri);
+    EXPECT_TRUE(file_priorities.set(file_indices, pri));
     std::ranges::fill(expected_file_priorities, pri);
     std::ranges::fill(expected_piece_priorities, pri);
     mark_file_endpoints_as_high_priority();
     compare_to_expected();
+}
+
+TEST_F(FilePieceMapTest, priorityBounds)
+{
+    auto const fpm = tr_file_piece_map{ block_info_, FileSizes };
+    auto file_priorities = tr_file_priorities(&fpm);
+    tr_file_index_t const n_files = fpm.file_count();
+
+    EXPECT_EQ(TR_PRI_NORMAL, file_priorities.file_priority(n_files));
+
+    EXPECT_TRUE(file_priorities.set(0U, TR_PRI_HIGH));
+    EXPECT_FALSE(file_priorities.set(0U, TR_PRI_HIGH));
+    EXPECT_FALSE(file_priorities.set(n_files, TR_PRI_LOW));
+    EXPECT_EQ(TR_PRI_HIGH, file_priorities.file_priority(0U));
+    EXPECT_EQ(TR_PRI_NORMAL, file_priorities.file_priority(n_files));
+
+    auto const invalid_files = std::to_array<tr_file_index_t>({ 1U, n_files });
+    EXPECT_FALSE(file_priorities.set(invalid_files, TR_PRI_LOW));
+    EXPECT_EQ(TR_PRI_NORMAL, file_priorities.file_priority(1U));
+
+    constexpr auto Files = std::to_array<tr_file_index_t>({ 1U, 2U });
+    EXPECT_TRUE(file_priorities.set(Files, TR_PRI_LOW));
+    EXPECT_FALSE(file_priorities.set(Files, TR_PRI_LOW));
+    EXPECT_EQ(TR_PRI_LOW, file_priorities.file_priority(1U));
+    EXPECT_EQ(TR_PRI_LOW, file_priorities.file_priority(2U));
 }
 
 TEST_F(FilePieceMapTest, wanted)

--- a/tests/libtransmission/file-piece-map-test.cc
+++ b/tests/libtransmission/file-piece-map-test.cc
@@ -238,7 +238,7 @@ TEST_F(FilePieceMapTest, priorities)
     // Prep for the next test: set all files to normal priority
     pri = TR_PRI_NORMAL;
     for (tr_file_index_t i = 0U; i < n_files; ++i) {
-        EXPECT_EQ(i != 8U, file_priorities.set(i, pri));
+        EXPECT_EQ(expected_file_priorities[i] != pri, file_priorities.set(i, pri));
     }
     std::ranges::fill(expected_file_priorities, pri);
     std::ranges::fill(expected_piece_priorities, pri);

--- a/tests/libtransmission/file-piece-map-test.cc
+++ b/tests/libtransmission/file-piece-map-test.cc
@@ -26,6 +26,7 @@ protected:
     static constexpr size_t PieceSize{ tr_block_info::BlockSize };
     static constexpr size_t TotalSize{ 10 * PieceSize };
     tr_block_info const block_info_{ TotalSize, PieceSize };
+    tr_block_info const magnet_block_info_{ 0, 0 };
 
     static constexpr std::array<uint64_t, 17> FileSizes{
         5U * PieceSize, // [offset 0] begins and ends on a piece boundary
@@ -286,6 +287,13 @@ TEST_F(FilePieceMapTest, priorities)
 
 TEST_F(FilePieceMapTest, priorityBounds)
 {
+    // A torrent with no files yet -- a magnet before its metadata arrives --
+    // must reject every index rather than index an empty vector.
+    auto const empty_fpm = tr_file_piece_map{ magnet_block_info_, {} };
+    auto empty_priorities = tr_file_priorities(&empty_fpm);
+    EXPECT_FALSE(empty_priorities.set(0U, TR_PRI_HIGH));
+    EXPECT_EQ(TR_PRI_NORMAL, empty_priorities.file_priority(0U));
+
     auto const fpm = tr_file_piece_map{ block_info_, FileSizes };
     auto file_priorities = tr_file_priorities(&fpm);
     tr_file_index_t const n_files = fpm.file_count();


### PR DESCRIPTION
## Description

Fix a potential buffer overflow from RPC `torrent_add.priority_*`.

The way to trigger the buffer overflow is simple: Add a torrent with `N` pieces using `torrent_add` with argument `"priority_high": [N]`, and the client will try to write one byte past the end of `tr_file_priorities::priorities_`.

Notes: Hardened the `torrent-add` RPC method against malformed requests.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
