### PR TITLE
refactor: add upper limit for incoming BT payload size

### DIFF
--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -113,6 +113,11 @@ public:
         read_bytes(nullptr, n_bytes);
     }
 
+    void read_buffer_discard()
+    {
+        read_buffer_discard(std::size(inbuf_));
+    }
+
     void read_bytes(void* bytes, size_t n_bytes);
 
     void read_uint8(uint8_t* setme)

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -762,7 +762,7 @@ private:
 
 // ---
 
-[[nodiscard]] constexpr bool is_message_length_correct(tr_torrent const& tor, uint8_t id, uint32_t len)
+[[nodiscard]] constexpr bool is_message_length_correct(tr_torrent const& tor, uint8_t const id, uint32_t const len)
 {
     switch (id) {
     case BtPeerMsgs::Choke:
@@ -771,12 +771,12 @@ private:
     case BtPeerMsgs::NotInterested:
     case BtPeerMsgs::FextHaveAll:
     case BtPeerMsgs::FextHaveNone:
-        return len == 1U;
+        return len == sizeof(id);
 
     case BtPeerMsgs::Have:
     case BtPeerMsgs::FextSuggest:
     case BtPeerMsgs::FextAllowedFast:
-        return len == 5U;
+        return len == sizeof(id) + sizeof(uint32_t /*piece*/);
 
     case BtPeerMsgs::Bitfield:
         if (tor.has_metainfo()) {
@@ -787,16 +787,16 @@ private:
     case BtPeerMsgs::Request:
     case BtPeerMsgs::Cancel:
     case BtPeerMsgs::FextReject:
-        return len == 13U;
+        return len == sizeof(id) + sizeof(uint32_t /*piece*/) + sizeof(uint32_t /*offset*/) + sizeof(uint32_t /*length*/);
 
     case BtPeerMsgs::Piece:
         return len <= sizeof(id) + sizeof(uint32_t /*piece*/) + sizeof(uint32_t /*offset*/) + tr_block_info::BlockSize;
 
     case BtPeerMsgs::DhtPort:
-        return len == 3U;
+        return len == sizeof(id) + sizeof(uint16_t /*port*/);
 
     case BtPeerMsgs::Ltep:
-        return len >= 2U;
+        return len >= sizeof(id) + sizeof(uint8_t /*ltep_msgid*/);
 
     default: // unrecognized message
         return false;

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1809,9 +1809,15 @@ ReadResult tr_peerMsgsImpl::can_read_impl(tr_peerIo* io)
 
 ReadState tr_peerMsgsImpl::can_read(tr_peerIo* io, void* vmsgs, size_t* piece)
 {
+    auto const msgs = static_cast<tr_peerMsgsImpl*>(vmsgs);
+    if (msgs->is_disconnecting()) {
+        io->read_buffer_discard();
+        return ReadState::Err;
+    }
+
     // Some errors (e.g. disk IO error) can immediately remove this peer from the peer mgr,
     // which will destroy this object if we don't keep it alive
-    auto const msgs = static_cast<tr_peerMsgsImpl*>(vmsgs)->shared_from_this();
+    auto const keep_alive = msgs->shared_from_this();
 
     auto ret = ReadState::Now;
     *piece = 0U;

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -808,7 +808,11 @@ private:
         return false;
     }
 
-    return len >= sizeof(id) && len <= MaxIncomingMsgBytes;
+    // IMPORTANT: Any branches with no upper bound checks MUST NOT
+    // return early in order for program execution to reach this line.
+    // N.B. Every caller ensures len >= sizeof(id), so we don't need
+    // to check that here.
+    return len <= MaxIncomingMsgBytes;
 }
 
 namespace protocol_send_message_helpers

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1388,17 +1388,7 @@ ReadResult tr_peerMsgsImpl::process_peer_message(uint8_t id, MessageReader& payl
             static_cast<int>(id),
             std::size(payload)));
 
-    if (!is_message_length_correct(tor_, id, sizeof(id) + std::size(payload))) {
-        logdbg(
-            this,
-            fmt::format(
-                "bad msg: '{:s}' ({:d}) with payload len {:d}",
-                BtPeerMsgs::debug_name(id),
-                static_cast<int>(id),
-                std::size(payload)));
-        publish(tr_peer_event::GotError(EMSGSIZE));
-        return { ReadState::Err, {} };
-    }
+    TR_ASSERT(is_message_length_correct(tor_, id, sizeof(id) + std::size(payload)));
 
     switch (id) {
     case BtPeerMsgs::Choke:
@@ -1764,6 +1754,18 @@ ReadResult tr_peerMsgsImpl::can_read_impl(tr_peerIo* io)
 
         io->read_uint8(&message_type);
         current_message_type = message_type;
+    }
+
+    if (!is_message_length_correct(tor_, *current_message_type, *current_message_len)) {
+        logdbg(
+            this,
+            fmt::format(
+                "bad msg: '{:s}' ({:d}) with len {:d}, disconnecting",
+                BtPeerMsgs::debug_name(*current_message_type),
+                static_cast<int>(*current_message_type),
+                *current_message_len));
+        disconnect_soon();
+        return { ReadState::Err, {} };
     }
 
     // read <payload>

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -170,6 +170,9 @@ auto constexpr Reject = 2;
 
 } // namespace MetadataMsgType
 
+// Arbitrary upper size limit to avoid memory exhaustion attacks.
+auto constexpr MaxIncomingMsgBytes = size_t{ 4U * 1024U * 1024U };
+
 auto constexpr MinChokePeriodSec = time_t{ 10 };
 
 // idle seconds before we send a keepalive
@@ -776,7 +779,10 @@ private:
         return len == 5U;
 
     case BtPeerMsgs::Bitfield:
-        return !tor.has_metainfo() || len == 1 + tr_bytes_needed(tor.piece_count());
+        if (tor.has_metainfo()) {
+            return len == sizeof(id) + tr_bytes_needed(tor.piece_count());
+        }
+        break;
 
     case BtPeerMsgs::Request:
     case BtPeerMsgs::Cancel:
@@ -796,6 +802,8 @@ private:
     default: // unrecognized message
         return false;
     }
+
+    return len <= MaxIncomingMsgBytes;
 }
 
 namespace protocol_send_message_helpers

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -762,7 +762,7 @@ private:
 
 // ---
 
-[[nodiscard]] constexpr bool is_message_length_correct(tr_torrent const& tor, uint8_t const id, uint32_t const len)
+[[nodiscard]] constexpr bool is_message_length_correct(tr_torrent const& tor, uint8_t const id, uint32_t const len) noexcept
 {
     switch (id) {
     case BtPeerMsgs::Choke:

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -802,7 +802,7 @@ private:
         return false;
     }
 
-    return len <= MaxIncomingMsgBytes;
+    return len >= sizeof(id) && len <= MaxIncomingMsgBytes;
 }
 
 namespace protocol_send_message_helpers

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -790,7 +790,10 @@ private:
         return len == sizeof(id) + sizeof(uint32_t /*piece*/) + sizeof(uint32_t /*offset*/) + sizeof(uint32_t /*length*/);
 
     case BtPeerMsgs::Piece:
-        return len <= sizeof(id) + sizeof(uint32_t /*piece*/) + sizeof(uint32_t /*offset*/) + tr_block_info::BlockSize;
+        {
+            auto constexpr HeaderLen = sizeof(id) + sizeof(uint32_t /*piece*/) + sizeof(uint32_t /*offset*/);
+            return len >= HeaderLen && len <= HeaderLen + tr_block_info::BlockSize;
+        }
 
     case BtPeerMsgs::DhtPort:
         return len == sizeof(id) + sizeof(uint16_t /*port*/);

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -790,8 +790,7 @@ private:
         return len == 13U;
 
     case BtPeerMsgs::Piece:
-        len -= sizeof(id) + sizeof(uint32_t /*piece*/) + sizeof(uint32_t /*offset*/);
-        return len <= tr_block_info::BlockSize;
+        return len <= sizeof(id) + sizeof(uint32_t /*piece*/) + sizeof(uint32_t /*offset*/) + tr_block_info::BlockSize;
 
     case BtPeerMsgs::DhtPort:
         return len == 3U;

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -647,6 +647,9 @@ private:
 
     tr_error_code_t client_got_block(std::span<uint8_t const> block_data, tr_block_index_t block);
     ReadResult read_piece_data(MessageReader& payload);
+
+    // Precondition: `payload` is a complete message body whose length
+    // can_read_impl() has already accepted for `id`.
     ReadResult process_peer_message(uint8_t id, MessageReader& payload);
 
     // ---

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1762,19 +1762,22 @@ ReadResult tr_peerMsgsImpl::can_read_impl(tr_peerIo* io)
         }
 
         io->read_uint8(&message_type);
-        current_message_type = message_type;
-    }
 
-    if (!is_message_length_correct(tor_, *current_message_type, *current_message_len)) {
-        logdbg(
-            this,
-            fmt::format(
-                "bad msg: '{:s}' ({:d}) with len {:d}, disconnecting",
-                BtPeerMsgs::debug_name(*current_message_type),
-                static_cast<int>(*current_message_type),
-                *current_message_len));
-        disconnect_soon();
-        return { ReadState::Err, {} };
+        // The header is complete, so the length can be checked
+        // before any payload is buffered.
+        if (!is_message_length_correct(tor_, message_type, *current_message_len)) {
+            logdbg(
+                this,
+                fmt::format(
+                    "bad msg: '{:s}' ({:d}) with len {:d}, disconnecting",
+                    BtPeerMsgs::debug_name(message_type),
+                    static_cast<int>(message_type),
+                    *current_message_len));
+            disconnect_soon();
+            return { ReadState::Err, {} };
+        }
+
+        current_message_type = message_type;
     }
 
     // read <payload>

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -799,7 +799,10 @@ private:
         return len == sizeof(id) + sizeof(uint16_t /*port*/);
 
     case BtPeerMsgs::Ltep:
-        return len >= sizeof(id) + sizeof(uint8_t /*ltep_msgid*/);
+        if (len < sizeof(id) + sizeof(uint8_t /*ltep_msgid*/)) {
+            return false;
+        }
+        break;
 
     default: // unrecognized message
         return false;


### PR DESCRIPTION
## Description

Incorporate an upper size limit for incoming BT messages into `is_message_length_correct`, currently arbitrarily chosen to be 4MiB. This is meant to prevent malicious peers from launching DoS attacks by exhausting the client's memory.

I've considered adding similar checks in peerIo code, but figured this isn't needed because the read buffer in peerIo never grows large:
1. Data in the peerIo read buffer is always moved into `tr_incoming::payload` soon after it was buffered.
2. The most number bytes buffered into peerIo at a time is limited by the connection's MTU.

I've also stopped using `tr_peer_event::GotError(EMSGSIZE)` because all the event handler code does is log and disconnecting the peer. Nothing concerns the swarm, yet the error details are obfuscated by the errno. I plan to remove the `GotError` event altogether in a future PR.

More details in the commit messages.

Notes: Implemented size limits on peer messages to guard against memory exhaustion.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
