### PR TITLE
perf: execute follow-ups iff files_wanted changed

### DIFF
--- a/libtransmission/file-piece-map.cc
+++ b/libtransmission/file-piece-map.cc
@@ -212,16 +212,22 @@ tr_files_wanted::tr_files_wanted(tr_file_piece_map const* const fpm)
     wanted_.set_has_all(); // by default we want all files
 }
 
-void tr_files_wanted::set(tr_file_index_t const file, bool const wanted)
+bool tr_files_wanted::set(tr_file_index_t const file, bool const wanted)
 {
-    wanted_.set(file, wanted);
+    return wanted_.set(file, wanted);
 }
 
-void tr_files_wanted::set(std::span<tr_file_index_t const> const files, bool const wanted)
+bool tr_files_wanted::set(std::span<tr_file_index_t const> const files, bool const wanted)
 {
-    for (auto const file : files) {
-        set(file, wanted);
+    if (std::ranges::any_of(files, [this](tr_file_index_t const file) { return file >= fpm_->file_count(); })) {
+        return false;
     }
+
+    auto ret = false;
+    for (auto const file : files) {
+        ret |= set(file, wanted);
+    }
+    return ret;
 }
 
 bool tr_files_wanted::piece_wanted(tr_piece_index_t const piece) const

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -104,8 +104,8 @@ class tr_files_wanted
 public:
     explicit tr_files_wanted(tr_file_piece_map const* fpm);
 
-    void set(tr_file_index_t file, bool wanted);
-    void set(std::span<tr_file_index_t const> files, bool wanted);
+    bool set(tr_file_index_t file, bool wanted);
+    bool set(std::span<tr_file_index_t const> files, bool wanted);
 
     [[nodiscard]] constexpr bool file_wanted(tr_file_index_t file) const
     {

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -1905,6 +1905,23 @@ tr_block_span_t tr_torrent::block_span_for_file(tr_file_index_t const file) cons
 
 // ---
 
+void tr_torrent::set_files_wanted(std::span<tr_file_index_t const> files, bool wanted, bool is_bootstrapping)
+{
+    auto const lock = unique_lock();
+
+    if (files_wanted_.set(files, wanted)) {
+        completion_.invalidate_size_when_done();
+        files_wanted_changed_(this, files, wanted);
+
+        if (!is_bootstrapping) {
+            set_dirty();
+            recheck_completeness();
+        }
+    }
+}
+
+// ---
+
 void tr_torrent::set_file_priorities(std::span<tr_file_index_t const> const files, tr_priority_t priority)
 {
     auto const lock = unique_lock();

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -1198,19 +1198,7 @@ private:
         needs_completeness_check_ = true;
     }
 
-    void set_files_wanted(std::span<tr_file_index_t const> files, bool wanted, bool is_bootstrapping)
-    {
-        auto const lock = unique_lock();
-
-        files_wanted_.set(files, wanted);
-        completion_.invalidate_size_when_done();
-        files_wanted_changed_(this, files, wanted);
-
-        if (!is_bootstrapping) {
-            set_dirty();
-            recheck_completeness();
-        }
-    }
+    void set_files_wanted(std::span<tr_file_index_t const> files, bool wanted, bool is_bootstrapping);
 
     void set_verify_state(VerifyState state);
 

--- a/tests/libtransmission/file-piece-map-test.cc
+++ b/tests/libtransmission/file-piece-map-test.cc
@@ -7,6 +7,7 @@
 #include <array>
 #include <cstddef> // size_t
 #include <cstdint> // uint64_t
+#include <limits>
 #include <numeric>
 #include <vector>
 
@@ -348,7 +349,7 @@ TEST_F(FilePieceMapTest, wanted)
     // since this begins and ends on a piece boundary,
     // this shouldn't affect any other files' pieces
     bool const wanted = false;
-    files_wanted.set(0U, wanted);
+    EXPECT_TRUE(files_wanted.set(0U, wanted));
     expected_files_wanted.set(0U, wanted);
     expected_pieces_wanted.set_span(0U, 5U, wanted);
     compare_to_expected();
@@ -363,33 +364,33 @@ TEST_F(FilePieceMapTest, wanted)
     // file #6: byte [5.5P, 6.5P) piece [5, 7)
     //
     // first test setting file #5...
-    files_wanted.set(5U, false);
+    EXPECT_TRUE(files_wanted.set(5U, false));
     expected_files_wanted.unset(5U);
     compare_to_expected();
     // marking all the files in the piece as unwanted
     // should cause the piece to become unwanted
-    files_wanted.set(1U, false);
-    files_wanted.set(2U, false);
-    files_wanted.set(3U, false);
-    files_wanted.set(4U, false);
-    files_wanted.set(5U, false);
-    files_wanted.set(6U, false);
+    EXPECT_TRUE(files_wanted.set(1U, false));
+    EXPECT_TRUE(files_wanted.set(2U, false));
+    EXPECT_TRUE(files_wanted.set(3U, false));
+    EXPECT_TRUE(files_wanted.set(4U, false));
+    EXPECT_FALSE(files_wanted.set(5U, false));
+    EXPECT_TRUE(files_wanted.set(6U, false));
     expected_files_wanted.set_span(1U, 7U, false);
     expected_pieces_wanted.unset(5U);
     compare_to_expected();
     // but as soon as any of them is turned back to wanted,
     // the piece should pop back.
-    files_wanted.set(6U, true);
+    EXPECT_TRUE(files_wanted.set(6U, true));
     expected_files_wanted.set(6U, true);
     expected_pieces_wanted.set(5U);
     compare_to_expected();
-    files_wanted.set(5U, true);
-    files_wanted.set(6U, false);
+    EXPECT_TRUE(files_wanted.set(5U, true));
+    EXPECT_TRUE(files_wanted.set(6U, false));
     expected_files_wanted.set(5U);
     expected_files_wanted.unset(6U);
     compare_to_expected();
-    files_wanted.set(4U, true);
-    files_wanted.set(5U, false);
+    EXPECT_TRUE(files_wanted.set(4U, true));
+    EXPECT_TRUE(files_wanted.set(5U, false));
     expected_files_wanted.set(4U);
     expected_files_wanted.unset(5U);
     compare_to_expected();
@@ -409,13 +410,13 @@ TEST_F(FilePieceMapTest, wanted)
     //
     // Check that even zero-sized files can change a file's 'wanted' state
     // file #1: byte [5P, 5P) piece [5, 6)
-    files_wanted.set(1U, true);
+    EXPECT_TRUE(files_wanted.set(1U, true));
     expected_files_wanted.set(1U);
     expected_pieces_wanted.set(5U);
     compare_to_expected();
     // Check that zero-sized files at the end of a torrent change the last piece's state.
     // file #16 byte [10P, 10P) piece [9, 10)
-    files_wanted.set(16U, true);
+    EXPECT_TRUE(files_wanted.set(16U, true));
     expected_files_wanted.set(16U);
     expected_pieces_wanted.set(9U);
     compare_to_expected();
@@ -423,12 +424,36 @@ TEST_F(FilePieceMapTest, wanted)
     // test the batch API
     auto file_indices = std::vector<tr_file_index_t>(n_files);
     std::iota(std::begin(file_indices), std::end(file_indices), 0);
-    files_wanted.set(file_indices, true);
+    EXPECT_TRUE(files_wanted.set(file_indices, true));
     expected_files_wanted.set_has_all();
     expected_pieces_wanted.set_has_all();
     compare_to_expected();
-    files_wanted.set(file_indices, false);
+    EXPECT_TRUE(files_wanted.set(file_indices, false));
     expected_files_wanted.set_has_none();
     expected_pieces_wanted.set_has_none();
     compare_to_expected();
+}
+
+TEST_F(FilePieceMapTest, wantedBounds)
+{
+    auto const fpm = tr_file_piece_map{ block_info_, FileSizes };
+    auto files_wanted = tr_files_wanted(&fpm);
+    tr_file_index_t const n_files = fpm.file_count();
+
+    EXPECT_TRUE(files_wanted.set(0U, false));
+    EXPECT_FALSE(files_wanted.set(0U, false));
+    EXPECT_FALSE(files_wanted.set(n_files, false));
+    EXPECT_FALSE(files_wanted.set(std::numeric_limits<tr_file_index_t>::max(), false));
+    EXPECT_FALSE(files_wanted.file_wanted(0U));
+    EXPECT_FALSE(files_wanted.file_wanted(n_files));
+
+    auto const invalid_files = std::to_array<tr_file_index_t>({ 1U, std::numeric_limits<tr_file_index_t>::max() });
+    EXPECT_FALSE(files_wanted.set(invalid_files, false));
+    EXPECT_TRUE(files_wanted.file_wanted(1U));
+
+    constexpr auto Files = std::to_array<tr_file_index_t>({ 1U, 2U });
+    EXPECT_TRUE(files_wanted.set(Files, false));
+    EXPECT_FALSE(files_wanted.set(Files, false));
+    EXPECT_FALSE(files_wanted.file_wanted(1U));
+    EXPECT_FALSE(files_wanted.file_wanted(2U));
 }


### PR DESCRIPTION
## Description

Execute the follow-ups, callbacks and whatnot iff `files_wanted` changed, instead of executing them unconditionally as long as `tr_torrent::set_files_wanted` is called.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
