### PR TITLE
perf: avoid re-allocating `have_` on bitfield msg

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1551,7 +1551,7 @@ ReadResult tr_peerMsgsImpl::process_peer_message(uint8_t id, MessageReader& payl
 
     case BtPeerMsgs::Bitfield:
         logtrace(this, "got a bitfield");
-        have_ = tr_bitfield{ tor_.has_metainfo() ? tor_.piece_count() : std::size(payload) * 8 };
+        have_.init_size(std::size(payload) * 8);
         {
             [[maybe_unused]] auto const set_raw_res = have_.set_raw(payload);
             TR_ASSERT(set_raw_res);


### PR DESCRIPTION
## Description

Simple perf improvement by re-using the existing bitfield object.

Extracted from #216.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
