### PR TITLE
refactor(mac): migrate macosx group to file-system synchronized folders

### DIFF
--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -20,21 +20,8 @@
 		3C7A11980D0B2EE300B5701F /* getgateway.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C7A11920D0B2EE300B5701F /* getgateway.h */; };
 		3C7A11990D0B2EE300B5701F /* natpmp.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C7A11930D0B2EE300B5701F /* natpmp.c */; };
 		3C7A119A0D0B2EE300B5701F /* natpmp.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C7A11940D0B2EE300B5701F /* natpmp.h */; };
-		4521532B29AF891F009331B0 /* GroupCell.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4521532929AF891E009331B0 /* GroupCell.mm */; };
-		4521532E29AF9D61009331B0 /* TorrentCell.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4521532D29AF9D61009331B0 /* TorrentCell.mm */; };
-		4534164229B0EA8600F544C9 /* SmallTorrentCell.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4534164129B0EA8600F544C9 /* SmallTorrentCell.mm */; };
-		45489C5429AF6FB20098A812 /* TorrentCellActionButton.mm in Sources */ = {isa = PBXBuildFile; fileRef = 45489C5029AF6FB10098A812 /* TorrentCellActionButton.mm */; };
-		45489C5629AF6FB20098A812 /* TorrentCellRevealButton.mm in Sources */ = {isa = PBXBuildFile; fileRef = 45489C5229AF6FB10098A812 /* TorrentCellRevealButton.mm */; };
-		45489C5729AF6FB20098A812 /* TorrentCellControlButton.mm in Sources */ = {isa = PBXBuildFile; fileRef = 45489C5329AF6FB10098A812 /* TorrentCellControlButton.mm */; };
-		4559D21629B32623004EFDF0 /* ProgressBarView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4559D21529B32623004EFDF0 /* ProgressBarView.mm */; };
-		457AF8EB28604AFC00BCF74F /* Toolbar.mm in Sources */ = {isa = PBXBuildFile; fileRef = 457AF8EA28604AFC00BCF74F /* Toolbar.mm */; };
-		45A7D3292843B54D00F0C32A /* GroupPopUpButtonCell.mm in Sources */ = {isa = PBXBuildFile; fileRef = 45A7D3282843B54D00F0C32A /* GroupPopUpButtonCell.mm */; };
-		45A7D32C2843B55F00F0C32A /* PriorityPopUpButtonCell.mm in Sources */ = {isa = PBXBuildFile; fileRef = 45A7D32B2843B55F00F0C32A /* PriorityPopUpButtonCell.mm */; };
-		4D043A7F090AE979009FEDA8 /* TransmissionDocument.icns in Resources */ = {isa = PBXBuildFile; fileRef = 4D043A7E090AE979009FEDA8 /* TransmissionDocument.icns */; };
-		4D118E1A08CB46B20033958F /* PrefsController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4D118E1908CB46B20033958F /* PrefsController.mm */; };
 		4D1838DD09DEC0E80047D688 /* libtransmission.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D18389709DEC0030047D688 /* libtransmission.a */; };
 		4D1A996DF3E6096A0EC5969E /* announcer-common.cc in Sources */ = {isa = PBXBuildFile; fileRef = 10D3CB271270C579F589D5A8 /* announcer-common.cc */; };
-		4D364DA0091FBB2C00377D12 /* TorrentTableView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4D364D9F091FBB2C00377D12 /* TorrentTableView.mm */; };
 		4D36BA6F0CA2F00800A63CA5 /* peer-mse.cc in Sources */ = {isa = PBXBuildFile; fileRef = 4D36BA600CA2F00800A63CA5 /* peer-mse.cc */; };
 		4D36BA700CA2F00800A63CA5 /* peer-mse.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D36BA610CA2F00800A63CA5 /* peer-mse.h */; };
 		4D36BA720CA2F00800A63CA5 /* handshake.cc in Sources */ = {isa = PBXBuildFile; fileRef = 4D36BA630CA2F00800A63CA5 /* handshake.cc */; };
@@ -51,11 +38,6 @@
 		4D80185910BBC0B0008A4AF2 /* magnet-metainfo.cc in Sources */ = {isa = PBXBuildFile; fileRef = 4D80185710BBC0B0008A4AF2 /* magnet-metainfo.cc */; };
 		4D80185A10BBC0B0008A4AF2 /* magnet-metainfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D80185810BBC0B0008A4AF2 /* magnet-metainfo.h */; };
 		4D9A2BF009E16D21002D0FF9 /* libtransmission.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D18389709DEC0030047D688 /* libtransmission.a */; };
-		4DE5CC9D0980656F00BE280E /* NSStringAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4DE5CC9C0980656F00BE280E /* NSStringAdditions.mm */; };
-		4DE5CCA70980735700BE280E /* Badger.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4DE5CCA60980735700BE280E /* Badger.mm */; };
-		4DE5CCCB0981D9BE00BE280E /* Defaults.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4DE5CCCA0981D9BE00BE280E /* Defaults.plist */; };
-		4DF0C5AB0899190500DD8943 /* Controller.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4DF0C5A90899190500DD8943 /* Controller.mm */; };
-		4DFBC2DF09C0970D00D5C571 /* Torrent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4DFBC2DE09C0970D00D5C571 /* Torrent.mm */; };
 		51D0F7010000000000000003 /* simdutf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 51D0F7010000000000000001 /* simdutf.cpp */; };
 		51D0F7010000000000000006 /* simdutf.h in Headers */ = {isa = PBXBuildFile; fileRef = 51D0F7010000000000000002 /* simdutf.h */; };
 		51D0F701000000000000000F /* libsimdutf.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 51D0F7010000000000000005 /* libsimdutf.a */; };
@@ -67,8 +49,6 @@
 		66F977825E65AD498C028BB0 /* announce-list.cc in Sources */ = {isa = PBXBuildFile; fileRef = 66F977825E65AD498C028BB1 /* announce-list.cc */; };
 		66F977825E65AD498C028BB2 /* announce-list.h in Headers */ = {isa = PBXBuildFile; fileRef = 66F977825E65AD498C028BB3 /* announce-list.h */; };
 		888A256631B3DE536FEB8B00 /* tr-strbuf.h in Headers */ = {isa = PBXBuildFile; fileRef = 888A256631B3DE536FEB8B01 /* tr-strbuf.h */; };
-		8D11072B0486CEB800E47090 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165CFE840E0CC02AAC07 /* InfoPlist.strings */; };
-		8D11072D0486CEB800E47090 /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.mm */; settings = {ATTRIBUTES = (); }; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		9F0B1F302E4D1A0100A1B2C3 /* env.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0B1F2A2E4D1A0100A1B2C3 /* env.h */; };
 		9F0B1F312E4D1A0100A1B2C3 /* file-utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0B1F2C2E4D1A0100A1B2C3 /* file-utils.h */; };
@@ -79,7 +59,6 @@
 		9F0B1F372E4D1A0100A1B2C3 /* values.cc in Sources */ = {isa = PBXBuildFile; fileRef = 9F0B1F362E4D1A0100A1B2C3 /* values.cc */; };
 		9F0B1F3B2E4D1A0100A1B2C3 /* shared-string.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F0B1F3A2E4D1A0100A1B2C3 /* shared-string.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		9F0B1F3D2E4D1A0100A1B2C3 /* shared-string.cc in Sources */ = {isa = PBXBuildFile; fileRef = 9F0B1F3C2E4D1A0100A1B2C3 /* shared-string.cc */; };
-		A200B9200A22798F007BBB1E /* InfoWindowController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A200B83A0A2263BA007BBB1E /* InfoWindowController.mm */; };
 		A201527E0D1C270F0081714F /* torrent-builder.cc in Sources */ = {isa = PBXBuildFile; fileRef = A20152790D1C26EB0081714F /* torrent-builder.cc */; };
 		A20162C913DE48BF00E15488 /* receivedata.c in Sources */ = {isa = PBXBuildFile; fileRef = A20162C713DE48BF00E15488 /* receivedata.c */; };
 		A20162CA13DE48BF00E15488 /* receivedata.h in Headers */ = {isa = PBXBuildFile; fileRef = A20162C813DE48BF00E15488 /* receivedata.h */; };
@@ -103,41 +82,15 @@
 		A207503512BEAD9C00F70985 /* select.c in Sources */ = {isa = PBXBuildFile; fileRef = A207503412BEAD9C00F70985 /* select.c */; };
 		A207503712BEADA200F70985 /* poll.c in Sources */ = {isa = PBXBuildFile; fileRef = A207503612BEADA200F70985 /* poll.c */; };
 		A20750B812BEB66900F70985 /* bufferevent_ratelim.c in Sources */ = {isa = PBXBuildFile; fileRef = A20750B712BEB66900F70985 /* bufferevent_ratelim.c */; };
-		A2085DDC0C53BC74000BC3B7 /* AboutWindowController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2085DDA0C53BC74000BC3B7 /* AboutWindowController.mm */; };
-		A209EAC61142CF28002B02D1 /* InfoActivityViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A209EAC31142CF28002B02D1 /* InfoActivityViewController.mm */; };
-		A209EAC71142CF28002B02D1 /* InfoGeneralViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A209EAC51142CF28002B02D1 /* InfoGeneralViewController.mm */; };
-		A209EAEC1142D294002B02D1 /* InfoActivityView.xib in Resources */ = {isa = PBXBuildFile; fileRef = A209EAE81142D294002B02D1 /* InfoActivityView.xib */; };
-		A209EAED1142D294002B02D1 /* InfoGeneralView.xib in Resources */ = {isa = PBXBuildFile; fileRef = A209EAEA1142D294002B02D1 /* InfoGeneralView.xib */; };
-		A209EB011142D3A5002B02D1 /* InfoTrackersViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A209EB001142D3A5002B02D1 /* InfoTrackersViewController.mm */; };
-		A209EB201142DD85002B02D1 /* InfoTrackersView.xib in Resources */ = {isa = PBXBuildFile; fileRef = A209EB1F1142DD85002B02D1 /* InfoTrackersView.xib */; };
-		A209EB9D1142E59A002B02D1 /* InfoPeersViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A209EB9C1142E59A002B02D1 /* InfoPeersViewController.mm */; };
-		A209EBA71142EAF3002B02D1 /* InfoPeersView.xib in Resources */ = {isa = PBXBuildFile; fileRef = A209EBA61142EAF3002B02D1 /* InfoPeersView.xib */; };
-		A209EBCE1142F2B4002B02D1 /* InfoFileViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A209EBCD1142F2B4002B02D1 /* InfoFileViewController.mm */; };
-		A209EBD91142F52B002B02D1 /* InfoFileView.xib in Resources */ = {isa = PBXBuildFile; fileRef = A209EBD81142F52B002B02D1 /* InfoFileView.xib */; };
-		A209EBF91142FEEE002B02D1 /* InfoOptionsViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A209EBF81142FEEE002B02D1 /* InfoOptionsViewController.mm */; };
-		A209EC12114301C6002B02D1 /* InfoOptionsView.xib in Resources */ = {isa = PBXBuildFile; fileRef = A209EC11114301C6002B02D1 /* InfoOptionsView.xib */; };
-		A209ECA2114319C3002B02D1 /* InfoWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = A209ECA1114319C3002B02D1 /* InfoWindow.xib */; };
 		A209EE5D1144B51E002B02D1 /* history.h in Headers */ = {isa = PBXBuildFile; fileRef = A209EE5B1144B51E002B02D1 /* history.h */; };
-		A215BF5C0F02EBB800350CDB /* GroupRules.xib in Resources */ = {isa = PBXBuildFile; fileRef = A215BF5B0F02EBB800350CDB /* GroupRules.xib */; };
-		A219798B0D07B78400438EA7 /* GroupToolbarItem.mm in Sources */ = {isa = PBXBuildFile; fileRef = A219798A0D07B78400438EA7 /* GroupToolbarItem.mm */; };
-		A21A9BE2106D86A800F1C3C1 /* TrackerNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = A21A9BE1106D86A800F1C3C1 /* TrackerNode.mm */; };
-		A21A9D41106EC2E800F1C3C1 /* TrackerCell.mm in Sources */ = {isa = PBXBuildFile; fileRef = A21A9D40106EC2E800F1C3C1 /* TrackerCell.mm */; };
-		A21F15AC11729A8B00CF5A9C /* AddMagnetWindowController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A21F15AA11729A8B00CF5A9C /* AddMagnetWindowController.mm */; };
-		A21F15AD11729A9F00CF5A9C /* AddMagnetWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = A21F1538117299F100CF5A9C /* AddMagnetWindow.xib */; };
 		A21FBBAB0EDA78C300BC3C51 /* bandwidth.h in Headers */ = {isa = PBXBuildFile; fileRef = A21FBBA90EDA78C300BC3C51 /* bandwidth.h */; };
 		A21FBBAC0EDA78C300BC3C51 /* bandwidth.cc in Sources */ = {isa = PBXBuildFile; fileRef = A21FBBAA0EDA78C300BC3C51 /* bandwidth.cc */; };
-		A220AF7B13D7CC460035C512 /* GlobalOptionsPopover.xib in Resources */ = {isa = PBXBuildFile; fileRef = A220AF7913D7CC460035C512 /* GlobalOptionsPopover.xib */; };
 		A220EC5B118C8A060022B4BE /* tr-lpd.cc in Sources */ = {isa = PBXBuildFile; fileRef = A220EC59118C8A060022B4BE /* tr-lpd.cc */; };
 		A220EC5C118C8A060022B4BE /* tr-lpd.h in Headers */ = {isa = PBXBuildFile; fileRef = A220EC5A118C8A060022B4BE /* tr-lpd.h */; };
-		A22180980D148A71007D09ED /* GroupsPrefsController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A22180970D148A71007D09ED /* GroupsPrefsController.mm */; };
 		A221DCC8104B3660008A642D /* Quartz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A221DCC7104B3660008A642D /* Quartz.framework */; };
-		A222E9870E6B21D9009FB003 /* BlocklistDownloaderViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A222E9860E6B21D9009FB003 /* BlocklistDownloaderViewController.mm */; };
-		A225A4C0187E369C00CDE823 /* ShareToolbarItem.mm in Sources */ = {isa = PBXBuildFile; fileRef = A225A4BF187E369C00CDE823 /* ShareToolbarItem.mm */; };
 		A226FDAC0D0CDF20005A7F71 /* libnatpmp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C7A118D0D0B2EB800B5701F /* libnatpmp.a */; };
-		A22A8D560AEEAFA5007E9CB9 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = A22A8D540AEEAFA5007E9CB9 /* Localizable.strings */; };
 		A22B00B2116A9E9F003315FC /* connecthostport.h in Headers */ = {isa = PBXBuildFile; fileRef = A22B00AF116A9E90003315FC /* connecthostport.h */; };
 		A22B00B3116A9EA4003315FC /* connecthostport.c in Sources */ = {isa = PBXBuildFile; fileRef = A22B00AE116A9E90003315FC /* connecthostport.c */; };
-		A22BAE281388040500FB022F /* NSMutableArrayAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = A22BAE271388040500FB022F /* NSMutableArrayAdditions.mm */; };
 		A22CFB820FB66EF30009BD3E /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A22CFB810FB66EF30009BD3E /* Carbon.framework */; };
 		A22CFCA80FC24ED80009BD3E /* tr-dht.cc in Sources */ = {isa = PBXBuildFile; fileRef = A22CFCA60FC24ED80009BD3E /* tr-dht.cc */; };
 		A22CFCA90FC24ED80009BD3E /* tr-dht.h in Headers */ = {isa = PBXBuildFile; fileRef = A22CFCA70FC24ED80009BD3E /* tr-dht.h */; };
@@ -145,28 +98,11 @@
 		A22CFCC30FC24F890009BD3E /* dht.c in Sources */ = {isa = PBXBuildFile; fileRef = A22CFCC10FC24F890009BD3E /* dht.c */; };
 		A22CFCCB0FC24FDA0009BD3E /* libdht.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A22CFCBA0FC24F710009BD3E /* libdht.a */; };
 		A22CFCCD0FC250480009BD3E /* libevent.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BE75C3490C729E9500DBEFE0 /* libevent.a */; };
-		A231274C0D11D0B7003F9AFF /* AboutWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = A231274B0D11D0B7003F9AFF /* AboutWindow.xib */; };
-		A232F07E0EEA034A00041646 /* BonjourController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A232F07D0EEA034A00041646 /* BonjourController.mm */; };
-		A233BD330D8C6585007EE7B4 /* MessageWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = A233BD320D8C6585007EE7B4 /* MessageWindow.xib */; };
-		A233BD690D8CF2C7007EE7B4 /* StatsWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = A233BD680D8CF2C7007EE7B4 /* StatsWindow.xib */; };
-		A234EA541453563B000F3E97 /* NSImageAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = A234EA531453563B000F3E97 /* NSImageAdditions.mm */; };
-		A2385DD40BFE06C800B24EF6 /* DragOverlayWindow.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2385DD20BFE06C800B24EF6 /* DragOverlayWindow.mm */; };
 		A23F29A1132A447400E9A83B /* announcer-common.h in Headers */ = {isa = PBXBuildFile; fileRef = A23F299F132A447400E9A83B /* announcer-common.h */; };
 		A23F29A2132A447400E9A83B /* announcer-http.cc in Sources */ = {isa = PBXBuildFile; fileRef = A23F29A0132A447400E9A83B /* announcer-http.cc */; };
-		A23F4FF20D1D98AD002FCB97 /* PrefsWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = A23F4FF00D1D98AD002FCB97 /* PrefsWindow.xib */; };
-		A23F50020D1D99D7002FCB97 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = A23F50000D1D99D7002FCB97 /* MainMenu.xib */; };
-		A23F526F0F14395900AA02E3 /* PredicateEditorRowTemplateAny.mm in Sources */ = {isa = PBXBuildFile; fileRef = A23F526E0F14395900AA02E3 /* PredicateEditorRowTemplateAny.mm */; };
-		A2451E6916ACE4EB00586E0E /* FileRenameSheetController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2451E6716ACE4EB00586E0E /* FileRenameSheetController.mm */; };
-		A2451E6A16ACE4EB00586E0E /* FileRenameSheetController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A2451E6816ACE4EB00586E0E /* FileRenameSheetController.xib */; };
 		A24621410C769D0900088E81 /* session-thread.h in Headers */ = {isa = PBXBuildFile; fileRef = A24621350C769CF400088E81 /* session-thread.h */; };
 		A24621420C769D0900088E81 /* session-thread.cc in Sources */ = {isa = PBXBuildFile; fileRef = A24621360C769CF400088E81 /* session-thread.cc */; };
-		A24F19080A3A790800C9C145 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A24F19070A3A790800C9C145 /* Sparkle.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		A24F19210A3A796800C9C145 /* Sparkle.framework in Copy Files to Frameworks */ = {isa = PBXBuildFile; fileRef = A24F19070A3A790800C9C145 /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		A254853C0EB66CD4004539DA /* codelength.h in Headers */ = {isa = PBXBuildFile; fileRef = A25485390EB66CBB004539DA /* codelength.h */; };
-		A256588D0A9A695400E8A03B /* MessageWindowController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A256588B0A9A695400E8A03B /* MessageWindowController.mm */; };
-		A257C1820CAD3003004E121C /* PeerTableView.mm in Sources */ = {isa = PBXBuildFile; fileRef = A257C1800CAD3003004E121C /* PeerTableView.mm */; };
-		A25892640CF1F7E800CCCDDF /* StatsWindowController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A25892630CF1F7E800CCCDDF /* StatsWindowController.mm */; };
-		A259317E0A73B2CC002F4FE7 /* TransmissionHelp in Resources */ = {isa = PBXBuildFile; fileRef = A259316A0A73B2CC002F4FE7 /* TransmissionHelp */; };
 		A25964A6106D73A800453B31 /* announcer.cc in Sources */ = {isa = PBXBuildFile; fileRef = A25964A4106D73A800453B31 /* announcer.cc */; };
 		A25964A7106D73A800453B31 /* announcer.h in Headers */ = {isa = PBXBuildFile; fileRef = A25964A5106D73A800453B31 /* announcer.h */; };
 		A25BFD69167BED3B0039D1AA /* variant-benc.cc in Sources */ = {isa = PBXBuildFile; fileRef = A25BFD63167BED3B0039D1AA /* variant-benc.cc */; };
@@ -178,40 +114,20 @@
 		A25E03D90E4015100086C225 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		A25E03E20E4015380086C225 /* tr-getopt.h in Headers */ = {isa = PBXBuildFile; fileRef = A25E03E00E4015380086C225 /* tr-getopt.h */; };
 		A25E03E30E4015380086C225 /* tr-getopt.cc in Sources */ = {isa = PBXBuildFile; fileRef = A25E03E10E4015380086C225 /* tr-getopt.cc */; };
-		A25E74650AF5097C006F11AE /* ExpandedPathToPathTransformer.mm in Sources */ = {isa = PBXBuildFile; fileRef = A25E74440AF5089E006F11AE /* ExpandedPathToPathTransformer.mm */; };
-		A25E74660AF5097D006F11AE /* ExpandedPathToIconTransformer.mm in Sources */ = {isa = PBXBuildFile; fileRef = A25E74460AF5089E006F11AE /* ExpandedPathToIconTransformer.mm */; };
 		A263C6B1F6718E2486DB20E0 /* tr-buffer.h in Headers */ = {isa = PBXBuildFile; fileRef = A263C6B1F6718E2486DB20E1 /* tr-buffer.h */; };
-		A263CFC010DD67670038DE27 /* InfoTextField.mm in Sources */ = {isa = PBXBuildFile; fileRef = A263CFBF10DD67670038DE27 /* InfoTextField.mm */; };
 		A267927C130DFF2700CB7464 /* libutp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A2E38544130DFEE3001F501B /* libutp.a */; };
 		A2679294130E00A000CB7464 /* tr-utp.cc in Sources */ = {isa = PBXBuildFile; fileRef = A2679292130E00A000CB7464 /* tr-utp.cc */; };
 		A2679295130E00A000CB7464 /* tr-utp.h in Headers */ = {isa = PBXBuildFile; fileRef = A2679293130E00A000CB7464 /* tr-utp.h */; };
-		A267C2842E9F2B23003B87D7 /* Transmission_Tahoe.icon in Resources */ = {isa = PBXBuildFile; fileRef = A267C2832E9F2B23003B87D7 /* Transmission_Tahoe.icon */; };
-		A26AF21A0D2DA35A00FF7140 /* FileOutlineController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A26AF2190D2DA35A00FF7140 /* FileOutlineController.mm */; };
-		A26AF27E0D2DBDDF00FF7140 /* AddWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = A26AF27C0D2DBDDF00FF7140 /* AddWindow.xib */; };
-		A26AF2840D2DC27C00FF7140 /* AddWindowController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A26AF2830D2DC27C00FF7140 /* AddWindowController.mm */; };
-		A2710E770A86796000CE4F7D /* PrefsWindow.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2710E750A86796000CE4F7D /* PrefsWindow.mm */; };
-		A2725B6E0DE5C4F5003445E7 /* FileListNode.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2725B6D0DE5C4F5003445E7 /* FileListNode.mm */; };
-		A2725D5D0DE7507C003445E7 /* TrackerTableView.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2725D5C0DE7507C003445E7 /* TrackerTableView.mm */; };
 		A2795C5928EFC6700002C8D9 /* public_html in Resources */ = {isa = PBXBuildFile; fileRef = A2795C5828EFC6700002C8D9 /* public_html */; };
-		A27F0F330E19AD9800B2DB97 /* TorrentGroup.mm in Sources */ = {isa = PBXBuildFile; fileRef = A27F0F320E19AD9800B2DB97 /* TorrentGroup.mm */; };
 		A284214412DA663E00FBDDBB /* tr-udp.cc in Sources */ = {isa = PBXBuildFile; fileRef = A284214212DA663E00FBDDBB /* tr-udp.cc */; };
-		A28F4F770E085BDC003A3882 /* ColorTextField.mm in Sources */ = {isa = PBXBuildFile; fileRef = A28F4F760E085BDC003A3882 /* ColorTextField.mm */; };
 		A292A6E80DFB45FC004B9C0A /* webseed.cc in Sources */ = {isa = PBXBuildFile; fileRef = A292A6E50DFB45EC004B9C0A /* webseed.cc */; };
-		A29576030D11D63C0093B167 /* Creator.xib in Resources */ = {isa = PBXBuildFile; fileRef = A29576010D11D63C0093B167 /* Creator.xib */; };
-		A2966E8713DAF74C007B52DF /* GlobalOptionsPopoverViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2966E8613DAF74C007B52DF /* GlobalOptionsPopoverViewController.mm */; };
-		A29B0C270BD15FEF0006F230 /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = A2F8951E0A2D4BA500ED2127 /* Credits.rtf */; };
-		A29C8B370ACC6EB3000ED9F9 /* PortChecker.mm in Sources */ = {isa = PBXBuildFile; fileRef = A29C8B350ACC6EB3000ED9F9 /* PortChecker.mm */; };
-		A29D84041049C25600D1987A /* NSApplicationAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = A29D84031049C25600D1987A /* NSApplicationAdditions.mm */; };
 		A29DF8B90DB2544C00D04E5A /* resume.cc in Sources */ = {isa = PBXBuildFile; fileRef = A29DF8B60DB2544C00D04E5A /* resume.cc */; };
 		A29DF8BA0DB2544C00D04E5A /* resume.h in Headers */ = {isa = PBXBuildFile; fileRef = A29DF8B70DB2544C00D04E5A /* resume.h */; };
 		A29DF8BB0DB2544C00D04E5A /* torrent.h in Headers */ = {isa = PBXBuildFile; fileRef = A29DF8B80DB2544C00D04E5A /* torrent.h */; };
 		A29DF8BE0DB2545F00D04E5A /* verify.h in Headers */ = {isa = PBXBuildFile; fileRef = A2D22A110D65EED100007D5F /* verify.h */; };
 		A29E653613F1603100048D71 /* evutil_rand.c in Sources */ = {isa = PBXBuildFile; fileRef = A29E653513F1603100048D71 /* evutil_rand.c */; };
-		A2A1CB7A0BF29D5500AE959F /* PeerProgressIndicatorCell.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2A1CB780BF29D5500AE959F /* PeerProgressIndicatorCell.mm */; };
 		A2A4E9210DE0F7E9000CE197 /* web.h in Headers */ = {isa = PBXBuildFile; fileRef = A29EBE530DC01FC9006CEE80 /* web.h */; };
 		A2A4E9220DE0F7EB000CE197 /* web.cc in Sources */ = {isa = PBXBuildFile; fileRef = A29EBE520DC01FC9006CEE80 /* web.cc */; };
-		A2A6321B0CD9751700E3DA60 /* BadgeView.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2A6321A0CD9751700E3DA60 /* BadgeView.mm */; };
-		A2AA579D0ADFCAB400CA59F6 /* PiecesView.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2AA579B0ADFCAB400CA59F6 /* PiecesView.mm */; };
 		A2AA9BE1132CAC8E00FA131E /* announcer-udp.cc in Sources */ = {isa = PBXBuildFile; fileRef = A2AA9BE0132CAC8D00FA131E /* announcer-udp.cc */; };
 		A2AA9BE3132CAE2000FA131E /* evdns.c in Sources */ = {isa = PBXBuildFile; fileRef = A2AA9BE2132CAE2000FA131E /* evdns.c */; };
 		A2AAB65C0DE0CF6200E04DDA /* rpc-server.cc in Sources */ = {isa = PBXBuildFile; fileRef = A2AAB6580DE0CF6200E04DDA /* rpc-server.cc */; };
@@ -219,40 +135,23 @@
 		A2AAB65E0DE0CF6200E04DDA /* rpc-server.h in Headers */ = {isa = PBXBuildFile; fileRef = A2AAB65A0DE0CF6200E04DDA /* rpc-server.h */; };
 		A2AAB65F0DE0CF6200E04DDA /* rpcimpl.cc in Sources */ = {isa = PBXBuildFile; fileRef = A2AAB65B0DE0CF6200E04DDA /* rpcimpl.cc */; };
 		A2AAB6650DE0D08B00E04DDA /* blocklist.h in Headers */ = {isa = PBXBuildFile; fileRef = A2D307930D9EC4860051FD27 /* blocklist.h */; };
-		A2AB883E16A399A6008FAD50 /* VDKQueue.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2AB883C16A399A6008FAD50 /* VDKQueue.mm */; };
-		A2AF1C390A3D0F6200F1575D /* FileOutlineView.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2AF1C370A3D0F6200F1575D /* FileOutlineView.mm */; };
 		A2AF23C816B44FA0003BC59E /* log.cc in Sources */ = {isa = PBXBuildFile; fileRef = A2AF23C616B44FA0003BC59E /* log.cc */; };
 		A2AF23C916B44FA0003BC59E /* log.h in Headers */ = {isa = PBXBuildFile; fileRef = A2AF23C716B44FA0003BC59E /* log.h */; };
 		A2B3FB460E5901E700FF78FB /* cli.cc in Sources */ = {isa = PBXBuildFile; fileRef = A2B3FB450E5901E700FF78FB /* cli.cc */; };
 		A2B3FB4C0E59023000FF78FB /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		A2B3FB530E59027100FF78FB /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
-		A2B5B4E91880665E0071A66A /* ShareTorrentFileHelper.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2B5B4E81880665E0071A66A /* ShareTorrentFileHelper.mm */; };
 		A2BE9C520C1E4AF5002D16E6 /* makemeta.cc in Sources */ = {isa = PBXBuildFile; fileRef = A2BE9C4E0C1E4ADA002D16E6 /* makemeta.cc */; };
 		A2BE9C530C1E4AF7002D16E6 /* makemeta.h in Headers */ = {isa = PBXBuildFile; fileRef = A2BE9C4F0C1E4ADA002D16E6 /* makemeta.h */; };
-		A2C89D600CFCBF57004CC2BC /* ButtonToolbarItem.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2C89D5F0CFCBF57004CC2BC /* ButtonToolbarItem.mm */; };
 		A2CB38AF0E1E6896002B514C /* COPYING in Resources */ = {isa = PBXBuildFile; fileRef = A2CB38AE0E1E6896002B514C /* COPYING */; };
 		A2D22A130D65EEE700007D5F /* verify.cc in Sources */ = {isa = PBXBuildFile; fileRef = A2D22A100D65EED100007D5F /* verify.cc */; };
-		A2D307B10D9EC9F50051FD27 /* BlocklistStatusWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = A2D307B00D9EC9F50051FD27 /* BlocklistStatusWindow.xib */; };
-		A2D77451154CC25700A62B93 /* WebSeedTableView.h in Headers */ = {isa = PBXBuildFile; fileRef = A2D7744F154CC25700A62B93 /* WebSeedTableView.h */; };
-		A2D77453154CC72B00A62B93 /* WebSeedTableView.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2D77450154CC25700A62B93 /* WebSeedTableView.mm */; };
-		A2DF37070C220D03006523C1 /* CreatorWindowController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2DF37050C220D03006523C1 /* CreatorWindowController.mm */; };
 		A2E384DD130DFB3A001F501B /* utp_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2E384D5130DFB3A001F501B /* utp_utils.cpp */; };
 		A2E384DE130DFB3A001F501B /* utp_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = A2E384D6130DFB3A001F501B /* utp_utils.h */; };
 		A2E384E0130DFB3A001F501B /* include/libutp/utp.h in Headers */ = {isa = PBXBuildFile; fileRef = A2E384D8130DFB3A001F501B /* include/libutp/utp.h */; };
-		A2E57ABB1310822C00A7DAB1 /* StatusBarController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2E57ABA1310822C00A7DAB1 /* StatusBarController.mm */; };
-		A2E57AC61310831400A7DAB1 /* StatusBar.xib in Resources */ = {isa = PBXBuildFile; fileRef = A2E57AC51310831400A7DAB1 /* StatusBar.xib */; };
-		A2E57B9C13109DC200A7DAB1 /* FilterBar.xib in Resources */ = {isa = PBXBuildFile; fileRef = A2E57B9B13109DC200A7DAB1 /* FilterBar.xib */; };
-		A2E57BA713109E6B00A7DAB1 /* FilterBarController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2E57BA613109E6B00A7DAB1 /* FilterBarController.mm */; };
 		A2E669790F5B8E5A00B4251A /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2E669780F5B8E5A00B4251A /* Security.framework */; };
 		A2EA52311686AC0D00180493 /* quark.cc in Sources */ = {isa = PBXBuildFile; fileRef = A2EA522F1686AC0D00180493 /* quark.cc */; };
 		A2EA52321686AC0D00180493 /* quark.h in Headers */ = {isa = PBXBuildFile; fileRef = A2EA52301686AC0D00180493 /* quark.h */; };
-		A2ED7D8F0CEF431B00970975 /* FilterButton.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2ED7D8E0CEF431B00970975 /* FilterButton.mm */; };
 		A2EE726F14DCCC950093C99A /* port-forwarding-natpmp.h in Headers */ = {isa = PBXBuildFile; fileRef = A2EE726E14DCCC950093C99A /* port-forwarding-natpmp.h */; };
-		A2F7CF5513035F7B0016FF10 /* URLSheetWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = A2F7CF5413035F7B0016FF10 /* URLSheetWindow.xib */; };
-		A2F7CF5F13035FFD0016FF10 /* URLSheetWindowController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2F7CF5E13035FFD0016FF10 /* URLSheetWindowController.mm */; };
 		A2F8CD430F3D0F4A00DB356A /* miniupnpcstrings.h in Headers */ = {isa = PBXBuildFile; fileRef = A2F8CD420F3D0F4A00DB356A /* miniupnpcstrings.h */; };
-		A2FB057F0BFEB6800095564D /* DragOverlayView.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2FB057D0BFEB6800095564D /* DragOverlayView.mm */; };
-		A2FB701C0D95CAEA0001F331 /* GroupsController.mm in Sources */ = {isa = PBXBuildFile; fileRef = A2FB701B0D95CAEA0001F331 /* GroupsController.mm */; };
 		A47A7C87B8B57BE50DF0D410 /* torrent-files.cc in Sources */ = {isa = PBXBuildFile; fileRef = A47A7C87B8B57BE50DF0D411 /* torrent-files.cc */; };
 		A47A7C87B8B57BE50DF0D412 /* torrent-files.h in Headers */ = {isa = PBXBuildFile; fileRef = A47A7C87B8B57BE50DF0D413 /* torrent-files.h */; };
 		ADD1A0000000000000000002 /* archive_acl.c in Sources */ = {isa = PBXBuildFile; fileRef = ADD1A0000000000000000001 /* archive_acl.c */; };
@@ -478,11 +377,8 @@
 		C3D9062727B7E3E800EF2386 /* psl.c in Sources */ = {isa = PBXBuildFile; fileRef = C3D9061827B7E1DE00EF2386 /* psl.c */; };
 		C3D9062A27B7EAC600EF2386 /* libpsl.h in Headers */ = {isa = PBXBuildFile; fileRef = C3D9061B27B7E31100EF2386 /* libpsl.h */; };
 		C3D9062F27B7F7E200EF2386 /* libpsl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C3D9062127B7E3C900EF2386 /* libpsl.a */; };
-		C809AEE7291ECFD000BFDBE1 /* NSDataAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = C809AEE6291ECFD000BFDBE1 /* NSDataAdditions.mm */; };
 		C83B17212B7341BC00B2EAE4 /* tr-assert.cc in Sources */ = {isa = PBXBuildFile; fileRef = C1425B321EE9C5EA001DB85F /* tr-assert.cc */; };
-		C841A28129197724009F18E8 /* NSKeyedUnarchiverAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = C841A28029197724009F18E8 /* NSKeyedUnarchiverAdditions.mm */; };
 		C843FC8429C51B9400491854 /* string-utils.mm in Sources */ = {isa = PBXBuildFile; fileRef = C843FC8329C51B9400491854 /* string-utils.mm */; };
-		C86BCD9928228A9600F45599 /* SparkleProxy.mm in Sources */ = {isa = PBXBuildFile; fileRef = C86BCD9828228A9600F45599 /* SparkleProxy.mm */; };
 		C87369652809984200573C90 /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C87369642809984200573C90 /* UserNotifications.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		C8748D8A29891EA100D9E979 /* suffixes_dafsa.h in Headers */ = {isa = PBXBuildFile; fileRef = C8748D8929891EA100D9E979 /* suffixes_dafsa.h */; };
 		C88771AE2803EE7C005C7523 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = C88771A92803EE42005C7523 /* libz.tbd */; };
@@ -516,7 +412,6 @@
 		CAB35C64252F6F5E00552A55 /* mime-types.h in Headers */ = {isa = PBXBuildFile; fileRef = CAB35C62252F6F5E00552A55 /* mime-types.h */; };
 		CCEBA596277340F6DF9F4480 /* session-alt-speeds.cc in Sources */ = {isa = PBXBuildFile; fileRef = CCEBA596277340F6DF9F4481 /* session-alt-speeds.cc */; };
 		CCEBA596277340F6DF9F4482 /* session-alt-speeds.h in Headers */ = {isa = PBXBuildFile; fileRef = CCEBA596277340F6DF9F4483 /* session-alt-speeds.h */; };
-		E138A9780C04D88F00C5426C /* ProgressGradients.mm in Sources */ = {isa = PBXBuildFile; fileRef = E138A9760C04D88F00C5426C /* ProgressGradients.mm */; };
 		E975121263DD973CAF4AEBA0 /* timer.h in Headers */ = {isa = PBXBuildFile; fileRef = E975121263DD973CAF4AEBA1 /* timer.h */; };
 		E975121263DD973CAF4AEBA2 /* timer-ev.h in Headers */ = {isa = PBXBuildFile; fileRef = E975121263DD973CAF4AEBA3 /* timer-ev.h */; };
 		E975121263DD973CAF4AEBA4 /* timer-ev.cc in Sources */ = {isa = PBXBuildFile; fileRef = E975121263DD973CAF4AEBA5 /* timer-ev.cc */; };
@@ -524,25 +419,16 @@
 		ED0C0D1D2E5F400100112233 /* lock-file.cc in Sources */ = {isa = PBXBuildFile; fileRef = ED0C0D1E2E5F400100112233 /* lock-file.cc */; };
 		ED5E0E7E2CD30B180071433B /* Quartz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED5E0E7D2CD30B180071433B /* Quartz.framework */; };
 		ED5E0E8D2CD30B180071433B /* QuickLookExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = ED5E0E7C2CD30B180071433B /* QuickLookExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		ED5E0E9C2CD30E8F0071433B /* PreviewProvider.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED5E0E962CD30E8F0071433B /* PreviewProvider.mm */; };
 		ED5E0E9D2CD3134B0071433B /* libtransmission.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D18389709DEC0030047D688 /* libtransmission.a */; };
 		ED5E0EA02CD3147B0071433B /* libcurl.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 55869925257074EC00F77A43 /* libcurl.tbd */; };
-		ED5E0EA22CD314FE0071433B /* style.css in Resources */ = {isa = PBXBuildFile; fileRef = ED5E0EA12CD314FE0071433B /* style.css */; };
-		ED5E0EFA2CD315720071433B /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = ED5E0EF72CD315720071433B /* Localizable.strings */; };
-		ED5E0F0F2CD31BC20071433B /* NSStringAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4DE5CC9C0980656F00BE280E /* NSStringAdditions.mm */; };
 		ED67FB422B70FCE400D8A037 /* converters.cc in Sources */ = {isa = PBXBuildFile; fileRef = ED67FB402B70FCE400D8A037 /* converters.cc */; };
 		ED67FB432B70FCE400D8A037 /* serializer.h in Headers */ = {isa = PBXBuildFile; fileRef = ED67FB412B70FCE400D8A037 /* serializer.h */; };
 		ED67FB452B70FCE400D8A037 /* converters.h in Headers */ = {isa = PBXBuildFile; fileRef = ED67FB442B70FCE400D8A037 /* converters.h */; };
-		ED6F16B52EB8F1EB007CD864 /* BaseFileNameCellView.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED6F16B22EB8F1EB007CD864 /* BaseFileNameCellView.mm */; };
-		ED6F16B62EB8F1EB007CD864 /* FilePriorityCellView.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED6F16B42EB8F1EB007CD864 /* FilePriorityCellView.mm */; };
-		ED6F16B72EB8F1EB007CD864 /* FileCheckCellView.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED6F16B02EB8F1EB007CD864 /* FileCheckCellView.mm */; };
-		ED86936F2ADAE34D00342B1A /* DefaultAppHelper.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED86936E2ADAE34D00342B1A /* DefaultAppHelper.mm */; };
 		ED8A16412735A8AA000D61F9 /* peer-mgr-wishlist.h in Headers */ = {isa = PBXBuildFile; fileRef = ED8A163D2735A8AA000D61F9 /* peer-mgr-wishlist.h */; };
 		ED8A16422735A8AA000D61F9 /* peer-mgr-wishlist.cc in Sources */ = {isa = PBXBuildFile; fileRef = ED8A163E2735A8AA000D61F9 /* peer-mgr-wishlist.cc */; };
 		ED91F28B2CBDA72C008388AA /* crc32iscsi.c in Sources */ = {isa = PBXBuildFile; fileRef = ED91F01E2CBDA72C008388AA /* crc32iscsi.c */; };
 		ED91F35A2CBDA72C008388AA /* crc32iscsi.h in Headers */ = {isa = PBXBuildFile; fileRef = ED91F01B2CBDA72C008388AA /* crc32iscsi.h */; };
 		ED91F3962CBDAAED008388AA /* libmadler-crcany.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ED91F00C2CBDA5D3008388AA /* libmadler-crcany.a */; };
-		ED9862972B979AA2002F3035 /* Utils.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED9862962B979AA2002F3035 /* Utils.mm */; };
 		EDB550032F55000100B05501 /* bep55-holepunch.cc in Sources */ = {isa = PBXBuildFile; fileRef = EDB550012F55000100B05501 /* bep55-holepunch.cc */; };
 		EDB550042F55000100B05501 /* bep55-holepunch.h in Headers */ = {isa = PBXBuildFile; fileRef = EDB550022F55000100B05501 /* bep55-holepunch.h */; };
 		EDB550062F55000100B05501 /* bep55-introducer-store.h in Headers */ = {isa = PBXBuildFile; fileRef = EDB550052F55000100B05501 /* bep55-introducer-store.h */; };
@@ -559,11 +445,9 @@
 		EDC0A1B22E5A100100A1B2C3 /* local-data.cc in Sources */ = {isa = PBXBuildFile; fileRef = EDC0A1B02E5A100100A1B2C3 /* local-data.cc */; };
 		EDC37BCD2EE9C2AD001E2612 /* api-compat.cc in Sources */ = {isa = PBXBuildFile; fileRef = EDC37BCC2EE9C2AD001E2612 /* api-compat.cc */; };
 		EDC37BCE2EE9C2AD001E2612 /* api-compat.h in Headers */ = {isa = PBXBuildFile; fileRef = EDC37BCB2EE9C2AD001E2612 /* api-compat.h */; };
-		EDC749F92D98AE3000A12D0F /* PowerManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = EDC749F82D98AE2900A12D0F /* PowerManager.mm */; };
 		EDD735D62D83087400852628 /* UniformTypeIdentifiers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDD735D52D83087400852628 /* UniformTypeIdentifiers.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		F0A1B2C32F1A2B3C00445566 /* session-settings.h in Headers */ = {isa = PBXBuildFile; fileRef = F0A1B2C42F1A2B3C00445566 /* session-settings.h */; };
 		F11545ACA7C4D7A464F703AB /* block-info.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A044CBD8C049AFCBD4DB411 /* block-info.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		F63480631E1D7274005B9E09 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F63480621E1D7274005B9E09 /* Images.xcassets */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -709,7 +593,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				A24F19210A3A796800C9C145 /* Sparkle.framework in Copy Files to Frameworks */,
 			);
 			name = "Copy Files to Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -747,7 +630,6 @@
 		1BB44E07B1B52E28291B4E30 /* file-piece-map.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "file-piece-map.cc"; sourceTree = "<group>"; };
 		1BB44E07B1B52E28291B4E31 /* file-piece-map.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "file-piece-map.h"; sourceTree = "<group>"; };
 		2856E0656A49F2665D69E761 /* benc.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = benc.h; sourceTree = "<group>"; };
-		29B97316FDCFA39411CA2CEA /* main.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = main.mm; sourceTree = "<group>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		2B9BA6C508B488FE586A0AB1 /* torrents.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = torrents.cc; sourceTree = "<group>"; };
@@ -757,132 +639,7 @@
 		3C7A11920D0B2EE300B5701F /* getgateway.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = getgateway.h; sourceTree = "<group>"; };
 		3C7A11930D0B2EE300B5701F /* natpmp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = natpmp.c; sourceTree = "<group>"; };
 		3C7A11940D0B2EE300B5701F /* natpmp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = natpmp.h; sourceTree = "<group>"; };
-		4521532929AF891E009331B0 /* GroupCell.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = GroupCell.mm; sourceTree = "<group>"; };
-		4521532A29AF891F009331B0 /* GroupCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GroupCell.h; sourceTree = "<group>"; };
-		4521532C29AF9D60009331B0 /* TorrentCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TorrentCell.h; sourceTree = "<group>"; };
-		4521532D29AF9D61009331B0 /* TorrentCell.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TorrentCell.mm; sourceTree = "<group>"; };
-		4534164029B0EA8500F544C9 /* SmallTorrentCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SmallTorrentCell.h; sourceTree = "<group>"; };
-		4534164129B0EA8600F544C9 /* SmallTorrentCell.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SmallTorrentCell.mm; sourceTree = "<group>"; };
-		45489C4729AE79FC0098A812 /* TorrentCellActionButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TorrentCellActionButton.h; sourceTree = "<group>"; };
-		45489C4A29AF10D00098A812 /* TorrentCellRevealButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TorrentCellRevealButton.h; sourceTree = "<group>"; };
-		45489C4B29AF10D10098A812 /* TorrentCellControlButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TorrentCellControlButton.h; sourceTree = "<group>"; };
-		45489C5029AF6FB10098A812 /* TorrentCellActionButton.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TorrentCellActionButton.mm; sourceTree = "<group>"; };
-		45489C5229AF6FB10098A812 /* TorrentCellRevealButton.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TorrentCellRevealButton.mm; sourceTree = "<group>"; };
-		45489C5329AF6FB10098A812 /* TorrentCellControlButton.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TorrentCellControlButton.mm; sourceTree = "<group>"; };
-		4559D21429B32622004EFDF0 /* ProgressBarView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProgressBarView.h; sourceTree = "<group>"; };
-		4559D21529B32623004EFDF0 /* ProgressBarView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ProgressBarView.mm; sourceTree = "<group>"; };
-		455C0939287767270003A078 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/PrefsWindow.strings; sourceTree = "<group>"; };
-		455C093A287767290003A078 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/PrefsWindow.strings; sourceTree = "<group>"; };
-		455C093B2877672C0003A078 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/PrefsWindow.strings; sourceTree = "<group>"; };
-		455C093C2877672E0003A078 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/PrefsWindow.strings; sourceTree = "<group>"; };
-		455C093D287767300003A078 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/PrefsWindow.strings; sourceTree = "<group>"; };
-		455C093E287767320003A078 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/PrefsWindow.strings"; sourceTree = "<group>"; };
-		455C093F287767350003A078 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/PrefsWindow.strings; sourceTree = "<group>"; };
-		455C0940287767380003A078 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/PrefsWindow.strings; sourceTree = "<group>"; };
-		455C09412877673A0003A078 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/PrefsWindow.strings; sourceTree = "<group>"; };
-		457AF8E928604AFC00BCF74F /* Toolbar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Toolbar.h; sourceTree = "<group>"; };
-		457AF8EA28604AFC00BCF74F /* Toolbar.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Toolbar.mm; sourceTree = "<group>"; };
-		457DC1E1287392F800ED04C4 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/MainMenu.strings; sourceTree = "<group>"; };
-		457DC1E2287392FD00ED04C4 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/MainMenu.strings; sourceTree = "<group>"; };
-		457DC1E32873930500ED04C4 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/MainMenu.strings; sourceTree = "<group>"; };
-		457DC1E42873930900ED04C4 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/MainMenu.strings; sourceTree = "<group>"; };
-		457DC1E52873930D00ED04C4 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/MainMenu.strings; sourceTree = "<group>"; };
-		457DC1E62873931100ED04C4 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/MainMenu.strings"; sourceTree = "<group>"; };
-		457DC1E72873931500ED04C4 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/MainMenu.strings; sourceTree = "<group>"; };
-		457DC1E82873931900ED04C4 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/MainMenu.strings; sourceTree = "<group>"; };
-		457DC1E92873931E00ED04C4 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/MainMenu.strings; sourceTree = "<group>"; };
-		45A7D3272843B54D00F0C32A /* GroupPopUpButtonCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GroupPopUpButtonCell.h; sourceTree = "<group>"; };
-		45A7D3282843B54D00F0C32A /* GroupPopUpButtonCell.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = GroupPopUpButtonCell.mm; sourceTree = "<group>"; };
-		45A7D32A2843B55F00F0C32A /* PriorityPopUpButtonCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PriorityPopUpButtonCell.h; sourceTree = "<group>"; };
-		45A7D32B2843B55F00F0C32A /* PriorityPopUpButtonCell.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PriorityPopUpButtonCell.mm; sourceTree = "<group>"; };
-		45C688C72875AC7800A2EB25 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/AddMagnetWindow.strings; sourceTree = "<group>"; };
-		45C688C82875AC7F00A2EB25 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/AddMagnetWindow.strings; sourceTree = "<group>"; };
-		45C688C92875AC8100A2EB25 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/AddMagnetWindow.strings; sourceTree = "<group>"; };
-		45C688CA2875AC8300A2EB25 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/AddMagnetWindow.strings; sourceTree = "<group>"; };
-		45C688CB2875AC8700A2EB25 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/AddMagnetWindow.strings; sourceTree = "<group>"; };
-		45C688CC2875AC8900A2EB25 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/AddMagnetWindow.strings"; sourceTree = "<group>"; };
-		45C688CD2875AC8D00A2EB25 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/AddMagnetWindow.strings; sourceTree = "<group>"; };
-		45C688CE2875AC8F00A2EB25 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/AddMagnetWindow.strings; sourceTree = "<group>"; };
-		45C688CF2875AC9200A2EB25 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/AddMagnetWindow.strings; sourceTree = "<group>"; };
-		45C688D02875ADF000A2EB25 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/GroupRules.strings; sourceTree = "<group>"; };
-		45C688D12875ADF500A2EB25 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/GroupRules.strings; sourceTree = "<group>"; };
-		45C688D22875ADF800A2EB25 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/GroupRules.strings; sourceTree = "<group>"; };
-		45C688D32875ADFB00A2EB25 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/GroupRules.strings"; sourceTree = "<group>"; };
-		45C688D42875ADFE00A2EB25 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/GroupRules.strings; sourceTree = "<group>"; };
-		45C688D52875AE0100A2EB25 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/GroupRules.strings; sourceTree = "<group>"; };
-		45C688D62875AE0500A2EB25 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/GroupRules.strings; sourceTree = "<group>"; };
-		45C688D72875AE0800A2EB25 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/GroupRules.strings; sourceTree = "<group>"; };
-		45C688D82875AE0C00A2EB25 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/GroupRules.strings; sourceTree = "<group>"; };
-		45C688D92875B05B00A2EB25 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/InfoGeneralView.strings; sourceTree = "<group>"; };
-		45C688DA2875B06000A2EB25 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/InfoGeneralView.strings; sourceTree = "<group>"; };
-		45C688DB2875B06200A2EB25 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoGeneralView.strings; sourceTree = "<group>"; };
-		45C688DC2875B06400A2EB25 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoGeneralView.strings; sourceTree = "<group>"; };
-		45C688DD2875B06700A2EB25 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/InfoGeneralView.strings; sourceTree = "<group>"; };
-		45C688DE2875B06900A2EB25 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/InfoGeneralView.strings"; sourceTree = "<group>"; };
-		45C688DF2875B06D00A2EB25 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/InfoGeneralView.strings; sourceTree = "<group>"; };
-		45C688E02875B06F00A2EB25 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoGeneralView.strings; sourceTree = "<group>"; };
-		45C688E12875B07300A2EB25 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/InfoGeneralView.strings; sourceTree = "<group>"; };
-		45C688E22875B17A00A2EB25 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/InfoActivityView.strings; sourceTree = "<group>"; };
-		45C688E32875B17C00A2EB25 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/InfoActivityView.strings; sourceTree = "<group>"; };
-		45C688E42875B17F00A2EB25 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoActivityView.strings; sourceTree = "<group>"; };
-		45C688E52875B18200A2EB25 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoActivityView.strings; sourceTree = "<group>"; };
-		45C688E62875B18700A2EB25 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/InfoActivityView.strings; sourceTree = "<group>"; };
-		45C688E72875B18A00A2EB25 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/InfoActivityView.strings"; sourceTree = "<group>"; };
-		45C688E82875B19000A2EB25 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/InfoActivityView.strings; sourceTree = "<group>"; };
-		45C688E92875B19200A2EB25 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoActivityView.strings; sourceTree = "<group>"; };
-		45C688EA2875B19500A2EB25 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/InfoActivityView.strings; sourceTree = "<group>"; };
-		45C688EB2875B2BB00A2EB25 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/InfoOptionsView.strings; sourceTree = "<group>"; };
-		45C688EC2875B2BE00A2EB25 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/InfoOptionsView.strings; sourceTree = "<group>"; };
-		45C688ED2875B2C000A2EB25 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoOptionsView.strings; sourceTree = "<group>"; };
-		45C688EE2875B2C200A2EB25 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoOptionsView.strings; sourceTree = "<group>"; };
-		45C688EF2875B2C400A2EB25 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/InfoOptionsView.strings; sourceTree = "<group>"; };
-		45C688F02875B2C700A2EB25 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/InfoOptionsView.strings"; sourceTree = "<group>"; };
-		45C688F12875B2CA00A2EB25 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/InfoOptionsView.strings; sourceTree = "<group>"; };
-		45C688F22875B2CD00A2EB25 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoOptionsView.strings; sourceTree = "<group>"; };
-		45C688F32875B2CF00A2EB25 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/InfoOptionsView.strings; sourceTree = "<group>"; };
-		45C688F42875B3F000A2EB25 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/GlobalOptionsPopover.strings; sourceTree = "<group>"; };
-		45C688F52875B3F400A2EB25 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/GlobalOptionsPopover.strings; sourceTree = "<group>"; };
-		45C688F62875B3F600A2EB25 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/GlobalOptionsPopover.strings; sourceTree = "<group>"; };
-		45C688F72875B3F800A2EB25 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/GlobalOptionsPopover.strings; sourceTree = "<group>"; };
-		45C688F82875B3FB00A2EB25 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/GlobalOptionsPopover.strings; sourceTree = "<group>"; };
-		45C688F92875B3FF00A2EB25 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/GlobalOptionsPopover.strings"; sourceTree = "<group>"; };
-		45C688FA2875B40300A2EB25 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/GlobalOptionsPopover.strings; sourceTree = "<group>"; };
-		45C688FB2875B40600A2EB25 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/GlobalOptionsPopover.strings; sourceTree = "<group>"; };
-		45C688FC2875B40900A2EB25 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/GlobalOptionsPopover.strings; sourceTree = "<group>"; };
-		45C688FD28762FBB00A2EB25 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/AddWindow.strings; sourceTree = "<group>"; };
-		45C688FE28762FE700A2EB25 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/AddWindow.strings; sourceTree = "<group>"; };
-		45C688FF28762FEC00A2EB25 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/AddWindow.strings; sourceTree = "<group>"; };
-		45C6890028762FEF00A2EB25 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/AddWindow.strings; sourceTree = "<group>"; };
-		45C6890128762FF200A2EB25 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/AddWindow.strings; sourceTree = "<group>"; };
-		45C6890228762FF800A2EB25 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/AddWindow.strings"; sourceTree = "<group>"; };
-		45C6890328762FFD00A2EB25 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/AddWindow.strings; sourceTree = "<group>"; };
-		45C6890428762FFF00A2EB25 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/AddWindow.strings; sourceTree = "<group>"; };
-		45C689052876300200A2EB25 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/AddWindow.strings; sourceTree = "<group>"; };
-		45C6890628763C2900A2EB25 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Creator.strings; sourceTree = "<group>"; };
-		45C6890728763C2E00A2EB25 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Creator.strings; sourceTree = "<group>"; };
-		45C6890828763C3200A2EB25 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Creator.strings; sourceTree = "<group>"; };
-		45C6890928763C3600A2EB25 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Creator.strings; sourceTree = "<group>"; };
-		45C6890A28763C3900A2EB25 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Creator.strings; sourceTree = "<group>"; };
-		45C6890B28763C3C00A2EB25 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/Creator.strings"; sourceTree = "<group>"; };
-		45C6890C28763C3F00A2EB25 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Creator.strings; sourceTree = "<group>"; };
-		45C6890D28763C4300A2EB25 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Creator.strings; sourceTree = "<group>"; };
-		45C6890E28763C4600A2EB25 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Creator.strings; sourceTree = "<group>"; };
-		45F195E828738F3100654B15 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
-		45F195E928738F3100654B15 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/PrefsWindow.xib; sourceTree = "<group>"; };
-		45F195EA28738F3200654B15 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/Creator.xib; sourceTree = "<group>"; };
-		45F195EB28738F3200654B15 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/AddWindow.xib; sourceTree = "<group>"; };
-		45F195EC28738F3200654B15 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/AddMagnetWindow.xib; sourceTree = "<group>"; };
-		45F195ED28738F3300654B15 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/GroupRules.xib; sourceTree = "<group>"; };
-		45F195EE28738F3300654B15 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/InfoGeneralView.xib; sourceTree = "<group>"; };
-		45F195EF28738F3400654B15 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/InfoActivityView.xib; sourceTree = "<group>"; };
-		45F195F028738F3400654B15 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/InfoOptionsView.xib; sourceTree = "<group>"; };
-		45F195F128738F3500654B15 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/GlobalOptionsPopover.xib; sourceTree = "<group>"; };
-		4D043A7E090AE979009FEDA8 /* TransmissionDocument.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = TransmissionDocument.icns; path = Images/TransmissionDocument.icns; sourceTree = "<group>"; };
-		4D118E1808CB46B20033958F /* PrefsController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrefsController.h; sourceTree = "<group>"; };
-		4D118E1908CB46B20033958F /* PrefsController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PrefsController.mm; sourceTree = "<group>"; };
 		4D18389709DEC0030047D688 /* libtransmission.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libtransmission.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		4D364D9E091FBB2C00377D12 /* TorrentTableView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TorrentTableView.h; sourceTree = "<group>"; };
-		4D364D9F091FBB2C00377D12 /* TorrentTableView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TorrentTableView.mm; sourceTree = "<group>"; };
 		4D36BA600CA2F00800A63CA5 /* peer-mse.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "peer-mse.cc"; sourceTree = "<group>"; };
 		4D36BA610CA2F00800A63CA5 /* peer-mse.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "peer-mse.h"; sourceTree = "<group>"; };
 		4D36BA630CA2F00800A63CA5 /* handshake.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = handshake.cc; sourceTree = "<group>"; };
@@ -898,15 +655,6 @@
 		4D80185710BBC0B0008A4AF2 /* magnet-metainfo.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "magnet-metainfo.cc"; sourceTree = "<group>"; };
 		4D80185810BBC0B0008A4AF2 /* magnet-metainfo.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "magnet-metainfo.h"; sourceTree = "<group>"; };
 		4DDBB71909E16BAE00284745 /* transmissioncli */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = transmissioncli; sourceTree = BUILT_PRODUCTS_DIR; };
-		4DE5CC9B0980656F00BE280E /* NSStringAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSStringAdditions.h; sourceTree = "<group>"; };
-		4DE5CC9C0980656F00BE280E /* NSStringAdditions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NSStringAdditions.mm; sourceTree = "<group>"; };
-		4DE5CCA50980735700BE280E /* Badger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Badger.h; sourceTree = "<group>"; };
-		4DE5CCA60980735700BE280E /* Badger.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Badger.mm; sourceTree = "<group>"; };
-		4DE5CCCA0981D9BE00BE280E /* Defaults.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Defaults.plist; sourceTree = "<group>"; };
-		4DF0C5A90899190500DD8943 /* Controller.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Controller.mm; sourceTree = "<group>"; };
-		4DF0C5AA0899190500DD8943 /* Controller.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Controller.h; sourceTree = "<group>"; };
-		4DFBC2DD09C0970D00D5C571 /* Torrent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Torrent.h; sourceTree = "<group>"; };
-		4DFBC2DE09C0970D00D5C571 /* Torrent.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Torrent.mm; sourceTree = "<group>"; };
 		51D0F7010000000000000001 /* simdutf.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = simdutf.cpp; path = src/simdutf.cpp; sourceTree = "<group>"; };
 		51D0F7010000000000000002 /* simdutf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = simdutf.h; path = include/simdutf.h; sourceTree = "<group>"; };
 		51D0F7010000000000000005 /* libsimdutf.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libsimdutf.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -915,7 +663,6 @@
 		66F977825E65AD498C028BB3 /* announce-list.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "announce-list.h"; sourceTree = "<group>"; };
 		6A044CBD8C049AFCBD4DB411 /* block-info.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "block-info.h"; sourceTree = "<group>"; };
 		888A256631B3DE536FEB8B01 /* tr-strbuf.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = "tr-strbuf.h"; sourceTree = "<group>"; };
-		8D1107310486CEB800E47090 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* Transmission.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Transmission.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F0B1F2A2E4D1A0100A1B2C3 /* env.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = env.h; sourceTree = "<group>"; };
 		9F0B1F2B2E4D1A0100A1B2C3 /* env.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = env.cc; sourceTree = "<group>"; };
@@ -926,16 +673,12 @@
 		9F0B1F362E4D1A0100A1B2C3 /* values.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = values.cc; sourceTree = "<group>"; };
 		9F0B1F3A2E4D1A0100A1B2C3 /* shared-string.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "shared-string.h"; sourceTree = "<group>"; };
 		9F0B1F3C2E4D1A0100A1B2C3 /* shared-string.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "shared-string.cc"; sourceTree = "<group>"; };
-		A200B8390A2263BA007BBB1E /* InfoWindowController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InfoWindowController.h; sourceTree = "<group>"; };
-		A200B83A0A2263BA007BBB1E /* InfoWindowController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = InfoWindowController.mm; sourceTree = "<group>"; };
 		A20152790D1C26EB0081714F /* torrent-builder.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "torrent-builder.cc"; sourceTree = "<group>"; };
 		A20162C713DE48BF00E15488 /* receivedata.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = receivedata.c; sourceTree = "<group>"; };
 		A20162C813DE48BF00E15488 /* receivedata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = receivedata.h; sourceTree = "<group>"; };
 		A20162CB13DE497000E15488 /* portlistingparse.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = portlistingparse.c; sourceTree = "<group>"; };
 		A20162CC13DE497000E15488 /* portlistingparse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = portlistingparse.h; sourceTree = "<group>"; };
 		A20162CF13DE49E500E15488 /* miniupnpctypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = miniupnpctypes.h; sourceTree = "<group>"; };
-		A202FF5D0DDA9275009938FF /* it */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		A202FF5F0DDA9275009938FF /* it */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A2074F4B12BEA8CE00F70985 /* buffer.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = buffer.c; sourceTree = "<group>"; };
 		A2074F5012BEA8E000F70985 /* bufferevent_filter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bufferevent_filter.c; sourceTree = "<group>"; };
 		A2074F5212BEA8E000F70985 /* bufferevent_pair.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bufferevent_pair.c; sourceTree = "<group>"; };
@@ -953,85 +696,25 @@
 		A207503412BEAD9C00F70985 /* select.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = select.c; sourceTree = "<group>"; };
 		A207503612BEADA200F70985 /* poll.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = poll.c; sourceTree = "<group>"; };
 		A20750B712BEB66900F70985 /* bufferevent_ratelim.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bufferevent_ratelim.c; sourceTree = "<group>"; };
-		A2085DD90C53BC74000BC3B7 /* AboutWindowController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AboutWindowController.h; sourceTree = "<group>"; };
-		A2085DDA0C53BC74000BC3B7 /* AboutWindowController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AboutWindowController.mm; sourceTree = "<group>"; };
-		A209EAC21142CF28002B02D1 /* InfoActivityViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InfoActivityViewController.h; sourceTree = "<group>"; };
-		A209EAC31142CF28002B02D1 /* InfoActivityViewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = InfoActivityViewController.mm; sourceTree = "<group>"; };
-		A209EAC41142CF28002B02D1 /* InfoGeneralViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InfoGeneralViewController.h; sourceTree = "<group>"; };
-		A209EAC51142CF28002B02D1 /* InfoGeneralViewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = InfoGeneralViewController.mm; sourceTree = "<group>"; };
-		A209EAFF1142D3A5002B02D1 /* InfoTrackersViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InfoTrackersViewController.h; sourceTree = "<group>"; };
-		A209EB001142D3A5002B02D1 /* InfoTrackersViewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = InfoTrackersViewController.mm; sourceTree = "<group>"; };
-		A209EB1F1142DD85002B02D1 /* InfoTrackersView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InfoTrackersView.xib; sourceTree = "<group>"; };
-		A209EB9B1142E59A002B02D1 /* InfoPeersViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InfoPeersViewController.h; sourceTree = "<group>"; };
-		A209EB9C1142E59A002B02D1 /* InfoPeersViewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = InfoPeersViewController.mm; sourceTree = "<group>"; };
-		A209EBA61142EAF3002B02D1 /* InfoPeersView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InfoPeersView.xib; sourceTree = "<group>"; };
-		A209EBCC1142F2B4002B02D1 /* InfoFileViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InfoFileViewController.h; sourceTree = "<group>"; };
-		A209EBCD1142F2B4002B02D1 /* InfoFileViewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = InfoFileViewController.mm; sourceTree = "<group>"; };
-		A209EBD81142F52B002B02D1 /* InfoFileView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InfoFileView.xib; sourceTree = "<group>"; };
-		A209EBF71142FEEE002B02D1 /* InfoOptionsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InfoOptionsViewController.h; sourceTree = "<group>"; };
-		A209EBF81142FEEE002B02D1 /* InfoOptionsViewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = InfoOptionsViewController.mm; sourceTree = "<group>"; };
-		A209ECA1114319C3002B02D1 /* InfoWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InfoWindow.xib; sourceTree = "<group>"; };
 		A209EE5B1144B51E002B02D1 /* history.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = history.h; sourceTree = "<group>"; };
-		A21979890D07B78400438EA7 /* GroupToolbarItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GroupToolbarItem.h; sourceTree = "<group>"; };
-		A219798A0D07B78400438EA7 /* GroupToolbarItem.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = GroupToolbarItem.mm; sourceTree = "<group>"; };
-		A21A9BE0106D86A800F1C3C1 /* TrackerNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TrackerNode.h; sourceTree = "<group>"; };
-		A21A9BE1106D86A800F1C3C1 /* TrackerNode.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TrackerNode.mm; sourceTree = "<group>"; };
-		A21A9D3F106EC2E800F1C3C1 /* TrackerCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TrackerCell.h; sourceTree = "<group>"; };
-		A21A9D40106EC2E800F1C3C1 /* TrackerCell.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TrackerCell.mm; sourceTree = "<group>"; };
-		A21F15AA11729A8B00CF5A9C /* AddMagnetWindowController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AddMagnetWindowController.mm; sourceTree = "<group>"; };
-		A21F15AB11729A8B00CF5A9C /* AddMagnetWindowController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AddMagnetWindowController.h; sourceTree = "<group>"; };
 		A21FBBA90EDA78C300BC3C51 /* bandwidth.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = bandwidth.h; sourceTree = "<group>"; };
 		A21FBBAA0EDA78C300BC3C51 /* bandwidth.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = bandwidth.cc; sourceTree = "<group>"; };
 		A220EC59118C8A060022B4BE /* tr-lpd.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "tr-lpd.cc"; sourceTree = "<group>"; };
 		A220EC5A118C8A060022B4BE /* tr-lpd.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "tr-lpd.h"; sourceTree = "<group>"; };
-		A22180960D148A71007D09ED /* GroupsPrefsController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GroupsPrefsController.h; sourceTree = "<group>"; };
-		A22180970D148A71007D09ED /* GroupsPrefsController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = GroupsPrefsController.mm; sourceTree = "<group>"; };
 		A221DCC7104B3660008A642D /* Quartz.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quartz.framework; path = System/Library/Frameworks/Quartz.framework; sourceTree = SDKROOT; };
-		A222E9850E6B21D9009FB003 /* BlocklistDownloaderViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BlocklistDownloaderViewController.h; sourceTree = "<group>"; };
-		A222E9860E6B21D9009FB003 /* BlocklistDownloaderViewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BlocklistDownloaderViewController.mm; sourceTree = "<group>"; };
-		A223AA7E0D220CEB00840069 /* nl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		A223AA800D220CEB00840069 /* nl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
-		A225A4BE187E369C00CDE823 /* ShareToolbarItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ShareToolbarItem.h; sourceTree = "<group>"; };
-		A225A4BF187E369C00CDE823 /* ShareToolbarItem.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ShareToolbarItem.mm; sourceTree = "<group>"; };
 		A22B00AE116A9E90003315FC /* connecthostport.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = connecthostport.c; sourceTree = "<group>"; };
 		A22B00AF116A9E90003315FC /* connecthostport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = connecthostport.h; sourceTree = "<group>"; };
-		A22BAE261388040500FB022F /* NSMutableArrayAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSMutableArrayAdditions.h; sourceTree = "<group>"; };
-		A22BAE271388040500FB022F /* NSMutableArrayAdditions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NSMutableArrayAdditions.mm; sourceTree = "<group>"; };
-		A22CEF9E21CDC44400C5C1BA /* Transmission.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = Transmission.entitlements; path = macosx/Transmission.entitlements; sourceTree = "<group>"; };
 		A22CFB810FB66EF30009BD3E /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		A22CFCA60FC24ED80009BD3E /* tr-dht.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "tr-dht.cc"; sourceTree = "<group>"; };
 		A22CFCA70FC24ED80009BD3E /* tr-dht.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "tr-dht.h"; sourceTree = "<group>"; };
 		A22CFCBA0FC24F710009BD3E /* libdht.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libdht.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A22CFCC00FC24F890009BD3E /* dht.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = dht.h; sourceTree = "<group>"; };
 		A22CFCC10FC24F890009BD3E /* dht.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = dht.c; sourceTree = "<group>"; };
-		A231274B0D11D0B7003F9AFF /* AboutWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AboutWindow.xib; sourceTree = "<group>"; };
-		A232F07C0EEA034A00041646 /* BonjourController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BonjourController.h; sourceTree = "<group>"; };
-		A232F07D0EEA034A00041646 /* BonjourController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BonjourController.mm; sourceTree = "<group>"; };
-		A233BD320D8C6585007EE7B4 /* MessageWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MessageWindow.xib; sourceTree = "<group>"; };
-		A233BD680D8CF2C7007EE7B4 /* StatsWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StatsWindow.xib; sourceTree = "<group>"; };
-		A234EA521453563B000F3E97 /* NSImageAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSImageAdditions.h; sourceTree = "<group>"; };
-		A234EA531453563B000F3E97 /* NSImageAdditions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NSImageAdditions.mm; sourceTree = "<group>"; };
-		A2385DD20BFE06C800B24EF6 /* DragOverlayWindow.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DragOverlayWindow.mm; sourceTree = "<group>"; };
-		A2385DD30BFE06C800B24EF6 /* DragOverlayWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DragOverlayWindow.h; sourceTree = "<group>"; };
 		A23F299F132A447400E9A83B /* announcer-common.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "announcer-common.h"; sourceTree = "<group>"; };
 		A23F29A0132A447400E9A83B /* announcer-http.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "announcer-http.cc"; sourceTree = "<group>"; };
-		A23F526D0F14395900AA02E3 /* PredicateEditorRowTemplateAny.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PredicateEditorRowTemplateAny.h; sourceTree = "<group>"; };
-		A23F526E0F14395900AA02E3 /* PredicateEditorRowTemplateAny.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PredicateEditorRowTemplateAny.mm; sourceTree = "<group>"; };
-		A2451E6616ACE4EB00586E0E /* FileRenameSheetController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileRenameSheetController.h; sourceTree = "<group>"; };
-		A2451E6716ACE4EB00586E0E /* FileRenameSheetController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FileRenameSheetController.mm; sourceTree = "<group>"; };
-		A2451E6816ACE4EB00586E0E /* FileRenameSheetController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FileRenameSheetController.xib; sourceTree = "<group>"; };
 		A24621350C769CF400088E81 /* session-thread.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "session-thread.h"; sourceTree = "<group>"; };
 		A24621360C769CF400088E81 /* session-thread.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "session-thread.cc"; sourceTree = "<group>"; };
-		A247A442114C701800547DFC /* InfoViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InfoViewController.h; sourceTree = "<group>"; };
-		A24F19070A3A790800C9C145 /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Sparkle.framework; sourceTree = "<group>"; };
 		A25485390EB66CBB004539DA /* codelength.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = codelength.h; sourceTree = "<group>"; };
-		A256588A0A9A695400E8A03B /* MessageWindowController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MessageWindowController.h; sourceTree = "<group>"; };
-		A256588B0A9A695400E8A03B /* MessageWindowController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MessageWindowController.mm; sourceTree = "<group>"; };
-		A257C17F0CAD3003004E121C /* PeerTableView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PeerTableView.h; sourceTree = "<group>"; };
-		A257C1800CAD3003004E121C /* PeerTableView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PeerTableView.mm; sourceTree = "<group>"; };
-		A25892620CF1F7E800CCCDDF /* StatsWindowController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StatsWindowController.h; sourceTree = "<group>"; };
-		A25892630CF1F7E800CCCDDF /* StatsWindowController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = StatsWindowController.mm; sourceTree = "<group>"; };
-		A259316A0A73B2CC002F4FE7 /* TransmissionHelp */ = {isa = PBXFileReference; lastKnownFileType = folder; path = TransmissionHelp; sourceTree = "<group>"; };
 		A25964A4106D73A800453B31 /* announcer.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = announcer.cc; sourceTree = "<group>"; };
 		A25964A5106D73A800453B31 /* announcer.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = announcer.h; sourceTree = "<group>"; };
 		A25BFD63167BED3B0039D1AA /* variant-benc.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "variant-benc.cc"; sourceTree = "<group>"; };
@@ -1042,126 +725,48 @@
 		A25D2CBB0CF4C7190096A262 /* stats.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = stats.cc; sourceTree = "<group>"; };
 		A25E03E00E4015380086C225 /* tr-getopt.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "tr-getopt.h"; sourceTree = "<group>"; };
 		A25E03E10E4015380086C225 /* tr-getopt.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "tr-getopt.cc"; sourceTree = "<group>"; };
-		A25E74440AF5089E006F11AE /* ExpandedPathToPathTransformer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ExpandedPathToPathTransformer.mm; sourceTree = "<group>"; };
-		A25E74450AF5089E006F11AE /* ExpandedPathToPathTransformer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExpandedPathToPathTransformer.h; sourceTree = "<group>"; };
-		A25E74460AF5089E006F11AE /* ExpandedPathToIconTransformer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ExpandedPathToIconTransformer.mm; sourceTree = "<group>"; };
-		A25E74470AF5089E006F11AE /* ExpandedPathToIconTransformer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExpandedPathToIconTransformer.h; sourceTree = "<group>"; };
-		A2613F9811B3383200472893 /* pt-PT */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
-		A2613F9911B3383200472893 /* pt-PT */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/Localizable.strings"; sourceTree = "<group>"; };
-		A263C5661560A3CF0082A3D1 /* da */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
-		A263C5671560A4210082A3D1 /* da */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		A263C6B1F6718E2486DB20E1 /* tr-buffer.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "tr-buffer.h"; sourceTree = "<group>"; };
-		A263CFBE10DD67670038DE27 /* InfoTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InfoTextField.h; sourceTree = "<group>"; };
-		A263CFBF10DD67670038DE27 /* InfoTextField.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = InfoTextField.mm; sourceTree = "<group>"; };
 		A2679292130E00A000CB7464 /* tr-utp.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "tr-utp.cc"; sourceTree = "<group>"; };
 		A2679293130E00A000CB7464 /* tr-utp.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "tr-utp.h"; sourceTree = "<group>"; };
-		A267C2832E9F2B23003B87D7 /* Transmission_Tahoe.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; name = Transmission_Tahoe.icon; path = Images/Transmission_Tahoe.icon; sourceTree = "<group>"; };
-		A26AF1050D2855FC00FF7140 /* ru */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		A26AF1070D2855FC00FF7140 /* ru */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
-		A26AF2180D2DA35A00FF7140 /* FileOutlineController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileOutlineController.h; sourceTree = "<group>"; };
-		A26AF2190D2DA35A00FF7140 /* FileOutlineController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FileOutlineController.mm; sourceTree = "<group>"; };
-		A26AF2820D2DC27C00FF7140 /* AddWindowController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AddWindowController.h; sourceTree = "<group>"; };
-		A26AF2830D2DC27C00FF7140 /* AddWindowController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AddWindowController.mm; sourceTree = "<group>"; };
-		A2710E740A86796000CE4F7D /* PrefsWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrefsWindow.h; sourceTree = "<group>"; };
-		A2710E750A86796000CE4F7D /* PrefsWindow.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PrefsWindow.mm; sourceTree = "<group>"; };
-		A2725B6C0DE5C4F5003445E7 /* FileListNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileListNode.h; sourceTree = "<group>"; };
-		A2725B6D0DE5C4F5003445E7 /* FileListNode.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FileListNode.mm; sourceTree = "<group>"; };
-		A2725D5B0DE7507C003445E7 /* TrackerTableView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TrackerTableView.h; sourceTree = "<group>"; };
-		A2725D5C0DE7507C003445E7 /* TrackerTableView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TrackerTableView.mm; sourceTree = "<group>"; };
-		A27476FF0CC38EE6003CC76D /* es */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		A27477010CC38EE6003CC76D /* es */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
-		A2795C5828EFC6700002C8D9 /* public_html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = public_html; path = web/public_html; sourceTree = SOURCE_ROOT; };
-		A27F0F310E19AD9800B2DB97 /* TorrentGroup.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TorrentGroup.h; sourceTree = "<group>"; };
-		A27F0F320E19AD9800B2DB97 /* TorrentGroup.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TorrentGroup.mm; sourceTree = "<group>"; };
-		A28393FD10D54A79005C0240 /* de */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		A28393FF10D54A96005C0240 /* de */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		A2795C5828EFC6700002C8D9 /* public_html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = folder; name = public_html; path = web/public_html; sourceTree = SOURCE_ROOT; };
 		A284214212DA663E00FBDDBB /* tr-udp.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "tr-udp.cc"; sourceTree = "<group>"; };
-		A28E1DDF0CFFD8EC00E16385 /* ButtonToolbarItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ButtonToolbarItem.h; sourceTree = "<group>"; };
-		A28F4F750E085BDC003A3882 /* ColorTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ColorTextField.h; sourceTree = "<group>"; };
-		A28F4F760E085BDC003A3882 /* ColorTextField.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ColorTextField.mm; sourceTree = "<group>"; };
-		A291477D0E195A0C00F60CB2 /* en */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		A291477F0E195A0C00F60CB2 /* en */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A292A6E40DFB45E5004B9C0A /* peer-common.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "peer-common.h"; sourceTree = "<group>"; };
 		A292A6E50DFB45EC004B9C0A /* webseed.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = webseed.cc; sourceTree = "<group>"; };
 		A292A6E60DFB45EC004B9C0A /* webseed.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = webseed.h; sourceTree = "<group>"; };
-		A2966E8513DAF74C007B52DF /* GlobalOptionsPopoverViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GlobalOptionsPopoverViewController.h; sourceTree = "<group>"; };
-		A2966E8613DAF74C007B52DF /* GlobalOptionsPopoverViewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = GlobalOptionsPopoverViewController.mm; sourceTree = "<group>"; };
-		A29C8B340ACC6EB3000ED9F9 /* PortChecker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PortChecker.h; sourceTree = "<group>"; };
-		A29C8B350ACC6EB3000ED9F9 /* PortChecker.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PortChecker.mm; sourceTree = "<group>"; };
-		A29D84021049C25600D1987A /* NSApplicationAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSApplicationAdditions.h; sourceTree = "<group>"; };
-		A29D84031049C25600D1987A /* NSApplicationAdditions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NSApplicationAdditions.mm; sourceTree = "<group>"; };
 		A29DF8B60DB2544C00D04E5A /* resume.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = resume.cc; sourceTree = "<group>"; };
 		A29DF8B70DB2544C00D04E5A /* resume.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = resume.h; sourceTree = "<group>"; };
 		A29DF8B80DB2544C00D04E5A /* torrent.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = torrent.h; sourceTree = "<group>"; };
 		A29E653513F1603100048D71 /* evutil_rand.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = evutil_rand.c; sourceTree = "<group>"; };
 		A29EBE520DC01FC9006CEE80 /* web.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = web.cc; sourceTree = "<group>"; };
 		A29EBE530DC01FC9006CEE80 /* web.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = web.h; sourceTree = "<group>"; };
-		A2A1CB770BF29D5500AE959F /* PeerProgressIndicatorCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PeerProgressIndicatorCell.h; sourceTree = "<group>"; };
-		A2A1CB780BF29D5500AE959F /* PeerProgressIndicatorCell.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PeerProgressIndicatorCell.mm; sourceTree = "<group>"; };
-		A2A632190CD9751700E3DA60 /* BadgeView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BadgeView.h; sourceTree = "<group>"; };
-		A2A6321A0CD9751700E3DA60 /* BadgeView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BadgeView.mm; sourceTree = "<group>"; };
-		A2A9D119187DD75100C52A1F /* tr */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
-		A2A9D11A187DD75200C52A1F /* tr */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		A2AA579A0ADFCAB400CA59F6 /* PiecesView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PiecesView.h; sourceTree = "<group>"; };
-		A2AA579B0ADFCAB400CA59F6 /* PiecesView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PiecesView.mm; sourceTree = "<group>"; };
 		A2AA9BE0132CAC8D00FA131E /* announcer-udp.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "announcer-udp.cc"; sourceTree = "<group>"; };
 		A2AA9BE2132CAE2000FA131E /* evdns.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = evdns.c; sourceTree = "<group>"; };
 		A2AAB6580DE0CF6200E04DDA /* rpc-server.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "rpc-server.cc"; sourceTree = "<group>"; };
 		A2AAB6590DE0CF6200E04DDA /* rpcimpl.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = rpcimpl.h; sourceTree = "<group>"; };
 		A2AAB65A0DE0CF6200E04DDA /* rpc-server.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "rpc-server.h"; sourceTree = "<group>"; };
 		A2AAB65B0DE0CF6200E04DDA /* rpcimpl.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = rpcimpl.cc; sourceTree = "<group>"; };
-		A2AB883B16A399A6008FAD50 /* VDKQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VDKQueue.h; sourceTree = "<group>"; };
-		A2AB883C16A399A6008FAD50 /* VDKQueue.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VDKQueue.mm; sourceTree = "<group>"; };
-		A2AF1C360A3D0F6200F1575D /* FileOutlineView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileOutlineView.h; sourceTree = "<group>"; };
-		A2AF1C370A3D0F6200F1575D /* FileOutlineView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FileOutlineView.mm; sourceTree = "<group>"; };
 		A2AF23C616B44FA0003BC59E /* log.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = log.cc; sourceTree = "<group>"; };
 		A2AF23C716B44FA0003BC59E /* log.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = log.h; sourceTree = "<group>"; };
 		A2B3FB450E5901E700FF78FB /* cli.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = cli.cc; sourceTree = "<group>"; };
-		A2B5B4E71880665E0071A66A /* ShareTorrentFileHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ShareTorrentFileHelper.h; sourceTree = "<group>"; };
-		A2B5B4E81880665E0071A66A /* ShareTorrentFileHelper.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ShareTorrentFileHelper.mm; sourceTree = "<group>"; };
 		A2BE9C4E0C1E4ADA002D16E6 /* makemeta.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = makemeta.cc; sourceTree = "<group>"; };
 		A2BE9C4F0C1E4ADA002D16E6 /* makemeta.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = makemeta.h; sourceTree = "<group>"; };
-		A2C89D5F0CFCBF57004CC2BC /* ButtonToolbarItem.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ButtonToolbarItem.mm; sourceTree = "<group>"; };
-		A2CB38AE0E1E6896002B514C /* COPYING */ = {isa = PBXFileReference; lastKnownFileType = text; name = COPYING; path = ../COPYING; sourceTree = "<group>"; };
+		A2CB38AE0E1E6896002B514C /* COPYING */ = {isa = PBXFileReference; lastKnownFileType = text; path = COPYING; sourceTree = "<group>"; };
 		A2D22A100D65EED100007D5F /* verify.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = verify.cc; sourceTree = "<group>"; };
 		A2D22A110D65EED100007D5F /* verify.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = verify.h; sourceTree = "<group>"; };
 		A2D3078E0D9EC45F0051FD27 /* blocklist.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = blocklist.cc; sourceTree = "<group>"; };
 		A2D307930D9EC4860051FD27 /* blocklist.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = blocklist.h; sourceTree = "<group>"; };
-		A2D307B00D9EC9F50051FD27 /* BlocklistStatusWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BlocklistStatusWindow.xib; sourceTree = "<group>"; };
-		A2D7744F154CC25700A62B93 /* WebSeedTableView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebSeedTableView.h; sourceTree = "<group>"; };
-		A2D77450154CC25700A62B93 /* WebSeedTableView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebSeedTableView.mm; sourceTree = "<group>"; };
-		A2DF37040C220D03006523C1 /* CreatorWindowController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CreatorWindowController.h; sourceTree = "<group>"; };
-		A2DF37050C220D03006523C1 /* CreatorWindowController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CreatorWindowController.mm; sourceTree = "<group>"; };
 		A2E384D5130DFB3A001F501B /* utp_utils.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = utp_utils.cpp; sourceTree = "<group>"; };
 		A2E384D6130DFB3A001F501B /* utp_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = utp_utils.h; sourceTree = "<group>"; };
 		A2E384D8130DFB3A001F501B /* include/libutp/utp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = include/libutp/utp.h; sourceTree = "<group>"; };
 		A2E38544130DFEE3001F501B /* libutp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libutp.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		A2E57AB91310822C00A7DAB1 /* StatusBarController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StatusBarController.h; sourceTree = "<group>"; };
-		A2E57ABA1310822C00A7DAB1 /* StatusBarController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = StatusBarController.mm; sourceTree = "<group>"; };
-		A2E57AC51310831400A7DAB1 /* StatusBar.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StatusBar.xib; sourceTree = "<group>"; };
-		A2E57B9B13109DC200A7DAB1 /* FilterBar.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FilterBar.xib; sourceTree = "<group>"; };
-		A2E57BA513109E6B00A7DAB1 /* FilterBarController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FilterBarController.h; sourceTree = "<group>"; };
-		A2E57BA613109E6B00A7DAB1 /* FilterBarController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FilterBarController.mm; sourceTree = "<group>"; };
 		A2E669780F5B8E5A00B4251A /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		A2EA522F1686AC0D00180493 /* quark.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = quark.cc; sourceTree = "<group>"; };
 		A2EA52301686AC0D00180493 /* quark.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = quark.h; sourceTree = "<group>"; };
-		A2EA8E3C0CC3C9830081201C /* fr */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		A2EA8E3E0CC3C9830081201C /* fr */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
-		A2ED7D8D0CEF431B00970975 /* FilterButton.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FilterButton.h; sourceTree = "<group>"; };
-		A2ED7D8E0CEF431B00970975 /* FilterButton.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FilterButton.mm; sourceTree = "<group>"; };
 		A2EE726E14DCCC950093C99A /* port-forwarding-natpmp.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "port-forwarding-natpmp.h"; sourceTree = "<group>"; };
 		A2F35BBB15C5A0A100EBF632 /* QuickLook.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuickLook.framework; path = System/Library/Frameworks/QuickLook.framework; sourceTree = SDKROOT; };
 		A2F35BC115C5A0A100EBF632 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		A2F35BE215C5A7F900EBF632 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		A2F7CF5413035F7B0016FF10 /* URLSheetWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = URLSheetWindow.xib; sourceTree = "<group>"; };
-		A2F7CF5D13035FFD0016FF10 /* URLSheetWindowController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = URLSheetWindowController.h; sourceTree = "<group>"; };
-		A2F7CF5E13035FFD0016FF10 /* URLSheetWindowController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = URLSheetWindowController.mm; sourceTree = "<group>"; };
-		A2F8951E0A2D4BA500ED2127 /* Credits.rtf */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; path = Credits.rtf; sourceTree = "<group>"; };
 		A2F8CD420F3D0F4A00DB356A /* miniupnpcstrings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = miniupnpcstrings.h; sourceTree = "<group>"; };
-		A2FB057C0BFEB6800095564D /* DragOverlayView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DragOverlayView.h; sourceTree = "<group>"; };
-		A2FB057D0BFEB6800095564D /* DragOverlayView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DragOverlayView.mm; sourceTree = "<group>"; };
-		A2FB701A0D95CAEA0001F331 /* GroupsController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GroupsController.h; sourceTree = "<group>"; };
-		A2FB701B0D95CAEA0001F331 /* GroupsController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = GroupsController.mm; sourceTree = "<group>"; };
 		A47A7C87B8B57BE50DF0D411 /* torrent-files.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "torrent-files.cc"; sourceTree = "<group>"; };
 		A47A7C87B8B57BE50DF0D413 /* torrent-files.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "torrent-files.h"; sourceTree = "<group>"; };
 		A54D44C6A7AAF131D9AE29F5 /* block-info.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "block-info.cc"; sourceTree = "<group>"; };
@@ -1379,126 +984,6 @@
 		C17740D3273A002C00E455D2 /* web-utils.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "web-utils.cc"; sourceTree = "<group>"; };
 		C17740D4273A002C00E455D2 /* web-utils.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = "web-utils.h"; sourceTree = "<group>"; };
 		C1846B87294F781800A98F30 /* wildmat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = wildmat.h; sourceTree = "<group>"; };
-		C1A6BB3C2B3E69CB00C4A151 /* eu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = eu; path = eu.lproj/Localizable.strings; sourceTree = "<group>"; };
-		C1A6BB3D2B3E6A0700C4A151 /* he */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/Localizable.strings; sourceTree = "<group>"; };
-		C1A6BB3E2B3E6A0F00C4A151 /* hu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/Localizable.strings; sourceTree = "<group>"; };
-		C1A6BB3F2B3E6A1800C4A151 /* ja */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
-		C1A6BB402B3E6A2200C4A151 /* pl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
-		C1A6BB412B3E6A2900C4A151 /* pt-BR */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
-		C1A6BB422B3E6A3000C4A151 /* sv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
-		C1A6BB432B3E6A3A00C4A151 /* uk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Localizable.strings; sourceTree = "<group>"; };
-		C1A6BB442B3E6A3F00C4A151 /* zh-CN */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/Localizable.strings"; sourceTree = "<group>"; };
-		C1A6BB452B3E6A4C00C4A151 /* zh-TW */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/Localizable.strings"; sourceTree = "<group>"; };
-		C1A6BB462B3E6ACE00C4A151 /* eu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = eu; path = eu.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		C1A6BB472B3E6ADA00C4A151 /* he */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		C1A6BB482B3E6ADF00C4A151 /* hu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		C1A6BB492B3E6AE800C4A151 /* ja */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		C1A6BB4A2B3E6AEE00C4A151 /* pl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		C1A6BB4B2B3E6AF500C4A151 /* pt-BR */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
-		C1A6BB4C2B3E6AFC00C4A151 /* sv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		C1A6BB4D2B3E6B0200C4A151 /* uk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		C1A6BB4E2B3E6B0800C4A151 /* zh-CN */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
-		C1A6BB4F2B3E6B0D00C4A151 /* zh-TW */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
-		C1A6BB532B3E6C6600C4A151 /* eu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = eu; path = eu.lproj/MainMenu.strings; sourceTree = "<group>"; };
-		C1A6BB542B3E6C7900C4A151 /* he */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/MainMenu.strings; sourceTree = "<group>"; };
-		C1A6BB552B3E6C8700C4A151 /* hu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/MainMenu.strings; sourceTree = "<group>"; };
-		C1A6BB562B3E6C8D00C4A151 /* ja */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/MainMenu.strings; sourceTree = "<group>"; };
-		C1A6BB572B3E6C9000C4A151 /* pl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/MainMenu.strings; sourceTree = "<group>"; };
-		C1A6BB582B3E6C9300C4A151 /* pt-BR */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/MainMenu.strings"; sourceTree = "<group>"; };
-		C1A6BB592B3E6C9B00C4A151 /* sv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/MainMenu.strings; sourceTree = "<group>"; };
-		C1A6BB5A2B3E6C9C00C4A151 /* uk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/MainMenu.strings; sourceTree = "<group>"; };
-		C1A6BB5B2B3E6CA100C4A151 /* zh-CN */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/MainMenu.strings"; sourceTree = "<group>"; };
-		C1A6BB5C2B3E6CA300C4A151 /* zh-TW */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/MainMenu.strings"; sourceTree = "<group>"; };
-		C1A6BB5D2B3E6CD600C4A151 /* eu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = eu; path = eu.lproj/PrefsWindow.strings; sourceTree = "<group>"; };
-		C1A6BB5E2B3E6CD800C4A151 /* he */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/PrefsWindow.strings; sourceTree = "<group>"; };
-		C1A6BB5F2B3E6CDA00C4A151 /* hu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/PrefsWindow.strings; sourceTree = "<group>"; };
-		C1A6BB602B3E6CDB00C4A151 /* ja */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/PrefsWindow.strings; sourceTree = "<group>"; };
-		C1A6BB612B3E6CDD00C4A151 /* pl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/PrefsWindow.strings; sourceTree = "<group>"; };
-		C1A6BB622B3E6CDF00C4A151 /* pt-BR */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/PrefsWindow.strings"; sourceTree = "<group>"; };
-		C1A6BB632B3E6CE000C4A151 /* sv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/PrefsWindow.strings; sourceTree = "<group>"; };
-		C1A6BB642B3E6CE200C4A151 /* uk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/PrefsWindow.strings; sourceTree = "<group>"; };
-		C1A6BB652B3E6CE400C4A151 /* zh-CN */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/PrefsWindow.strings"; sourceTree = "<group>"; };
-		C1A6BB662B3E6CE500C4A151 /* zh-TW */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/PrefsWindow.strings"; sourceTree = "<group>"; };
-		C1A6BB672B3E6CF000C4A151 /* eu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = eu; path = eu.lproj/Creator.strings; sourceTree = "<group>"; };
-		C1A6BB682B3E6CF200C4A151 /* he */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/Creator.strings; sourceTree = "<group>"; };
-		C1A6BB692B3E6CF300C4A151 /* hu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/Creator.strings; sourceTree = "<group>"; };
-		C1A6BB6A2B3E6CF500C4A151 /* ja */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Creator.strings; sourceTree = "<group>"; };
-		C1A6BB6B2B3E6CF600C4A151 /* pl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Creator.strings; sourceTree = "<group>"; };
-		C1A6BB6C2B3E6CF800C4A151 /* pt-BR */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Creator.strings"; sourceTree = "<group>"; };
-		C1A6BB6D2B3E6CFA00C4A151 /* sv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Creator.strings; sourceTree = "<group>"; };
-		C1A6BB6E2B3E6CFC00C4A151 /* uk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Creator.strings; sourceTree = "<group>"; };
-		C1A6BB6F2B3E6D0200C4A151 /* zh-CN */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/Creator.strings"; sourceTree = "<group>"; };
-		C1A6BB702B3E6D0300C4A151 /* zh-TW */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/Creator.strings"; sourceTree = "<group>"; };
-		C1A6BB712B3E6D1000C4A151 /* eu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = eu; path = eu.lproj/AddWindow.strings; sourceTree = "<group>"; };
-		C1A6BB722B3E6D1200C4A151 /* he */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/AddWindow.strings; sourceTree = "<group>"; };
-		C1A6BB732B3E6D1400C4A151 /* hu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/AddWindow.strings; sourceTree = "<group>"; };
-		C1A6BB742B3E6D1500C4A151 /* ja */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/AddWindow.strings; sourceTree = "<group>"; };
-		C1A6BB752B3E6D1600C4A151 /* pl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/AddWindow.strings; sourceTree = "<group>"; };
-		C1A6BB762B3E6D1800C4A151 /* pt-BR */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/AddWindow.strings"; sourceTree = "<group>"; };
-		C1A6BB772B3E6D1900C4A151 /* sv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/AddWindow.strings; sourceTree = "<group>"; };
-		C1A6BB782B3E6D1B00C4A151 /* uk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/AddWindow.strings; sourceTree = "<group>"; };
-		C1A6BB792B3E6D1E00C4A151 /* zh-CN */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/AddWindow.strings"; sourceTree = "<group>"; };
-		C1A6BB7A2B3E6D2000C4A151 /* zh-TW */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/AddWindow.strings"; sourceTree = "<group>"; };
-		C1A6BB7B2B3E6D6200C4A151 /* eu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = eu; path = eu.lproj/AddMagnetWindow.strings; sourceTree = "<group>"; };
-		C1A6BB7C2B3E6D6400C4A151 /* he */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/AddMagnetWindow.strings; sourceTree = "<group>"; };
-		C1A6BB7D2B3E6D6500C4A151 /* hu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/AddMagnetWindow.strings; sourceTree = "<group>"; };
-		C1A6BB7E2B3E6D6700C4A151 /* ja */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/AddMagnetWindow.strings; sourceTree = "<group>"; };
-		C1A6BB7F2B3E6D6800C4A151 /* pl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/AddMagnetWindow.strings; sourceTree = "<group>"; };
-		C1A6BB802B3E6D6A00C4A151 /* pt-BR */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/AddMagnetWindow.strings"; sourceTree = "<group>"; };
-		C1A6BB812B3E6D6B00C4A151 /* sv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/AddMagnetWindow.strings; sourceTree = "<group>"; };
-		C1A6BB822B3E6D6D00C4A151 /* uk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/AddMagnetWindow.strings; sourceTree = "<group>"; };
-		C1A6BB832B3E6D6F00C4A151 /* zh-CN */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/AddMagnetWindow.strings"; sourceTree = "<group>"; };
-		C1A6BB842B3E6D7100C4A151 /* zh-TW */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/AddMagnetWindow.strings"; sourceTree = "<group>"; };
-		C1A6BB852B3E6D8100C4A151 /* eu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = eu; path = eu.lproj/GroupRules.strings; sourceTree = "<group>"; };
-		C1A6BB862B3E6D8300C4A151 /* he */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/GroupRules.strings; sourceTree = "<group>"; };
-		C1A6BB872B3E6D8400C4A151 /* hu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/GroupRules.strings; sourceTree = "<group>"; };
-		C1A6BB882B3E6D8600C4A151 /* ja */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/GroupRules.strings; sourceTree = "<group>"; };
-		C1A6BB892B3E6D8700C4A151 /* pl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/GroupRules.strings; sourceTree = "<group>"; };
-		C1A6BB8A2B3E6D8900C4A151 /* pt-BR */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/GroupRules.strings"; sourceTree = "<group>"; };
-		C1A6BB8B2B3E6D8A00C4A151 /* sv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/GroupRules.strings; sourceTree = "<group>"; };
-		C1A6BB8C2B3E6D8B00C4A151 /* uk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/GroupRules.strings; sourceTree = "<group>"; };
-		C1A6BB8D2B3E6D8D00C4A151 /* zh-CN */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/GroupRules.strings"; sourceTree = "<group>"; };
-		C1A6BB8E2B3E6D8F00C4A151 /* zh-TW */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/GroupRules.strings"; sourceTree = "<group>"; };
-		C1A6BB8F2B3E6DA200C4A151 /* eu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = eu; path = eu.lproj/InfoGeneralView.strings; sourceTree = "<group>"; };
-		C1A6BB902B3E6DA500C4A151 /* he */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/InfoGeneralView.strings; sourceTree = "<group>"; };
-		C1A6BB912B3E6DA600C4A151 /* hu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/InfoGeneralView.strings; sourceTree = "<group>"; };
-		C1A6BB922B3E6DA700C4A151 /* ja */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/InfoGeneralView.strings; sourceTree = "<group>"; };
-		C1A6BB932B3E6DA900C4A151 /* pl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/InfoGeneralView.strings; sourceTree = "<group>"; };
-		C1A6BB942B3E6DAA00C4A151 /* pt-BR */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/InfoGeneralView.strings"; sourceTree = "<group>"; };
-		C1A6BB952B3E6DAB00C4A151 /* sv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/InfoGeneralView.strings; sourceTree = "<group>"; };
-		C1A6BB962B3E6DAD00C4A151 /* uk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/InfoGeneralView.strings; sourceTree = "<group>"; };
-		C1A6BB972B3E6DAF00C4A151 /* zh-CN */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/InfoGeneralView.strings"; sourceTree = "<group>"; };
-		C1A6BB982B3E6DB000C4A151 /* zh-TW */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/InfoGeneralView.strings"; sourceTree = "<group>"; };
-		C1A6BB992B3E6DBE00C4A151 /* eu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = eu; path = eu.lproj/InfoActivityView.strings; sourceTree = "<group>"; };
-		C1A6BB9A2B3E6DC000C4A151 /* he */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/InfoActivityView.strings; sourceTree = "<group>"; };
-		C1A6BB9B2B3E6DC100C4A151 /* hu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/InfoActivityView.strings; sourceTree = "<group>"; };
-		C1A6BB9C2B3E6DC300C4A151 /* ja */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/InfoActivityView.strings; sourceTree = "<group>"; };
-		C1A6BB9D2B3E6DC400C4A151 /* pl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/InfoActivityView.strings; sourceTree = "<group>"; };
-		C1A6BB9E2B3E6DC600C4A151 /* pt-BR */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/InfoActivityView.strings"; sourceTree = "<group>"; };
-		C1A6BB9F2B3E6DC700C4A151 /* sv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/InfoActivityView.strings; sourceTree = "<group>"; };
-		C1A6BBA02B3E6DC900C4A151 /* uk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/InfoActivityView.strings; sourceTree = "<group>"; };
-		C1A6BBA12B3E6DCA00C4A151 /* zh-CN */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/InfoActivityView.strings"; sourceTree = "<group>"; };
-		C1A6BBA22B3E6DCC00C4A151 /* zh-TW */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/InfoActivityView.strings"; sourceTree = "<group>"; };
-		C1A6BBA32B3E6DDC00C4A151 /* eu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = eu; path = eu.lproj/InfoOptionsView.strings; sourceTree = "<group>"; };
-		C1A6BBA42B3E6DDE00C4A151 /* he */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/InfoOptionsView.strings; sourceTree = "<group>"; };
-		C1A6BBA52B3E6DDF00C4A151 /* hu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/InfoOptionsView.strings; sourceTree = "<group>"; };
-		C1A6BBA62B3E6DE000C4A151 /* ja */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/InfoOptionsView.strings; sourceTree = "<group>"; };
-		C1A6BBA72B3E6DE200C4A151 /* pl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/InfoOptionsView.strings; sourceTree = "<group>"; };
-		C1A6BBA82B3E6DE300C4A151 /* pt-BR */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/InfoOptionsView.strings"; sourceTree = "<group>"; };
-		C1A6BBA92B3E6DE500C4A151 /* sv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/InfoOptionsView.strings; sourceTree = "<group>"; };
-		C1A6BBAA2B3E6DE600C4A151 /* uk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/InfoOptionsView.strings; sourceTree = "<group>"; };
-		C1A6BBAB2B3E6DE800C4A151 /* zh-CN */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/InfoOptionsView.strings"; sourceTree = "<group>"; };
-		C1A6BBAC2B3E6DEA00C4A151 /* zh-TW */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/InfoOptionsView.strings"; sourceTree = "<group>"; };
-		C1A6BBAD2B3E6E0900C4A151 /* eu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = eu; path = eu.lproj/GlobalOptionsPopover.strings; sourceTree = "<group>"; };
-		C1A6BBAE2B3E6E0B00C4A151 /* he */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/GlobalOptionsPopover.strings; sourceTree = "<group>"; };
-		C1A6BBAF2B3E6E0C00C4A151 /* hu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/GlobalOptionsPopover.strings; sourceTree = "<group>"; };
-		C1A6BBB02B3E6E0E00C4A151 /* ja */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/GlobalOptionsPopover.strings; sourceTree = "<group>"; };
-		C1A6BBB12B3E6E0F00C4A151 /* pl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/GlobalOptionsPopover.strings; sourceTree = "<group>"; };
-		C1A6BBB22B3E6E1000C4A151 /* pt-BR */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/GlobalOptionsPopover.strings"; sourceTree = "<group>"; };
-		C1A6BBB32B3E6E1200C4A151 /* sv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/GlobalOptionsPopover.strings; sourceTree = "<group>"; };
-		C1A6BBB42B3E6E1300C4A151 /* uk */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/GlobalOptionsPopover.strings; sourceTree = "<group>"; };
-		C1A6BBB52B3E6E1600C4A151 /* zh-CN */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/GlobalOptionsPopover.strings"; sourceTree = "<group>"; };
-		C1A6BBB62B3E6E1A00C4A151 /* zh-TW */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/GlobalOptionsPopover.strings"; sourceTree = "<group>"; };
 		C1BF7BA71F2A3CB7008E88A7 /* upnpdev.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = upnpdev.c; sourceTree = "<group>"; };
 		C1BF7BA91F2A3CCE008E88A7 /* upnpdev.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = upnpdev.h; sourceTree = "<group>"; };
 		C1F690FC1AD0627500D95CF0 /* daemon-posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "daemon-posix.cc"; sourceTree = "<group>"; };
@@ -1511,13 +996,7 @@
 		C3D9061827B7E1DE00EF2386 /* psl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = psl.c; path = src/psl.c; sourceTree = "<group>"; };
 		C3D9061B27B7E31100EF2386 /* libpsl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = libpsl.h; path = include/libpsl.h; sourceTree = "<group>"; };
 		C3D9062127B7E3C900EF2386 /* libpsl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libpsl.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		C809AEE5291ECFD000BFDBE1 /* NSDataAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSDataAdditions.h; sourceTree = "<group>"; };
-		C809AEE6291ECFD000BFDBE1 /* NSDataAdditions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NSDataAdditions.mm; sourceTree = "<group>"; };
-		C81E411127F5BABD00652F56 /* CocoaCompatibility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CocoaCompatibility.h; sourceTree = "<group>"; };
-		C841A27F29197724009F18E8 /* NSKeyedUnarchiverAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSKeyedUnarchiverAdditions.h; sourceTree = "<group>"; };
-		C841A28029197724009F18E8 /* NSKeyedUnarchiverAdditions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NSKeyedUnarchiverAdditions.mm; sourceTree = "<group>"; };
 		C843FC8329C51B9400491854 /* string-utils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "string-utils.mm"; sourceTree = "<group>"; };
-		C86BCD9828228A9600F45599 /* SparkleProxy.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SparkleProxy.mm; sourceTree = "<group>"; };
 		C87369642809984200573C90 /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
 		C8748D8929891EA100D9E979 /* suffixes_dafsa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = suffixes_dafsa.h; path = "third-party/suffixes_dafsa.h"; sourceTree = SOURCE_ROOT; };
 		C88771A92803EE42005C7523 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
@@ -1533,8 +1012,6 @@
 		CAB35C62252F6F5E00552A55 /* mime-types.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = "mime-types.h"; sourceTree = "<group>"; };
 		CCEBA596277340F6DF9F4481 /* session-alt-speeds.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "session-alt-speeds.cc"; sourceTree = "<group>"; };
 		CCEBA596277340F6DF9F4483 /* session-alt-speeds.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "session-alt-speeds.h"; sourceTree = "<group>"; };
-		E138A9750C04D88F00C5426C /* ProgressGradients.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ProgressGradients.h; sourceTree = "<group>"; };
-		E138A9760C04D88F00C5426C /* ProgressGradients.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ProgressGradients.mm; sourceTree = "<group>"; };
 		E975121263DD973CAF4AEBA1 /* timer.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = timer.h; sourceTree = "<group>"; };
 		E975121263DD973CAF4AEBA3 /* timer-ev.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = "timer-ev.h"; sourceTree = "<group>"; };
 		E975121263DD973CAF4AEBA5 /* timer-ev.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "timer-ev.cc"; sourceTree = "<group>"; };
@@ -1544,49 +1021,14 @@
 		ED0C0D1F2E5F400100112233 /* lock-file.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "lock-file.h"; sourceTree = "<group>"; };
 		ED5E0E7C2CD30B180071433B /* QuickLookExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = QuickLookExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED5E0E7D2CD30B180071433B /* Quartz.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quartz.framework; path = System/Library/Frameworks/Quartz.framework; sourceTree = SDKROOT; };
-		ED5E0E942CD30E8F0071433B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		ED5E0E952CD30E8F0071433B /* PreviewProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PreviewProvider.h; sourceTree = "<group>"; };
-		ED5E0E962CD30E8F0071433B /* PreviewProvider.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PreviewProvider.mm; sourceTree = "<group>"; };
-		ED5E0E972CD30E8F0071433B /* QuickLookExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = QuickLookExtension.entitlements; sourceTree = "<group>"; };
-		ED5E0EA12CD314FE0071433B /* style.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = style.css; sourceTree = "<group>"; };
-		ED5E0EF92CD315720071433B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
-		ED5E0EFC2CD3157E0071433B /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
-		ED5E0EFD2CD3158A0071433B /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
-		ED5E0EFE2CD315940071433B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
-		ED5E0EFF2CD315A90071433B /* eu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = eu; path = eu.lproj/Localizable.strings; sourceTree = "<group>"; };
-		ED5E0F002CD315B10071433B /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
-		ED5E0F012CD315B90071433B /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/Localizable.strings; sourceTree = "<group>"; };
-		ED5E0F022CD315C50071433B /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/Localizable.strings; sourceTree = "<group>"; };
-		ED5E0F032CD315CD0071433B /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
-		ED5E0F042CD315D70071433B /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
-		ED5E0F052CD315E10071433B /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
-		ED5E0F062CD315EC0071433B /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
-		ED5E0F072CD315FE0071433B /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/Localizable.strings"; sourceTree = "<group>"; };
-		ED5E0F082CD316090071433B /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
-		ED5E0F092CD3161C0071433B /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
-		ED5E0F0A2CD316240071433B /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
-		ED5E0F0B2CD3162E0071433B /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
-		ED5E0F0C2CD3163B0071433B /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Localizable.strings; sourceTree = "<group>"; };
-		ED5E0F0D2CD316450071433B /* zh-CN */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-CN"; path = "zh-CN.lproj/Localizable.strings"; sourceTree = "<group>"; };
-		ED5E0F0E2CD3164D0071433B /* zh-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = "zh-TW.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		ED67FB402B70FCE400D8A037 /* converters.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = converters.cc; sourceTree = "<group>"; };
 		ED67FB412B70FCE400D8A037 /* serializer.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = serializer.h; sourceTree = "<group>"; };
 		ED67FB442B70FCE400D8A037 /* converters.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = converters.h; sourceTree = "<group>"; };
-		ED6F16AF2EB8F1EB007CD864 /* FileCheckCellView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileCheckCellView.h; sourceTree = "<group>"; };
-		ED6F16B02EB8F1EB007CD864 /* FileCheckCellView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FileCheckCellView.mm; sourceTree = "<group>"; };
-		ED6F16B12EB8F1EB007CD864 /* BaseFileNameCellView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BaseFileNameCellView.h; sourceTree = "<group>"; };
-		ED6F16B22EB8F1EB007CD864 /* BaseFileNameCellView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BaseFileNameCellView.mm; sourceTree = "<group>"; };
-		ED6F16B32EB8F1EB007CD864 /* FilePriorityCellView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FilePriorityCellView.h; sourceTree = "<group>"; };
-		ED6F16B42EB8F1EB007CD864 /* FilePriorityCellView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FilePriorityCellView.mm; sourceTree = "<group>"; };
-		ED86936D2ADAE34D00342B1A /* DefaultAppHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DefaultAppHelper.h; sourceTree = "<group>"; };
-		ED86936E2ADAE34D00342B1A /* DefaultAppHelper.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DefaultAppHelper.mm; sourceTree = "<group>"; };
 		ED8A163D2735A8AA000D61F9 /* peer-mgr-wishlist.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = "peer-mgr-wishlist.h"; sourceTree = "<group>"; };
 		ED8A163E2735A8AA000D61F9 /* peer-mgr-wishlist.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "peer-mgr-wishlist.cc"; sourceTree = "<group>"; };
 		ED91F00C2CBDA5D3008388AA /* libmadler-crcany.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libmadler-crcany.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED91F01B2CBDA72C008388AA /* crc32iscsi.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = crc32iscsi.h; sourceTree = "<group>"; };
 		ED91F01E2CBDA72C008388AA /* crc32iscsi.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = crc32iscsi.c; sourceTree = "<group>"; };
-		ED9862952B979AA2002F3035 /* Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Utils.h; sourceTree = "<group>"; };
-		ED9862962B979AA2002F3035 /* Utils.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Utils.mm; sourceTree = "<group>"; };
 		EDB550012F55000100B05501 /* bep55-holepunch.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "bep55-holepunch.cc"; sourceTree = "<group>"; };
 		EDB550022F55000100B05501 /* bep55-holepunch.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "bep55-holepunch.h"; sourceTree = "<group>"; };
 		EDB550052F55000100B05501 /* bep55-introducer-store.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "bep55-introducer-store.h"; sourceTree = "<group>"; };
@@ -1603,14 +1045,64 @@
 		EDC0A1B02E5A100100A1B2C3 /* local-data.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "local-data.cc"; sourceTree = "<group>"; };
 		EDC37BCB2EE9C2AD001E2612 /* api-compat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "api-compat.h"; sourceTree = "<group>"; };
 		EDC37BCC2EE9C2AD001E2612 /* api-compat.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "api-compat.cc"; sourceTree = "<group>"; };
-		EDC749F72D98ADE200A12D0F /* PowerManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PowerManager.h; sourceTree = "<group>"; };
-		EDC749F82D98AE2900A12D0F /* PowerManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PowerManager.mm; sourceTree = "<group>"; };
 		EDD735D52D83087400852628 /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
 		EDEB86BE2BDF9E9D00112233 /* constants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = constants.h; sourceTree = "<group>"; };
 		EDEB86BF2BDF9E9D00112233 /* types.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = types.h; sourceTree = "<group>"; };
 		F0A1B2C42F1A2B3C00445566 /* session-settings.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; path = "session-settings.h"; sourceTree = "<group>"; };
-		F63480621E1D7274005B9E09 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Images/Images.xcassets; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		0AD81F53304EC83D00C22874 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			attributesByRelativePath = {
+				Sparkle.framework = (
+					Weak,
+				);
+			};
+			membershipExceptions = (
+				/Localized/QuickLookExtension/Localizable.strings,
+				CMakeLists.txt,
+				Info.plist,
+				Info.plist.in,
+				QuickLookExtension/CMakeLists.txt,
+				QuickLookExtension/Info.plist,
+				QuickLookExtension/Info.plist.in,
+				QuickLookExtension/PreviewProvider.mm,
+				QuickLookExtension/style.css,
+				VDKQueue/CMakeLists.txt,
+			);
+			target = 8D1107260486CEB800E47090 /* Transmission */;
+		};
+		0AD81F55304EC83D00C22874 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				/Localized/QuickLookExtension/Localizable.strings,
+				Additions/NSStringAdditions.mm,
+				QuickLookExtension/PreviewProvider.mm,
+				QuickLookExtension/style.css,
+			);
+			target = ED5E0E7B2CD30B180071433B /* QuickLookExtension */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
+		0AD81F54304EC83D00C22874 /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet;
+			attributesByRelativePath = {
+				Sparkle.framework = (
+					CodeSignOnCopy,
+				);
+			};
+			buildPhase = A24F191B0A3A792300C9C145 /* Copy Files to Frameworks */;
+			membershipExceptions = (
+				Sparkle.framework,
+			);
+		};
+/* End PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		0AD81ED4304EC83C00C22874 /* macosx */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (0AD81F53304EC83D00C22874 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 0AD81F54304EC83D00C22874 /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */, 0AD81F55304EC83D00C22874 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (TransmissionHelp, ); path = macosx; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		3C7A118B0D0B2EB800B5701F /* Frameworks */ = {
@@ -1648,7 +1140,6 @@
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
 				4D1838DD09DEC0E80047D688 /* libtransmission.a in Frameworks */,
 				C0FFEE000000000000000017 /* IOKit.framework in Frameworks */,
-				A24F19080A3A790800C9C145 /* Sparkle.framework in Frameworks */,
 				C88771B52803EEB1005C7523 /* libiconv.tbd in Frameworks */,
 				55869926257074EC00F77A43 /* libcurl.tbd in Frameworks */,
 				A2E669790F5B8E5A00B4251A /* Security.framework in Frameworks */,
@@ -1809,105 +1300,9 @@
 		080E96DDFE201D6D7F000001 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				29B97316FDCFA39411CA2CEA /* main.mm */,
-				C86BCD9828228A9600F45599 /* SparkleProxy.mm */,
-				4DF0C5AA0899190500DD8943 /* Controller.h */,
-				4DF0C5A90899190500DD8943 /* Controller.mm */,
-				4DFBC2DD09C0970D00D5C571 /* Torrent.h */,
-				4DFBC2DE09C0970D00D5C571 /* Torrent.mm */,
-				A27F0F310E19AD9800B2DB97 /* TorrentGroup.h */,
-				A27F0F320E19AD9800B2DB97 /* TorrentGroup.mm */,
-				4D364D9E091FBB2C00377D12 /* TorrentTableView.h */,
-				4D364D9F091FBB2C00377D12 /* TorrentTableView.mm */,
-				4521532C29AF9D60009331B0 /* TorrentCell.h */,
-				4521532D29AF9D61009331B0 /* TorrentCell.mm */,
-				4534164029B0EA8500F544C9 /* SmallTorrentCell.h */,
-				4534164129B0EA8600F544C9 /* SmallTorrentCell.mm */,
-				4521532A29AF891F009331B0 /* GroupCell.h */,
-				4521532929AF891E009331B0 /* GroupCell.mm */,
-				4559D21429B32622004EFDF0 /* ProgressBarView.h */,
-				4559D21529B32623004EFDF0 /* ProgressBarView.mm */,
-				45489C4729AE79FC0098A812 /* TorrentCellActionButton.h */,
-				45489C5029AF6FB10098A812 /* TorrentCellActionButton.mm */,
-				45489C4B29AF10D10098A812 /* TorrentCellControlButton.h */,
-				45489C5329AF6FB10098A812 /* TorrentCellControlButton.mm */,
-				45489C4A29AF10D00098A812 /* TorrentCellRevealButton.h */,
-				45489C5229AF6FB10098A812 /* TorrentCellRevealButton.mm */,
-				A21A9BE0106D86A800F1C3C1 /* TrackerNode.h */,
-				A21A9BE1106D86A800F1C3C1 /* TrackerNode.mm */,
-				A2725B6C0DE5C4F5003445E7 /* FileListNode.h */,
-				A2725B6D0DE5C4F5003445E7 /* FileListNode.mm */,
-				A28F4F750E085BDC003A3882 /* ColorTextField.h */,
-				A28F4F760E085BDC003A3882 /* ColorTextField.mm */,
-				A26AF2820D2DC27C00FF7140 /* AddWindowController.h */,
-				A26AF2830D2DC27C00FF7140 /* AddWindowController.mm */,
-				A21F15AB11729A8B00CF5A9C /* AddMagnetWindowController.h */,
-				A21F15AA11729A8B00CF5A9C /* AddMagnetWindowController.mm */,
-				A25E74450AF5089E006F11AE /* ExpandedPathToPathTransformer.h */,
-				A25E74440AF5089E006F11AE /* ExpandedPathToPathTransformer.mm */,
-				A25E74470AF5089E006F11AE /* ExpandedPathToIconTransformer.h */,
-				A25E74460AF5089E006F11AE /* ExpandedPathToIconTransformer.mm */,
-				4DE5CCA50980735700BE280E /* Badger.h */,
-				4DE5CCA60980735700BE280E /* Badger.mm */,
-				A2A632190CD9751700E3DA60 /* BadgeView.h */,
-				A2A6321A0CD9751700E3DA60 /* BadgeView.mm */,
-				A256588A0A9A695400E8A03B /* MessageWindowController.h */,
-				A256588B0A9A695400E8A03B /* MessageWindowController.mm */,
-				A2DF37040C220D03006523C1 /* CreatorWindowController.h */,
-				A2DF37050C220D03006523C1 /* CreatorWindowController.mm */,
-				A25892620CF1F7E800CCCDDF /* StatsWindowController.h */,
-				A25892630CF1F7E800CCCDDF /* StatsWindowController.mm */,
-				A2085DD90C53BC74000BC3B7 /* AboutWindowController.h */,
-				A2085DDA0C53BC74000BC3B7 /* AboutWindowController.mm */,
-				A2F7CF5D13035FFD0016FF10 /* URLSheetWindowController.h */,
-				A2F7CF5E13035FFD0016FF10 /* URLSheetWindowController.mm */,
-				A2966E8513DAF74C007B52DF /* GlobalOptionsPopoverViewController.h */,
-				A2966E8613DAF74C007B52DF /* GlobalOptionsPopoverViewController.mm */,
-				C81E411027F5BA8300652F56 /* Compatibility */,
-				A234D0D40C79FB6000A82373 /* Additions */,
-				E1B6FBF80C0D719B0015FE4D /* Info Window */,
-				A26AF2220D2DA42800FF7140 /* File Outline View */,
-				E1B6FBFD0C0D72430015FE4D /* Prefs Window */,
-				E1B6FC000C0D72A00015FE4D /* Overlay Window */,
-				E138A9750C04D88F00C5426C /* ProgressGradients.h */,
-				E138A9760C04D88F00C5426C /* ProgressGradients.mm */,
-				A2E57AB91310822C00A7DAB1 /* StatusBarController.h */,
-				A2E57ABA1310822C00A7DAB1 /* StatusBarController.mm */,
-				A2E57BA513109E6B00A7DAB1 /* FilterBarController.h */,
-				A2E57BA613109E6B00A7DAB1 /* FilterBarController.mm */,
-				A2ED7D8D0CEF431B00970975 /* FilterButton.h */,
-				A2ED7D8E0CEF431B00970975 /* FilterButton.mm */,
-				A2C89D5F0CFCBF57004CC2BC /* ButtonToolbarItem.mm */,
-				A28E1DDF0CFFD8EC00E16385 /* ButtonToolbarItem.h */,
-				A225A4BE187E369C00CDE823 /* ShareToolbarItem.h */,
-				A225A4BF187E369C00CDE823 /* ShareToolbarItem.mm */,
-				A2B5B4E71880665E0071A66A /* ShareTorrentFileHelper.h */,
-				A2B5B4E81880665E0071A66A /* ShareTorrentFileHelper.mm */,
-				A21979890D07B78400438EA7 /* GroupToolbarItem.h */,
-				A219798A0D07B78400438EA7 /* GroupToolbarItem.mm */,
-				457AF8E928604AFC00BCF74F /* Toolbar.h */,
-				457AF8EA28604AFC00BCF74F /* Toolbar.mm */,
-				A22180960D148A71007D09ED /* GroupsPrefsController.h */,
-				A22180970D148A71007D09ED /* GroupsPrefsController.mm */,
-				45A7D3272843B54D00F0C32A /* GroupPopUpButtonCell.h */,
-				45A7D3282843B54D00F0C32A /* GroupPopUpButtonCell.mm */,
-				45A7D32A2843B55F00F0C32A /* PriorityPopUpButtonCell.h */,
-				45A7D32B2843B55F00F0C32A /* PriorityPopUpButtonCell.mm */,
-				A2FB701A0D95CAEA0001F331 /* GroupsController.h */,
-				A2FB701B0D95CAEA0001F331 /* GroupsController.mm */,
-				A2451E6616ACE4EB00586E0E /* FileRenameSheetController.h */,
-				A2451E6716ACE4EB00586E0E /* FileRenameSheetController.mm */,
-				A23F526D0F14395900AA02E3 /* PredicateEditorRowTemplateAny.h */,
-				A23F526E0F14395900AA02E3 /* PredicateEditorRowTemplateAny.mm */,
-				A222E9850E6B21D9009FB003 /* BlocklistDownloaderViewController.h */,
-				A222E9860E6B21D9009FB003 /* BlocklistDownloaderViewController.mm */,
-				ED86936D2ADAE34D00342B1A /* DefaultAppHelper.h */,
-				ED86936E2ADAE34D00342B1A /* DefaultAppHelper.mm */,
-				EDC749F72D98ADE200A12D0F /* PowerManager.h */,
-				EDC749F82D98AE2900A12D0F /* PowerManager.mm */,
-				ED9862952B979AA2002F3035 /* Utils.h */,
-				ED9862962B979AA2002F3035 /* Utils.mm */,
-				A2AB883916A399A6008FAD50 /* VDKQueue */,
+				29B97323FDCFA39411CA2CEA /* Frameworks */,
+				A2795C5828EFC6700002C8D9 /* public_html */,
+				A2CB38AE0E1E6896002B514C /* COPYING */,
 			);
 			name = Sources;
 			sourceTree = "<group>";
@@ -1942,9 +1337,8 @@
 			isa = PBXGroup;
 			children = (
 				ADD1A00000000000000000F9 /* libarchive */,
-				A22CEF9E21CDC44400C5C1BA /* Transmission.entitlements */,
-				4DDBB70A09E16B3200284745 /* GUI */,
-				ED5E0E992CD30E8F0071433B /* QuickLookExtension */,
+				080E96DDFE201D6D7F000001 /* Sources */,
+				0AD81ED4304EC83C00C22874 /* macosx */,
 				4D1838DC09DEC04A0047D688 /* libtransmission */,
 				4DDBB71F09E16BFE00284745 /* CLI */,
 				BEFC1C0B0C07754700B0BB3C /* daemon */,
@@ -1967,46 +1361,6 @@
 			sourceTree = "<group>";
 			usesTabs = 0;
 		};
-		29B97317FDCFA39411CA2CEA /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				A22A8D540AEEAFA5007E9CB9 /* Localizable.strings */,
-				A259316A0A73B2CC002F4FE7 /* TransmissionHelp */,
-				A2F8951E0A2D4BA500ED2127 /* Credits.rtf */,
-				A2CB38AE0E1E6896002B514C /* COPYING */,
-				4DE5CCCA0981D9BE00BE280E /* Defaults.plist */,
-				8D1107310486CEB800E47090 /* Info.plist */,
-				A2795C5828EFC6700002C8D9 /* public_html */,
-				089C165CFE840E0CC02AAC07 /* InfoPlist.strings */,
-				A23F50000D1D99D7002FCB97 /* MainMenu.xib */,
-				A23F4FF00D1D98AD002FCB97 /* PrefsWindow.xib */,
-				A29576010D11D63C0093B167 /* Creator.xib */,
-				A26AF27C0D2DBDDF00FF7140 /* AddWindow.xib */,
-				A21F1538117299F100CF5A9C /* AddMagnetWindow.xib */,
-				A215BF5B0F02EBB800350CDB /* GroupRules.xib */,
-				A233BD320D8C6585007EE7B4 /* MessageWindow.xib */,
-				A233BD680D8CF2C7007EE7B4 /* StatsWindow.xib */,
-				A231274B0D11D0B7003F9AFF /* AboutWindow.xib */,
-				A2E57AC51310831400A7DAB1 /* StatusBar.xib */,
-				A2E57B9B13109DC200A7DAB1 /* FilterBar.xib */,
-				A2F7CF5413035F7B0016FF10 /* URLSheetWindow.xib */,
-				A2D307B00D9EC9F50051FD27 /* BlocklistStatusWindow.xib */,
-				A209ECA1114319C3002B02D1 /* InfoWindow.xib */,
-				A209EAEA1142D294002B02D1 /* InfoGeneralView.xib */,
-				A209EAE81142D294002B02D1 /* InfoActivityView.xib */,
-				A209EB1F1142DD85002B02D1 /* InfoTrackersView.xib */,
-				A209EBA61142EAF3002B02D1 /* InfoPeersView.xib */,
-				A209EBD81142F52B002B02D1 /* InfoFileView.xib */,
-				A209EC11114301C6002B02D1 /* InfoOptionsView.xib */,
-				A220AF7913D7CC460035C512 /* GlobalOptionsPopover.xib */,
-				A2451E6816ACE4EB00586E0E /* FileRenameSheetController.xib */,
-				F63480621E1D7274005B9E09 /* Images.xcassets */,
-				4D043A7E090AE979009FEDA8 /* TransmissionDocument.icns */,
-				A267C2832E9F2B23003B87D7 /* Transmission_Tahoe.icon */,
-			);
-			name = Resources;
-			sourceTree = "<group>";
-		};
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -2016,7 +1370,6 @@
 				A2E669780F5B8E5A00B4251A /* Security.framework */,
 				A22CFB810FB66EF30009BD3E /* Carbon.framework */,
 				A221DCC7104B3660008A642D /* Quartz.framework */,
-				A24F19070A3A790800C9C145 /* Sparkle.framework */,
 				C0FFEE000000000000000016 /* IOKit.framework */,
 			);
 			name = Frameworks;
@@ -2216,17 +1569,6 @@
 			path = libtransmission;
 			sourceTree = "<group>";
 		};
-		4DDBB70A09E16B3200284745 /* GUI */ = {
-			isa = PBXGroup;
-			children = (
-				080E96DDFE201D6D7F000001 /* Sources */,
-				29B97317FDCFA39411CA2CEA /* Resources */,
-				29B97323FDCFA39411CA2CEA /* Frameworks */,
-			);
-			name = GUI;
-			path = macosx;
-			sourceTree = "<group>";
-		};
 		4DDBB71509E16B3F00284745 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
@@ -2261,51 +1603,6 @@
 			);
 			name = dht;
 			path = "third-party/dht";
-			sourceTree = "<group>";
-		};
-		A234D0D40C79FB6000A82373 /* Additions */ = {
-			isa = PBXGroup;
-			children = (
-				A29D84021049C25600D1987A /* NSApplicationAdditions.h */,
-				A29D84031049C25600D1987A /* NSApplicationAdditions.mm */,
-				C809AEE5291ECFD000BFDBE1 /* NSDataAdditions.h */,
-				C809AEE6291ECFD000BFDBE1 /* NSDataAdditions.mm */,
-				A234EA521453563B000F3E97 /* NSImageAdditions.h */,
-				A234EA531453563B000F3E97 /* NSImageAdditions.mm */,
-				C841A27F29197724009F18E8 /* NSKeyedUnarchiverAdditions.h */,
-				C841A28029197724009F18E8 /* NSKeyedUnarchiverAdditions.mm */,
-				A22BAE261388040500FB022F /* NSMutableArrayAdditions.h */,
-				A22BAE271388040500FB022F /* NSMutableArrayAdditions.mm */,
-				4DE5CC9B0980656F00BE280E /* NSStringAdditions.h */,
-				4DE5CC9C0980656F00BE280E /* NSStringAdditions.mm */,
-			);
-			name = Additions;
-			sourceTree = "<group>";
-		};
-		A26AF2220D2DA42800FF7140 /* File Outline View */ = {
-			isa = PBXGroup;
-			children = (
-				A26AF2180D2DA35A00FF7140 /* FileOutlineController.h */,
-				A26AF2190D2DA35A00FF7140 /* FileOutlineController.mm */,
-				A2AF1C360A3D0F6200F1575D /* FileOutlineView.h */,
-				A2AF1C370A3D0F6200F1575D /* FileOutlineView.mm */,
-				ED6F16AF2EB8F1EB007CD864 /* FileCheckCellView.h */,
-				ED6F16B02EB8F1EB007CD864 /* FileCheckCellView.mm */,
-				ED6F16B12EB8F1EB007CD864 /* BaseFileNameCellView.h */,
-				ED6F16B22EB8F1EB007CD864 /* BaseFileNameCellView.mm */,
-				ED6F16B32EB8F1EB007CD864 /* FilePriorityCellView.h */,
-				ED6F16B42EB8F1EB007CD864 /* FilePriorityCellView.mm */,
-			);
-			name = "File Outline View";
-			sourceTree = "<group>";
-		};
-		A2AB883916A399A6008FAD50 /* VDKQueue */ = {
-			isa = PBXGroup;
-			children = (
-				A2AB883B16A399A6008FAD50 /* VDKQueue.h */,
-				A2AB883C16A399A6008FAD50 /* VDKQueue.mm */,
-			);
-			path = VDKQueue;
 			sourceTree = "<group>";
 		};
 		A2E384BF130DFA49001F501B /* libutp */ = {
@@ -2570,14 +1867,6 @@
 			path = "third-party/libpsl";
 			sourceTree = "<group>";
 		};
-		C81E411027F5BA8300652F56 /* Compatibility */ = {
-			isa = PBXGroup;
-			children = (
-				C81E411127F5BABD00652F56 /* CocoaCompatibility.h */,
-			);
-			name = Compatibility;
-			sourceTree = "<group>";
-		};
 		C8734FB02B9EA39F00EF2AD9 /* src */ = {
 			isa = PBXGroup;
 			children = (
@@ -2621,82 +1910,6 @@
 				BE1183530CE160C50002D0F3 /* upnpreplyparse.h */,
 			);
 			path = include;
-			sourceTree = "<group>";
-		};
-		E1B6FBF80C0D719B0015FE4D /* Info Window */ = {
-			isa = PBXGroup;
-			children = (
-				A209EAC21142CF28002B02D1 /* InfoActivityViewController.h */,
-				A209EAC31142CF28002B02D1 /* InfoActivityViewController.mm */,
-				A209EBCC1142F2B4002B02D1 /* InfoFileViewController.h */,
-				A209EBCD1142F2B4002B02D1 /* InfoFileViewController.mm */,
-				A209EAC41142CF28002B02D1 /* InfoGeneralViewController.h */,
-				A209EAC51142CF28002B02D1 /* InfoGeneralViewController.mm */,
-				A209EBF71142FEEE002B02D1 /* InfoOptionsViewController.h */,
-				A209EBF81142FEEE002B02D1 /* InfoOptionsViewController.mm */,
-				A209EB9B1142E59A002B02D1 /* InfoPeersViewController.h */,
-				A209EB9C1142E59A002B02D1 /* InfoPeersViewController.mm */,
-				A263CFBE10DD67670038DE27 /* InfoTextField.h */,
-				A263CFBF10DD67670038DE27 /* InfoTextField.mm */,
-				A209EAFF1142D3A5002B02D1 /* InfoTrackersViewController.h */,
-				A209EB001142D3A5002B02D1 /* InfoTrackersViewController.mm */,
-				A247A442114C701800547DFC /* InfoViewController.h */,
-				A200B8390A2263BA007BBB1E /* InfoWindowController.h */,
-				A200B83A0A2263BA007BBB1E /* InfoWindowController.mm */,
-				A2A1CB770BF29D5500AE959F /* PeerProgressIndicatorCell.h */,
-				A2A1CB780BF29D5500AE959F /* PeerProgressIndicatorCell.mm */,
-				A257C17F0CAD3003004E121C /* PeerTableView.h */,
-				A257C1800CAD3003004E121C /* PeerTableView.mm */,
-				A2AA579A0ADFCAB400CA59F6 /* PiecesView.h */,
-				A2AA579B0ADFCAB400CA59F6 /* PiecesView.mm */,
-				A21A9D3F106EC2E800F1C3C1 /* TrackerCell.h */,
-				A21A9D40106EC2E800F1C3C1 /* TrackerCell.mm */,
-				A2725D5B0DE7507C003445E7 /* TrackerTableView.h */,
-				A2725D5C0DE7507C003445E7 /* TrackerTableView.mm */,
-				A2D7744F154CC25700A62B93 /* WebSeedTableView.h */,
-				A2D77450154CC25700A62B93 /* WebSeedTableView.mm */,
-			);
-			name = "Info Window";
-			sourceTree = "<group>";
-		};
-		E1B6FBFD0C0D72430015FE4D /* Prefs Window */ = {
-			isa = PBXGroup;
-			children = (
-				4D118E1808CB46B20033958F /* PrefsController.h */,
-				4D118E1908CB46B20033958F /* PrefsController.mm */,
-				A2710E740A86796000CE4F7D /* PrefsWindow.h */,
-				A2710E750A86796000CE4F7D /* PrefsWindow.mm */,
-				A29C8B340ACC6EB3000ED9F9 /* PortChecker.h */,
-				A29C8B350ACC6EB3000ED9F9 /* PortChecker.mm */,
-				A232F07C0EEA034A00041646 /* BonjourController.h */,
-				A232F07D0EEA034A00041646 /* BonjourController.mm */,
-			);
-			name = "Prefs Window";
-			sourceTree = "<group>";
-		};
-		E1B6FC000C0D72A00015FE4D /* Overlay Window */ = {
-			isa = PBXGroup;
-			children = (
-				A2385DD30BFE06C800B24EF6 /* DragOverlayWindow.h */,
-				A2385DD20BFE06C800B24EF6 /* DragOverlayWindow.mm */,
-				A2FB057C0BFEB6800095564D /* DragOverlayView.h */,
-				A2FB057D0BFEB6800095564D /* DragOverlayView.mm */,
-			);
-			name = "Overlay Window";
-			sourceTree = "<group>";
-		};
-		ED5E0E992CD30E8F0071433B /* QuickLookExtension */ = {
-			isa = PBXGroup;
-			children = (
-				ED5E0EF72CD315720071433B /* Localizable.strings */,
-				ED5E0EA12CD314FE0071433B /* style.css */,
-				ED5E0E942CD30E8F0071433B /* Info.plist */,
-				ED5E0E952CD30E8F0071433B /* PreviewProvider.h */,
-				ED5E0E962CD30E8F0071433B /* PreviewProvider.mm */,
-				ED5E0E972CD30E8F0071433B /* QuickLookExtension.entitlements */,
-			);
-			name = QuickLookExtension;
-			path = macosx/QuickLookExtension;
 			sourceTree = "<group>";
 		};
 		ED91F2682CBDA72C008388AA /* madler-crcany */ = {
@@ -2801,7 +2014,6 @@
 				A263C6B1F6718E2486DB20E0 /* tr-buffer.h in Headers */,
 				A23F29A1132A447400E9A83B /* announcer-common.h in Headers */,
 				A2EE726F14DCCC950093C99A /* port-forwarding-natpmp.h in Headers */,
-				A2D77451154CC25700A62B93 /* WebSeedTableView.h in Headers */,
 				A25BFD6E167BED3B0039D1AA /* variant.h in Headers */,
 				A2EA52321686AC0D00180493 /* quark.h in Headers */,
 				A2AF23C916B44FA0003BC59E /* log.h in Headers */,
@@ -2997,6 +2209,9 @@
 			dependencies = (
 				4D1838E609DEC1170047D688 /* PBXTargetDependency */,
 				ED5E0E8C2CD30B180071433B /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				0AD81ED4304EC83C00C22874 /* macosx */,
 			);
 			name = Transmission;
 			productInstallPath = "$(HOME)/Applications";
@@ -3308,6 +2523,8 @@
 				uk,
 				"zh-CN",
 				"zh-TW",
+				af,
+				el,
 			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* Transmission */;
 			preferredProjectObjectVersion = 77;
@@ -3342,38 +2559,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8D11072B0486CEB800E47090 /* InfoPlist.strings in Resources */,
-				4D043A7F090AE979009FEDA8 /* TransmissionDocument.icns in Resources */,
-				4DE5CCCB0981D9BE00BE280E /* Defaults.plist in Resources */,
-				A29B0C270BD15FEF0006F230 /* Credits.rtf in Resources */,
-				A259317E0A73B2CC002F4FE7 /* TransmissionHelp in Resources */,
-				A22A8D560AEEAFA5007E9CB9 /* Localizable.strings in Resources */,
-				A231274C0D11D0B7003F9AFF /* AboutWindow.xib in Resources */,
-				A29576030D11D63C0093B167 /* Creator.xib in Resources */,
-				A23F4FF20D1D98AD002FCB97 /* PrefsWindow.xib in Resources */,
-				A23F50020D1D99D7002FCB97 /* MainMenu.xib in Resources */,
-				A26AF27E0D2DBDDF00FF7140 /* AddWindow.xib in Resources */,
-				A233BD330D8C6585007EE7B4 /* MessageWindow.xib in Resources */,
-				A233BD690D8CF2C7007EE7B4 /* StatsWindow.xib in Resources */,
-				A2D307B10D9EC9F50051FD27 /* BlocklistStatusWindow.xib in Resources */,
 				A2CB38AF0E1E6896002B514C /* COPYING in Resources */,
-				A215BF5C0F02EBB800350CDB /* GroupRules.xib in Resources */,
-				A209EAEC1142D294002B02D1 /* InfoActivityView.xib in Resources */,
-				A209EAED1142D294002B02D1 /* InfoGeneralView.xib in Resources */,
-				A209EB201142DD85002B02D1 /* InfoTrackersView.xib in Resources */,
-				A267C2842E9F2B23003B87D7 /* Transmission_Tahoe.icon in Resources */,
-				A209EBA71142EAF3002B02D1 /* InfoPeersView.xib in Resources */,
-				A209EBD91142F52B002B02D1 /* InfoFileView.xib in Resources */,
-				A209EC12114301C6002B02D1 /* InfoOptionsView.xib in Resources */,
-				A209ECA2114319C3002B02D1 /* InfoWindow.xib in Resources */,
-				A21F15AD11729A9F00CF5A9C /* AddMagnetWindow.xib in Resources */,
-				A2F7CF5513035F7B0016FF10 /* URLSheetWindow.xib in Resources */,
-				A2E57AC61310831400A7DAB1 /* StatusBar.xib in Resources */,
-				A2E57B9C13109DC200A7DAB1 /* FilterBar.xib in Resources */,
-				A220AF7B13D7CC460035C512 /* GlobalOptionsPopover.xib in Resources */,
-				F63480631E1D7274005B9E09 /* Images.xcassets in Resources */,
 				A2795C5928EFC6700002C8D9 /* public_html in Resources */,
-				A2451E6A16ACE4EB00586E0E /* FileRenameSheetController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3381,8 +2568,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ED5E0EFA2CD315720071433B /* Localizable.strings in Resources */,
-				ED5E0EA22CD314FE0071433B /* style.css in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3620,85 +2805,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C86BCD9928228A9600F45599 /* SparkleProxy.mm in Sources */,
-				ED86936F2ADAE34D00342B1A /* DefaultAppHelper.mm in Sources */,
-				A225A4C0187E369C00CDE823 /* ShareToolbarItem.mm in Sources */,
-				A2D77453154CC72B00A62B93 /* WebSeedTableView.mm in Sources */,
-				8D11072D0486CEB800E47090 /* main.mm in Sources */,
-				45489C5629AF6FB20098A812 /* TorrentCellRevealButton.mm in Sources */,
-				4DF0C5AB0899190500DD8943 /* Controller.mm in Sources */,
-				4D118E1A08CB46B20033958F /* PrefsController.mm in Sources */,
-				4521532E29AF9D61009331B0 /* TorrentCell.mm in Sources */,
-				4D364DA0091FBB2C00377D12 /* TorrentTableView.mm in Sources */,
-				4DE5CC9D0980656F00BE280E /* NSStringAdditions.mm in Sources */,
-				4DE5CCA70980735700BE280E /* Badger.mm in Sources */,
-				4DFBC2DF09C0970D00D5C571 /* Torrent.mm in Sources */,
-				A200B9200A22798F007BBB1E /* InfoWindowController.mm in Sources */,
-				A2AF1C390A3D0F6200F1575D /* FileOutlineView.mm in Sources */,
-				A2710E770A86796000CE4F7D /* PrefsWindow.mm in Sources */,
-				A256588D0A9A695400E8A03B /* MessageWindowController.mm in Sources */,
-				A29C8B370ACC6EB3000ED9F9 /* PortChecker.mm in Sources */,
-				A2AA579D0ADFCAB400CA59F6 /* PiecesView.mm in Sources */,
-				A25E74650AF5097C006F11AE /* ExpandedPathToPathTransformer.mm in Sources */,
-				A25E74660AF5097D006F11AE /* ExpandedPathToIconTransformer.mm in Sources */,
-				A2A1CB7A0BF29D5500AE959F /* PeerProgressIndicatorCell.mm in Sources */,
-				457AF8EB28604AFC00BCF74F /* Toolbar.mm in Sources */,
-				A2385DD40BFE06C800B24EF6 /* DragOverlayWindow.mm in Sources */,
-				A2FB057F0BFEB6800095564D /* DragOverlayView.mm in Sources */,
-				E138A9780C04D88F00C5426C /* ProgressGradients.mm in Sources */,
-				ED6F16B52EB8F1EB007CD864 /* BaseFileNameCellView.mm in Sources */,
-				ED6F16B62EB8F1EB007CD864 /* FilePriorityCellView.mm in Sources */,
-				ED6F16B72EB8F1EB007CD864 /* FileCheckCellView.mm in Sources */,
-				A2DF37070C220D03006523C1 /* CreatorWindowController.mm in Sources */,
-				A2085DDC0C53BC74000BC3B7 /* AboutWindowController.mm in Sources */,
-				A257C1820CAD3003004E121C /* PeerTableView.mm in Sources */,
-				45489C5429AF6FB20098A812 /* TorrentCellActionButton.mm in Sources */,
-				A2A6321B0CD9751700E3DA60 /* BadgeView.mm in Sources */,
-				A2ED7D8F0CEF431B00970975 /* FilterButton.mm in Sources */,
-				45A7D32C2843B55F00F0C32A /* PriorityPopUpButtonCell.mm in Sources */,
-				A25892640CF1F7E800CCCDDF /* StatsWindowController.mm in Sources */,
-				EDC749F92D98AE3000A12D0F /* PowerManager.mm in Sources */,
-				A2C89D600CFCBF57004CC2BC /* ButtonToolbarItem.mm in Sources */,
-				A219798B0D07B78400438EA7 /* GroupToolbarItem.mm in Sources */,
-				4521532B29AF891F009331B0 /* GroupCell.mm in Sources */,
-				C841A28129197724009F18E8 /* NSKeyedUnarchiverAdditions.mm in Sources */,
-				A22180980D148A71007D09ED /* GroupsPrefsController.mm in Sources */,
-				A26AF21A0D2DA35A00FF7140 /* FileOutlineController.mm in Sources */,
-				A26AF2840D2DC27C00FF7140 /* AddWindowController.mm in Sources */,
-				A2FB701C0D95CAEA0001F331 /* GroupsController.mm in Sources */,
-				45A7D3292843B54D00F0C32A /* GroupPopUpButtonCell.mm in Sources */,
-				A2725B6E0DE5C4F5003445E7 /* FileListNode.mm in Sources */,
-				4559D21629B32623004EFDF0 /* ProgressBarView.mm in Sources */,
-				A2725D5D0DE7507C003445E7 /* TrackerTableView.mm in Sources */,
-				A28F4F770E085BDC003A3882 /* ColorTextField.mm in Sources */,
-				A27F0F330E19AD9800B2DB97 /* TorrentGroup.mm in Sources */,
-				45489C5729AF6FB20098A812 /* TorrentCellControlButton.mm in Sources */,
-				C809AEE7291ECFD000BFDBE1 /* NSDataAdditions.mm in Sources */,
-				A222E9870E6B21D9009FB003 /* BlocklistDownloaderViewController.mm in Sources */,
-				A232F07E0EEA034A00041646 /* BonjourController.mm in Sources */,
-				A23F526F0F14395900AA02E3 /* PredicateEditorRowTemplateAny.mm in Sources */,
-				A29D84041049C25600D1987A /* NSApplicationAdditions.mm in Sources */,
-				A21A9BE2106D86A800F1C3C1 /* TrackerNode.mm in Sources */,
-				A21A9D41106EC2E800F1C3C1 /* TrackerCell.mm in Sources */,
-				A263CFC010DD67670038DE27 /* InfoTextField.mm in Sources */,
-				A209EAC61142CF28002B02D1 /* InfoActivityViewController.mm in Sources */,
-				A209EAC71142CF28002B02D1 /* InfoGeneralViewController.mm in Sources */,
-				A209EB011142D3A5002B02D1 /* InfoTrackersViewController.mm in Sources */,
-				A209EB9D1142E59A002B02D1 /* InfoPeersViewController.mm in Sources */,
-				A209EBCE1142F2B4002B02D1 /* InfoFileViewController.mm in Sources */,
-				A209EBF91142FEEE002B02D1 /* InfoOptionsViewController.mm in Sources */,
-				ED9862972B979AA2002F3035 /* Utils.mm in Sources */,
-				A21F15AC11729A8B00CF5A9C /* AddMagnetWindowController.mm in Sources */,
-				A2F7CF5F13035FFD0016FF10 /* URLSheetWindowController.mm in Sources */,
-				A2E57ABB1310822C00A7DAB1 /* StatusBarController.mm in Sources */,
-				A2E57BA713109E6B00A7DAB1 /* FilterBarController.mm in Sources */,
-				A2B5B4E91880665E0071A66A /* ShareTorrentFileHelper.mm in Sources */,
-				A22BAE281388040500FB022F /* NSMutableArrayAdditions.mm in Sources */,
-				A2966E8713DAF74C007B52DF /* GlobalOptionsPopoverViewController.mm in Sources */,
-				A234EA541453563B000F3E97 /* NSImageAdditions.mm in Sources */,
-				A2AB883E16A399A6008FAD50 /* VDKQueue.mm in Sources */,
-				4534164229B0EA8600F544C9 /* SmallTorrentCell.mm in Sources */,
-				A2451E6916ACE4EB00586E0E /* FileRenameSheetController.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3965,8 +3071,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ED5E0F0F2CD31BC20071433B /* NSStringAdditions.mm in Sources */,
-				ED5E0E9C2CD30E8F0071433B /* PreviewProvider.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4078,360 +3182,6 @@
 		};
 /* End PBXTargetDependency section */
 
-/* Begin PBXVariantGroup section */
-		089C165CFE840E0CC02AAC07 /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				A291477D0E195A0C00F60CB2 /* en */,
-				A27476FF0CC38EE6003CC76D /* es */,
-				A2EA8E3C0CC3C9830081201C /* fr */,
-				A223AA7E0D220CEB00840069 /* nl */,
-				A26AF1050D2855FC00FF7140 /* ru */,
-				A202FF5D0DDA9275009938FF /* it */,
-				A28393FD10D54A79005C0240 /* de */,
-				A2613F9811B3383200472893 /* pt-PT */,
-				A263C5671560A4210082A3D1 /* da */,
-				A2A9D11A187DD75200C52A1F /* tr */,
-				C1A6BB462B3E6ACE00C4A151 /* eu */,
-				C1A6BB472B3E6ADA00C4A151 /* he */,
-				C1A6BB482B3E6ADF00C4A151 /* hu */,
-				C1A6BB492B3E6AE800C4A151 /* ja */,
-				C1A6BB4A2B3E6AEE00C4A151 /* pl */,
-				C1A6BB4B2B3E6AF500C4A151 /* pt-BR */,
-				C1A6BB4C2B3E6AFC00C4A151 /* sv */,
-				C1A6BB4D2B3E6B0200C4A151 /* uk */,
-				C1A6BB4E2B3E6B0800C4A151 /* zh-CN */,
-				C1A6BB4F2B3E6B0D00C4A151 /* zh-TW */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
-		A209EAE81142D294002B02D1 /* InfoActivityView.xib */ = {
-			isa = PBXVariantGroup;
-			children = (
-				45F195EF28738F3400654B15 /* Base */,
-				45C688E22875B17A00A2EB25 /* da */,
-				45C688E32875B17C00A2EB25 /* nl */,
-				45C688E42875B17F00A2EB25 /* fr */,
-				45C688E52875B18200A2EB25 /* de */,
-				45C688E62875B18700A2EB25 /* it */,
-				45C688E72875B18A00A2EB25 /* pt-PT */,
-				45C688E82875B19000A2EB25 /* ru */,
-				45C688E92875B19200A2EB25 /* es */,
-				45C688EA2875B19500A2EB25 /* tr */,
-				C1A6BB992B3E6DBE00C4A151 /* eu */,
-				C1A6BB9A2B3E6DC000C4A151 /* he */,
-				C1A6BB9B2B3E6DC100C4A151 /* hu */,
-				C1A6BB9C2B3E6DC300C4A151 /* ja */,
-				C1A6BB9D2B3E6DC400C4A151 /* pl */,
-				C1A6BB9E2B3E6DC600C4A151 /* pt-BR */,
-				C1A6BB9F2B3E6DC700C4A151 /* sv */,
-				C1A6BBA02B3E6DC900C4A151 /* uk */,
-				C1A6BBA12B3E6DCA00C4A151 /* zh-CN */,
-				C1A6BBA22B3E6DCC00C4A151 /* zh-TW */,
-			);
-			name = InfoActivityView.xib;
-			sourceTree = "<group>";
-		};
-		A209EAEA1142D294002B02D1 /* InfoGeneralView.xib */ = {
-			isa = PBXVariantGroup;
-			children = (
-				45F195EE28738F3300654B15 /* Base */,
-				45C688D92875B05B00A2EB25 /* da */,
-				45C688DA2875B06000A2EB25 /* nl */,
-				45C688DB2875B06200A2EB25 /* fr */,
-				45C688DC2875B06400A2EB25 /* de */,
-				45C688DD2875B06700A2EB25 /* it */,
-				45C688DE2875B06900A2EB25 /* pt-PT */,
-				45C688DF2875B06D00A2EB25 /* ru */,
-				45C688E02875B06F00A2EB25 /* es */,
-				45C688E12875B07300A2EB25 /* tr */,
-				C1A6BB8F2B3E6DA200C4A151 /* eu */,
-				C1A6BB902B3E6DA500C4A151 /* he */,
-				C1A6BB912B3E6DA600C4A151 /* hu */,
-				C1A6BB922B3E6DA700C4A151 /* ja */,
-				C1A6BB932B3E6DA900C4A151 /* pl */,
-				C1A6BB942B3E6DAA00C4A151 /* pt-BR */,
-				C1A6BB952B3E6DAB00C4A151 /* sv */,
-				C1A6BB962B3E6DAD00C4A151 /* uk */,
-				C1A6BB972B3E6DAF00C4A151 /* zh-CN */,
-				C1A6BB982B3E6DB000C4A151 /* zh-TW */,
-			);
-			name = InfoGeneralView.xib;
-			sourceTree = "<group>";
-		};
-		A209EC11114301C6002B02D1 /* InfoOptionsView.xib */ = {
-			isa = PBXVariantGroup;
-			children = (
-				45F195F028738F3400654B15 /* Base */,
-				45C688EB2875B2BB00A2EB25 /* nl */,
-				45C688EC2875B2BE00A2EB25 /* da */,
-				45C688ED2875B2C000A2EB25 /* fr */,
-				45C688EE2875B2C200A2EB25 /* de */,
-				45C688EF2875B2C400A2EB25 /* it */,
-				45C688F02875B2C700A2EB25 /* pt-PT */,
-				45C688F12875B2CA00A2EB25 /* ru */,
-				45C688F22875B2CD00A2EB25 /* es */,
-				45C688F32875B2CF00A2EB25 /* tr */,
-				C1A6BBA32B3E6DDC00C4A151 /* eu */,
-				C1A6BBA42B3E6DDE00C4A151 /* he */,
-				C1A6BBA52B3E6DDF00C4A151 /* hu */,
-				C1A6BBA62B3E6DE000C4A151 /* ja */,
-				C1A6BBA72B3E6DE200C4A151 /* pl */,
-				C1A6BBA82B3E6DE300C4A151 /* pt-BR */,
-				C1A6BBA92B3E6DE500C4A151 /* sv */,
-				C1A6BBAA2B3E6DE600C4A151 /* uk */,
-				C1A6BBAB2B3E6DE800C4A151 /* zh-CN */,
-				C1A6BBAC2B3E6DEA00C4A151 /* zh-TW */,
-			);
-			name = InfoOptionsView.xib;
-			sourceTree = "<group>";
-		};
-		A215BF5B0F02EBB800350CDB /* GroupRules.xib */ = {
-			isa = PBXVariantGroup;
-			children = (
-				45F195ED28738F3300654B15 /* Base */,
-				45C688D02875ADF000A2EB25 /* da */,
-				45C688D12875ADF500A2EB25 /* de */,
-				45C688D22875ADF800A2EB25 /* it */,
-				45C688D32875ADFB00A2EB25 /* pt-PT */,
-				45C688D42875ADFE00A2EB25 /* ru */,
-				45C688D52875AE0100A2EB25 /* es */,
-				45C688D62875AE0500A2EB25 /* tr */,
-				45C688D72875AE0800A2EB25 /* fr */,
-				45C688D82875AE0C00A2EB25 /* nl */,
-				C1A6BB852B3E6D8100C4A151 /* eu */,
-				C1A6BB862B3E6D8300C4A151 /* he */,
-				C1A6BB872B3E6D8400C4A151 /* hu */,
-				C1A6BB882B3E6D8600C4A151 /* ja */,
-				C1A6BB892B3E6D8700C4A151 /* pl */,
-				C1A6BB8A2B3E6D8900C4A151 /* pt-BR */,
-				C1A6BB8B2B3E6D8A00C4A151 /* sv */,
-				C1A6BB8C2B3E6D8B00C4A151 /* uk */,
-				C1A6BB8D2B3E6D8D00C4A151 /* zh-CN */,
-				C1A6BB8E2B3E6D8F00C4A151 /* zh-TW */,
-			);
-			name = GroupRules.xib;
-			sourceTree = "<group>";
-		};
-		A21F1538117299F100CF5A9C /* AddMagnetWindow.xib */ = {
-			isa = PBXVariantGroup;
-			children = (
-				45F195EC28738F3200654B15 /* Base */,
-				45C688C72875AC7800A2EB25 /* da */,
-				45C688C82875AC7F00A2EB25 /* nl */,
-				45C688C92875AC8100A2EB25 /* fr */,
-				45C688CA2875AC8300A2EB25 /* de */,
-				45C688CB2875AC8700A2EB25 /* it */,
-				45C688CC2875AC8900A2EB25 /* pt-PT */,
-				45C688CD2875AC8D00A2EB25 /* ru */,
-				45C688CE2875AC8F00A2EB25 /* es */,
-				45C688CF2875AC9200A2EB25 /* tr */,
-				C1A6BB7B2B3E6D6200C4A151 /* eu */,
-				C1A6BB7C2B3E6D6400C4A151 /* he */,
-				C1A6BB7D2B3E6D6500C4A151 /* hu */,
-				C1A6BB7E2B3E6D6700C4A151 /* ja */,
-				C1A6BB7F2B3E6D6800C4A151 /* pl */,
-				C1A6BB802B3E6D6A00C4A151 /* pt-BR */,
-				C1A6BB812B3E6D6B00C4A151 /* sv */,
-				C1A6BB822B3E6D6D00C4A151 /* uk */,
-				C1A6BB832B3E6D6F00C4A151 /* zh-CN */,
-				C1A6BB842B3E6D7100C4A151 /* zh-TW */,
-			);
-			name = AddMagnetWindow.xib;
-			sourceTree = "<group>";
-		};
-		A220AF7913D7CC460035C512 /* GlobalOptionsPopover.xib */ = {
-			isa = PBXVariantGroup;
-			children = (
-				45F195F128738F3500654B15 /* Base */,
-				45C688F42875B3F000A2EB25 /* da */,
-				45C688F52875B3F400A2EB25 /* nl */,
-				45C688F62875B3F600A2EB25 /* fr */,
-				45C688F72875B3F800A2EB25 /* de */,
-				45C688F82875B3FB00A2EB25 /* it */,
-				45C688F92875B3FF00A2EB25 /* pt-PT */,
-				45C688FA2875B40300A2EB25 /* ru */,
-				45C688FB2875B40600A2EB25 /* es */,
-				45C688FC2875B40900A2EB25 /* tr */,
-				C1A6BBAD2B3E6E0900C4A151 /* eu */,
-				C1A6BBAE2B3E6E0B00C4A151 /* he */,
-				C1A6BBAF2B3E6E0C00C4A151 /* hu */,
-				C1A6BBB02B3E6E0E00C4A151 /* ja */,
-				C1A6BBB12B3E6E0F00C4A151 /* pl */,
-				C1A6BBB22B3E6E1000C4A151 /* pt-BR */,
-				C1A6BBB32B3E6E1200C4A151 /* sv */,
-				C1A6BBB42B3E6E1300C4A151 /* uk */,
-				C1A6BBB52B3E6E1600C4A151 /* zh-CN */,
-				C1A6BBB62B3E6E1A00C4A151 /* zh-TW */,
-			);
-			name = GlobalOptionsPopover.xib;
-			sourceTree = "<group>";
-		};
-		A22A8D540AEEAFA5007E9CB9 /* Localizable.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				A27477010CC38EE6003CC76D /* es */,
-				A2EA8E3E0CC3C9830081201C /* fr */,
-				A223AA800D220CEB00840069 /* nl */,
-				A26AF1070D2855FC00FF7140 /* ru */,
-				A202FF5F0DDA9275009938FF /* it */,
-				A291477F0E195A0C00F60CB2 /* en */,
-				A28393FF10D54A96005C0240 /* de */,
-				A2613F9911B3383200472893 /* pt-PT */,
-				A263C5661560A3CF0082A3D1 /* da */,
-				A2A9D119187DD75100C52A1F /* tr */,
-				C1A6BB3C2B3E69CB00C4A151 /* eu */,
-				C1A6BB3D2B3E6A0700C4A151 /* he */,
-				C1A6BB3E2B3E6A0F00C4A151 /* hu */,
-				C1A6BB3F2B3E6A1800C4A151 /* ja */,
-				C1A6BB402B3E6A2200C4A151 /* pl */,
-				C1A6BB412B3E6A2900C4A151 /* pt-BR */,
-				C1A6BB422B3E6A3000C4A151 /* sv */,
-				C1A6BB432B3E6A3A00C4A151 /* uk */,
-				C1A6BB442B3E6A3F00C4A151 /* zh-CN */,
-				C1A6BB452B3E6A4C00C4A151 /* zh-TW */,
-			);
-			name = Localizable.strings;
-			sourceTree = "<group>";
-		};
-		A23F4FF00D1D98AD002FCB97 /* PrefsWindow.xib */ = {
-			isa = PBXVariantGroup;
-			children = (
-				45F195E928738F3100654B15 /* Base */,
-				455C0939287767270003A078 /* nl */,
-				455C093A287767290003A078 /* da */,
-				455C093B2877672C0003A078 /* fr */,
-				455C093C2877672E0003A078 /* de */,
-				455C093D287767300003A078 /* it */,
-				455C093E287767320003A078 /* pt-PT */,
-				455C093F287767350003A078 /* ru */,
-				455C0940287767380003A078 /* es */,
-				455C09412877673A0003A078 /* tr */,
-				C1A6BB5D2B3E6CD600C4A151 /* eu */,
-				C1A6BB5E2B3E6CD800C4A151 /* he */,
-				C1A6BB5F2B3E6CDA00C4A151 /* hu */,
-				C1A6BB602B3E6CDB00C4A151 /* ja */,
-				C1A6BB612B3E6CDD00C4A151 /* pl */,
-				C1A6BB622B3E6CDF00C4A151 /* pt-BR */,
-				C1A6BB632B3E6CE000C4A151 /* sv */,
-				C1A6BB642B3E6CE200C4A151 /* uk */,
-				C1A6BB652B3E6CE400C4A151 /* zh-CN */,
-				C1A6BB662B3E6CE500C4A151 /* zh-TW */,
-			);
-			name = PrefsWindow.xib;
-			sourceTree = "<group>";
-		};
-		A23F50000D1D99D7002FCB97 /* MainMenu.xib */ = {
-			isa = PBXVariantGroup;
-			children = (
-				45F195E828738F3100654B15 /* Base */,
-				457DC1E1287392F800ED04C4 /* da */,
-				457DC1E2287392FD00ED04C4 /* nl */,
-				457DC1E32873930500ED04C4 /* fr */,
-				457DC1E42873930900ED04C4 /* de */,
-				457DC1E52873930D00ED04C4 /* it */,
-				457DC1E62873931100ED04C4 /* pt-PT */,
-				457DC1E72873931500ED04C4 /* ru */,
-				457DC1E82873931900ED04C4 /* es */,
-				457DC1E92873931E00ED04C4 /* tr */,
-				C1A6BB532B3E6C6600C4A151 /* eu */,
-				C1A6BB542B3E6C7900C4A151 /* he */,
-				C1A6BB552B3E6C8700C4A151 /* hu */,
-				C1A6BB562B3E6C8D00C4A151 /* ja */,
-				C1A6BB572B3E6C9000C4A151 /* pl */,
-				C1A6BB582B3E6C9300C4A151 /* pt-BR */,
-				C1A6BB592B3E6C9B00C4A151 /* sv */,
-				C1A6BB5A2B3E6C9C00C4A151 /* uk */,
-				C1A6BB5B2B3E6CA100C4A151 /* zh-CN */,
-				C1A6BB5C2B3E6CA300C4A151 /* zh-TW */,
-			);
-			name = MainMenu.xib;
-			sourceTree = "<group>";
-		};
-		A26AF27C0D2DBDDF00FF7140 /* AddWindow.xib */ = {
-			isa = PBXVariantGroup;
-			children = (
-				45F195EB28738F3200654B15 /* Base */,
-				45C688FD28762FBB00A2EB25 /* de */,
-				45C688FE28762FE700A2EB25 /* da */,
-				45C688FF28762FEC00A2EB25 /* nl */,
-				45C6890028762FEF00A2EB25 /* it */,
-				45C6890128762FF200A2EB25 /* fr */,
-				45C6890228762FF800A2EB25 /* pt-PT */,
-				45C6890328762FFD00A2EB25 /* ru */,
-				45C6890428762FFF00A2EB25 /* es */,
-				45C689052876300200A2EB25 /* tr */,
-				C1A6BB712B3E6D1000C4A151 /* eu */,
-				C1A6BB722B3E6D1200C4A151 /* he */,
-				C1A6BB732B3E6D1400C4A151 /* hu */,
-				C1A6BB742B3E6D1500C4A151 /* ja */,
-				C1A6BB752B3E6D1600C4A151 /* pl */,
-				C1A6BB762B3E6D1800C4A151 /* pt-BR */,
-				C1A6BB772B3E6D1900C4A151 /* sv */,
-				C1A6BB782B3E6D1B00C4A151 /* uk */,
-				C1A6BB792B3E6D1E00C4A151 /* zh-CN */,
-				C1A6BB7A2B3E6D2000C4A151 /* zh-TW */,
-			);
-			name = AddWindow.xib;
-			sourceTree = "<group>";
-		};
-		A29576010D11D63C0093B167 /* Creator.xib */ = {
-			isa = PBXVariantGroup;
-			children = (
-				45F195EA28738F3200654B15 /* Base */,
-				45C6890628763C2900A2EB25 /* da */,
-				45C6890728763C2E00A2EB25 /* nl */,
-				45C6890828763C3200A2EB25 /* fr */,
-				45C6890928763C3600A2EB25 /* de */,
-				45C6890A28763C3900A2EB25 /* it */,
-				45C6890B28763C3C00A2EB25 /* pt-PT */,
-				45C6890C28763C3F00A2EB25 /* ru */,
-				45C6890D28763C4300A2EB25 /* es */,
-				45C6890E28763C4600A2EB25 /* tr */,
-				C1A6BB672B3E6CF000C4A151 /* eu */,
-				C1A6BB682B3E6CF200C4A151 /* he */,
-				C1A6BB692B3E6CF300C4A151 /* hu */,
-				C1A6BB6A2B3E6CF500C4A151 /* ja */,
-				C1A6BB6B2B3E6CF600C4A151 /* pl */,
-				C1A6BB6C2B3E6CF800C4A151 /* pt-BR */,
-				C1A6BB6D2B3E6CFA00C4A151 /* sv */,
-				C1A6BB6E2B3E6CFC00C4A151 /* uk */,
-				C1A6BB6F2B3E6D0200C4A151 /* zh-CN */,
-				C1A6BB702B3E6D0300C4A151 /* zh-TW */,
-			);
-			name = Creator.xib;
-			sourceTree = "<group>";
-		};
-		ED5E0EF72CD315720071433B /* Localizable.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				ED5E0EF92CD315720071433B /* en */,
-				ED5E0EFC2CD3157E0071433B /* de */,
-				ED5E0EFD2CD3158A0071433B /* da */,
-				ED5E0EFE2CD315940071433B /* es */,
-				ED5E0EFF2CD315A90071433B /* eu */,
-				ED5E0F002CD315B10071433B /* fr */,
-				ED5E0F012CD315B90071433B /* he */,
-				ED5E0F022CD315C50071433B /* hu */,
-				ED5E0F032CD315CD0071433B /* it */,
-				ED5E0F042CD315D70071433B /* ja */,
-				ED5E0F052CD315E10071433B /* nl */,
-				ED5E0F062CD315EC0071433B /* pl */,
-				ED5E0F072CD315FE0071433B /* pt-PT */,
-				ED5E0F082CD316090071433B /* pt-BR */,
-				ED5E0F092CD3161C0071433B /* ru */,
-				ED5E0F0A2CD316240071433B /* sv */,
-				ED5E0F0B2CD3162E0071433B /* tr */,
-				ED5E0F0C2CD3163B0071433B /* uk */,
-				ED5E0F0D2CD316450071433B /* zh-CN */,
-				ED5E0F0E2CD3164D0071433B /* zh-TW */,
-			);
-			name = Localizable.strings;
-			sourceTree = "<group>";
-		};
-/* End PBXVariantGroup section */
-
 /* Begin XCBuildConfiguration section */
 		0053D3D30C86774200545606 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -4509,7 +3259,10 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CODE_SIGN_ENTITLEMENTS = macosx/Transmission.entitlements;
 				ENABLE_HARDENED_RUNTIME = YES;
-				FRAMEWORK_SEARCH_PATHS = macosx;
+				FRAMEWORK_SEARCH_PATHS = (
+					macosx,
+					"$(PROJECT_DIR)/macosx",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					.,
@@ -4780,7 +3533,10 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CODE_SIGN_ENTITLEMENTS = macosx/Transmission.entitlements;
 				ENABLE_HARDENED_RUNTIME = YES;
-				FRAMEWORK_SEARCH_PATHS = macosx;
+				FRAMEWORK_SEARCH_PATHS = (
+					macosx,
+					"$(PROJECT_DIR)/macosx",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					.,
@@ -5042,7 +3798,10 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CODE_SIGN_ENTITLEMENTS = macosx/Transmission.entitlements;
 				ENABLE_HARDENED_RUNTIME = YES;
-				FRAMEWORK_SEARCH_PATHS = macosx;
+				FRAMEWORK_SEARCH_PATHS = (
+					macosx,
+					"$(PROJECT_DIR)/macosx",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					.,


### PR DESCRIPTION
### 📝 Description

This PR migrates the virtual Xcode groups inside the `macosx/` directory into **File-System Synchronized Folders** (`PBXFileSystemSynchronizedRootGroup`), a native feature introduced in **Xcode 16**. 

Historically, tracking every single file with unique UUIDs inside `project.pbxproj` has been a major pain point, leading to constant merge hell. By adopting synchronized folders, the file system becomes the single source of truth for the macOS target.

### 🚀 Key Benefits for the Team

* **Eliminating "Merge Hell":** Creating, moving, or deleting files within the `macosx/` folder will now be handled directly via Finder/File System. It **will no longer modify or pollute** the monolithic `project.pbxproj` file, completely eliminating git conflicts for macOS developers on every rebase.
* **Isolated Changes:** libtransmission core contributors retain exclusive access to the underlying Xcode project file, while macOS-focused PRs remain strictly isolated.
* **Automation-Friendly:** Modern AI tools, scripts, and code generation tools can now freely create files on disk without risking `.xcodeproj` corruption.

### ⚠️ Caveats & Scope

1. **Scope Limitations:** To keep this PR highly reviewable and avoid a massive refactoring wave, this change **strictly touches the `macosx/` folder**. Legacy dependencies and third-party targets are left untouched for now.
2. **CMake Interaction:** Since the project relies on CMake, adding or removing files will still require standard updates to `CMakeLists.txt`. However, resolving conflicts in a human-readable CMake file is significantly easier than fixing a broken `project.pbxproj` XML structure.
3. **Compatibility:** This requires bumping the minimum project compatibility version to **Xcode 16**.

### ⚠️ Remaining Caveats for QuickLookExtension
Due to current layout limitations, `macosx/` is configured as a single synchronized root group. As a result, **any new file created under `macosx/QuickLookExtension/` will join the main app target by default, not the extension**, unless both target exception sets are manually edited in Xcode.

This physical layout separation and proper target decoupling is deferred to a dedicated follow-up task tracked in #364.

Closes #210
