### PR TITLE
Extract small torrent cell from xib.

### DIFF
--- a/macosx/SmallTorrentCell.mm
+++ b/macosx/SmallTorrentCell.mm
@@ -14,6 +14,106 @@
 
 @implementation SmallTorrentCell
 
+// Layout
+- (void)configurePriorities
+{
+    auto groupIndicatorView = self.fGroupIndicatorView;
+    auto iconView = self.fIconView;
+    auto torrentTitleField = self.fTorrentTitleField;
+    auto torrentPriorityView = self.fTorrentPriorityView;
+    auto torrentStatusField = self.fTorrentStatusField;
+
+    // left items
+    for (NSView* leftView in @[ groupIndicatorView, iconView ]) {
+        [leftView setContentHuggingPriority:NSLayoutPriorityDefaultLow + 1 forOrientation:NSLayoutConstraintOrientationHorizontal];
+        [leftView setContentHuggingPriority:NSLayoutPriorityDefaultLow + 1 forOrientation:NSLayoutConstraintOrientationVertical];
+    }
+
+    /// middle items
+    [torrentTitleField setContentHuggingPriority:NSLayoutPriorityRequired forOrientation:NSLayoutConstraintOrientationHorizontal];
+    [torrentTitleField setContentHuggingPriority:NSLayoutPriorityDefaultHigh forOrientation:NSLayoutConstraintOrientationVertical];
+    [torrentPriorityView setContentHuggingPriority:NSLayoutPriorityRequired forOrientation:NSLayoutConstraintOrientationHorizontal];
+    [torrentPriorityView setContentHuggingPriority:NSLayoutPriorityDefaultLow + 1 forOrientation:NSLayoutConstraintOrientationVertical];
+
+    [torrentStatusField setContentHuggingPriority:NSLayoutPriorityDefaultLow + 1 forOrientation:NSLayoutConstraintOrientationHorizontal];
+    [torrentStatusField setContentHuggingPriority:NSLayoutPriorityDefaultHigh forOrientation:NSLayoutConstraintOrientationVertical];
+    [torrentStatusField setContentCompressionResistancePriority:NSLayoutPriorityRequired
+                                                 forOrientation:NSLayoutConstraintOrientationHorizontal];
+}
+
+- (void)setupConstraints
+{
+    auto groupIndicatorView = self.fGroupIndicatorView;
+    auto iconView = self.fIconView;
+    auto actionButton = self.fActionButton;
+    auto stackView = self.fStackView;
+    auto torrentStatusField = self.fTorrentStatusField;
+    auto torrentProgressBarView = self.fTorrentProgressBarView;
+    auto controlButton = self.fControlButton;
+    auto revealButton = self.fRevealButton;
+
+    for (NSView* view in @[
+             groupIndicatorView,
+             iconView,
+             actionButton,
+             torrentProgressBarView,
+             stackView,
+             torrentStatusField,
+             controlButton,
+             revealButton,
+         ]) {
+        [self addSubview:view];
+    }
+
+    [NSLayoutConstraint activateConstraints:@[
+        // groupIndicatorView
+        [groupIndicatorView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+        [groupIndicatorView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [groupIndicatorView.widthAnchor constraintEqualToConstant:6],
+        [groupIndicatorView.heightAnchor constraintEqualToConstant:6],
+
+        // iconView
+        [iconView.leadingAnchor constraintEqualToAnchor:groupIndicatorView.trailingAnchor constant:8],
+        [iconView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [iconView.widthAnchor constraintEqualToConstant:16],
+        [iconView.heightAnchor constraintEqualToConstant:16],
+
+        // actionButton
+        [actionButton.centerXAnchor constraintEqualToAnchor:iconView.centerXAnchor],
+        [actionButton.centerYAnchor constraintEqualToAnchor:iconView.centerYAnchor],
+        [actionButton.widthAnchor constraintEqualToConstant:16],
+        [actionButton.heightAnchor constraintEqualToConstant:16],
+
+        // torrentProgressBarView
+        [torrentProgressBarView.leadingAnchor constraintEqualToAnchor:iconView.trailingAnchor constant:15],
+        [torrentProgressBarView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-5],
+        [torrentProgressBarView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [torrentProgressBarView.heightAnchor constraintEqualToConstant:18],
+
+        // stackView
+        [stackView.leadingAnchor constraintEqualToAnchor:torrentProgressBarView.leadingAnchor],
+        [stackView.topAnchor constraintEqualToAnchor:torrentProgressBarView.topAnchor],
+        [stackView.bottomAnchor constraintEqualToAnchor:torrentProgressBarView.bottomAnchor],
+
+        // torrentStatusField
+        [torrentStatusField.leadingAnchor constraintEqualToAnchor:stackView.trailingAnchor],
+        [torrentStatusField.trailingAnchor constraintEqualToAnchor:torrentProgressBarView.trailingAnchor constant:-3],
+        [torrentStatusField.centerYAnchor constraintEqualToAnchor:torrentProgressBarView.centerYAnchor],
+
+        // controlButton
+        [controlButton.centerYAnchor constraintEqualToAnchor:torrentProgressBarView.centerYAnchor],
+        [controlButton.widthAnchor constraintEqualToConstant:14],
+        [controlButton.heightAnchor constraintEqualToConstant:14],
+
+        // revealButton
+        [revealButton.leadingAnchor constraintEqualToAnchor:controlButton.trailingAnchor constant:3],
+        [revealButton.trailingAnchor constraintEqualToAnchor:torrentProgressBarView.trailingAnchor constant:-3],
+        [revealButton.centerYAnchor constraintEqualToAnchor:controlButton.centerYAnchor],
+        [revealButton.widthAnchor constraintEqualToConstant:14],
+        [revealButton.heightAnchor constraintEqualToConstant:14],
+    ]];
+}
+
 // show fControlButton and fRevealButton
 - (void)mouseEntered:(NSEvent*)event
 {

--- a/macosx/SmallTorrentCell.mm
+++ b/macosx/SmallTorrentCell.mm
@@ -14,6 +14,13 @@
 
 @implementation SmallTorrentCell
 
+- (void)configureViews
+{
+    [super configureViews];
+    // also set alignment as part of priorities ( text inside a textLabel ).
+    self.fTorrentStatusField.alignment = NSTextAlignmentRight;
+}
+
 // Layout
 - (void)configurePriorities
 {
@@ -46,6 +53,7 @@
     auto groupIndicatorView = self.fGroupIndicatorView;
     auto iconView = self.fIconView;
     auto actionButton = self.fActionButton;
+    auto torrentPriorityView = self.fTorrentPriorityView;
     auto stackView = self.fStackView;
     auto torrentStatusField = self.fTorrentStatusField;
     auto torrentProgressBarView = self.fTorrentProgressBarView;
@@ -90,13 +98,17 @@
         [torrentProgressBarView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
         [torrentProgressBarView.heightAnchor constraintEqualToConstant:18],
 
+        // torrentPriorityView
+        [torrentPriorityView.heightAnchor constraintEqualToConstant:12],
+        [torrentPriorityView.widthAnchor constraintEqualToConstant:12],
+
         // stackView
         [stackView.leadingAnchor constraintEqualToAnchor:torrentProgressBarView.leadingAnchor],
         [stackView.topAnchor constraintEqualToAnchor:torrentProgressBarView.topAnchor],
         [stackView.bottomAnchor constraintEqualToAnchor:torrentProgressBarView.bottomAnchor],
 
         // torrentStatusField
-        [torrentStatusField.leadingAnchor constraintEqualToAnchor:stackView.trailingAnchor],
+        [torrentStatusField.leadingAnchor constraintEqualToAnchor:stackView.trailingAnchor constant:4],
         [torrentStatusField.trailingAnchor constraintEqualToAnchor:torrentProgressBarView.trailingAnchor constant:-3],
         [torrentStatusField.centerYAnchor constraintEqualToAnchor:torrentProgressBarView.centerYAnchor],
 

--- a/macosx/TorrentCell.h
+++ b/macosx/TorrentCell.h
@@ -26,6 +26,7 @@
 
 @property(nonatomic, weak) TorrentTableView* fTorrentTableView;
 
+- (void)configureViews;
 - (void)configurePriorities;
 - (void)setupConstraints;
 

--- a/macosx/TorrentCell.h
+++ b/macosx/TorrentCell.h
@@ -26,4 +26,7 @@
 
 @property(nonatomic, weak) TorrentTableView* fTorrentTableView;
 
+- (void)configurePriorities;
+- (void)setupConstraints;
+
 @end

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -147,6 +147,7 @@
     auto groupIndicatorView = self.fGroupIndicatorView;
     auto iconView = self.fIconView;
     auto actionButton = self.fActionButton;
+    auto torrentPriorityView = self.fTorrentPriorityView;
     auto stackView = self.fStackView;
     auto torrentProgressField = self.fTorrentProgressField;
     auto torrentStatusField = self.fTorrentStatusField;
@@ -186,6 +187,10 @@
         [actionButton.centerYAnchor constraintEqualToAnchor:iconView.centerYAnchor],
         [actionButton.widthAnchor constraintEqualToConstant:16],
         [actionButton.heightAnchor constraintEqualToConstant:16],
+
+        // torrentPriorityView
+        [torrentPriorityView.heightAnchor constraintEqualToConstant:12],
+        [torrentPriorityView.widthAnchor constraintEqualToConstant:12],
 
         // stackView
         [stackView.leadingAnchor constraintEqualToAnchor:iconView.trailingAnchor constant:16],

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -87,7 +87,6 @@
              revealButton,
          ]) {
         view.translatesAutoresizingMaskIntoConstraints = NO;
-        [self addSubview:view];
     }
 
     self.fGroupIndicatorView = groupIndicatorView;
@@ -154,6 +153,20 @@
     auto torrentProgressBarView = self.fTorrentProgressBarView;
     auto controlButton = self.fControlButton;
     auto revealButton = self.fRevealButton;
+
+    for (NSView* view in @[
+             groupIndicatorView,
+             iconView,
+             actionButton,
+             stackView,
+             torrentProgressField,
+             torrentStatusField,
+             torrentProgressBarView,
+             controlButton,
+             revealButton,
+         ]) {
+        [self addSubview:view];
+    }
 
     [NSLayoutConstraint activateConstraints:@[
         // groupIndicatorView

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -205,7 +205,16 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
         TorrentCell* torrentCell;
         if (minimal) {
-            torrentCell = [outlineView makeViewWithIdentifier:@"SmallTorrentCell" owner:self];
+            // TODO(lolgear): Remove small torrent cell from xib.
+            torrentCell = [outlineView makeViewWithIdentifier:@"NewSmallTorrentCell" owner:self];
+            if (!torrentCell) {
+                torrentCell = [[TorrentCell alloc] initWithFrame:NSZeroRect];
+                torrentCell.identifier = @"NewSmallTorrentCell";
+            }
+
+            ((TorrentCellControlButton*)torrentCell.fControlButton).torrentCell = torrentCell;
+            ((TorrentCellRevealButton*)torrentCell.fRevealButton).torrentCell = torrentCell;
+            ((TorrentCellActionButton*)torrentCell.fActionButton).torrentCell = torrentCell;
 
             // set torrent icon or error badge
             torrentCell.fIconView.image = error ? [NSImage imageNamed:NSImageNameCaution] : torrent.icon;

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -208,8 +208,9 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
             // TODO(lolgear): Remove small torrent cell from xib.
             torrentCell = [outlineView makeViewWithIdentifier:@"NewSmallTorrentCell" owner:self];
             if (!torrentCell) {
-                torrentCell = [[TorrentCell alloc] initWithFrame:NSZeroRect];
+                torrentCell = [[SmallTorrentCell alloc] initWithFrame:NSMakeRect(0, 0, NSWidth(outlineView.bounds), self.rowHeight)];
                 torrentCell.identifier = @"NewSmallTorrentCell";
+                [torrentCell layoutSubtreeIfNeeded];
             }
 
             ((TorrentCellControlButton*)torrentCell.fControlButton).torrentCell = torrentCell;


### PR DESCRIPTION
To increase flexibility when editing the small torrent cell.
Based on #8547

Extracting the cell from the XIB unlocks:
1. Encapsulating static data inside the cell (e.g., `NSLocalizedString` or custom colors).
2. Implementing a proper `ProgressView` using `CALayer` to improve performance by offloading computations to the GPU.

### Results

This PR changes the behavior related to multiple invocations of `awakeFromNib` in `TorrentTableView` according to the [Apple documentation](https://apple.com).

> This method is usually called by the delegate in [tableView(_:viewFor:row:)](https://apple.com), but it can also be overridden to provide custom views for the identifier. Note that [awakeFromNib()](https://apple.com) is called each time this method is called, meaning that `awakeFromNib()` will trigger for the owner bundle repeatedly if the owner is passed down during instantiation.
