### PR TITLE
fix(wishlist): prevent duplicate bitfields inflating replication

### DIFF
--- a/libtransmission/peer-common.h
+++ b/libtransmission/peer-common.h
@@ -60,6 +60,7 @@ public:
         ClientSentCancel,
         ClientSentPieceData,
         ClientSentRequest,
+        ClientStaleBitfield,
         Error // generic
     };
 
@@ -187,6 +188,14 @@ public:
         event.pieceIndex = loc_begin.piece;
         event.offset = loc_begin.piece_offset;
         event.length = loc_end.byte - loc_begin.byte;
+        return event;
+    }
+
+    [[nodiscard]] constexpr static auto StaleBitfield(tr_bitfield* bitfield) noexcept
+    {
+        auto event = tr_peer_event{};
+        event.type = Type::ClientStaleBitfield;
+        event.bitfield = bitfield;
         return event;
     }
 };

--- a/libtransmission/peer-mgr-wishlist.h
+++ b/libtransmission/peer-mgr-wishlist.h
@@ -120,6 +120,11 @@ public:
         inc_replication_bitfield(bitfield);
     }
 
+    constexpr void on_stale_bitfield(tr_bitfield const& bitfield)
+    {
+        dec_replication_bitfield(bitfield);
+    }
+
     constexpr void on_got_block(tr_block_index_t const block)
     {
         if (auto const iter = find_by_block(block); iter != std::end(candidates_)) {

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -386,6 +386,8 @@ public:
                       [this](tr_torrent*, tr_peer*, tr_block_index_t block) { wishlist_.on_sent_cancel(block); }),
                   swarm_.sent_request.connect_scoped(
                       [this](tr_torrent*, tr_peer*, tr_block_span_t block_span) { wishlist_.on_sent_request(block_span); }),
+                  swarm_.stale_bitfield.connect_scoped(
+                      [this](tr_torrent*, tr_bitfield const& bitfield) { wishlist_.on_stale_bitfield(bitfield); }),
                   tor_.sequential_download_changed_.connect_scoped(
                       [this](tr_torrent*, bool) { wishlist_.on_sequential_download_changed(); }),
                   tor_.sequential_download_from_piece_changed_.connect_scoped(
@@ -452,7 +454,7 @@ public:
         tr_torrent& tor_;
         tr_swarm& swarm_;
         Wishlist wishlist_;
-        std::array<sigslot::scoped_connection, 15U> signal_tags_; // depends-on: wishlist_
+        std::array<sigslot::scoped_connection, 16U> signal_tags_; // depends-on: wishlist_
     };
 
     [[nodiscard]] auto unique_lock() const
@@ -638,6 +640,10 @@ public:
             s->mark_all_upload_only_flag_dirty();
             break;
 
+        case tr_peer_event::Type::ClientStaleBitfield:
+            s->stale_bitfield(s->tor, msgs->has());
+            break;
+
         case tr_peer_event::Type::ClientGotChoke:
             s->got_choke(s->tor, msgs->active_requests);
             break;
@@ -700,6 +706,7 @@ public:
     sigslot::signal<tr_torrent*, tr_peer*, tr_block_index_t> got_reject;
     sigslot::signal<tr_torrent*, tr_peer*, tr_block_index_t> sent_cancel;
     sigslot::signal<tr_torrent*, tr_peer*, tr_block_span_t> sent_request;
+    sigslot::signal<tr_torrent*, tr_bitfield const&> stale_bitfield;
 
     mutable tr_swarm_stats stats = {};
 

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1551,6 +1551,9 @@ ReadResult tr_peerMsgsImpl::process_peer_message(uint8_t id, MessageReader& payl
 
     case BtPeerMsgs::Bitfield:
         logtrace(this, "got a bitfield");
+        if (!have_.has_none()) {
+            publish(tr_peer_event::StaleBitfield(&have_));
+        }
         have_ = tr_bitfield{ tor_.has_metainfo() ? tor_.piece_count() : std::size(payload) * 8 };
         {
             [[maybe_unused]] auto const set_raw_res = have_.set_raw(payload);
@@ -1649,6 +1652,9 @@ ReadResult tr_peerMsgsImpl::process_peer_message(uint8_t id, MessageReader& payl
         logtrace(this, "Got a BtPeerMsgs::FextHaveAll");
 
         if (fext) {
+            if (!have_.has_none()) {
+                publish(tr_peer_event::StaleBitfield(&have_));
+            }
             have_.set_has_all();
             peer_info->set_seed();
             publish(tr_peer_event::GotHaveAll());
@@ -1668,6 +1674,9 @@ ReadResult tr_peerMsgsImpl::process_peer_message(uint8_t id, MessageReader& payl
         logtrace(this, "Got a BtPeerMsgs::FextHaveNone");
 
         if (fext) {
+            if (!have_.has_none()) {
+                publish(tr_peer_event::StaleBitfield(&have_));
+            }
             have_.set_has_none();
             peer_info->set_seed(false);
             publish(tr_peer_event::GotHaveNone());

--- a/tests/libtransmission/peer-mgr-wishlist-test.cc
+++ b/tests/libtransmission/peer-mgr-wishlist-test.cc
@@ -719,6 +719,74 @@ TEST_F(PeerMgrWishlistTest, gotBitfieldIncrementsReplication)
     }
 }
 
+TEST_F(PeerMgrWishlistTest, staleBitfieldDecrementsReplication)
+{
+    auto const get_spans = [](size_t n_wanted) {
+        auto mediator = MockMediator{};
+
+        // setup: three pieces, all missing
+        mediator.block_span_[0] = { .begin = 0, .end = 100 };
+        mediator.block_span_[1] = { .begin = 100, .end = 200 };
+        mediator.block_span_[2] = { .begin = 200, .end = 300 };
+
+        // and we want everything
+        for (tr_piece_index_t i = 0; i < mediator.piece_count(); ++i) {
+            mediator.client_wants_piece_.insert(i);
+        }
+
+        // all pieces had the same rarity
+        mediator.piece_replication_[0] = 2;
+        mediator.piece_replication_[1] = 2;
+        mediator.piece_replication_[2] = 2;
+
+        // allow the wishlist to build its cache
+        auto wishlist = Wishlist{ mediator };
+
+        // a peer that has only the first piece sent a duplicated
+        // bitfield message. We need to undo the bookkeeping from
+        // the previous bitfield message.
+        auto have = tr_bitfield{ 3 };
+        have.set(0);
+        wishlist.on_stale_bitfield(have);
+
+        // this is what a real mediator should return at this point:
+        // mediator.piece_replication_[0] = 1;
+
+        return wishlist.next(n_wanted, PeerHasAllPieces);
+    };
+
+    // wishlist prefers to request rarer pieces, so it
+    // should pick the ones with the smallest replication.
+    // NB: when all other things are equal in the wishlist, pieces are
+    // picked at random so this test -could- pass even if there's a bug.
+    // So test several times to shake out any randomness
+    static auto constexpr NumRuns = 1000;
+    for (int run = 0; run < NumRuns; ++run) {
+        auto const spans = get_spans(100);
+        auto requested = tr_bitfield{ 300 };
+        for (auto const& [begin, end] : spans) {
+            requested.set_span(begin, end);
+        }
+        EXPECT_EQ(100U, requested.count());
+        EXPECT_EQ(100U, requested.count(0, 100));
+        EXPECT_EQ(0U, requested.count(100, 300));
+    }
+
+    // Same premise as previous test, but ask for more blocks.
+    // Since the second and third piece are the second-rarest,
+    // those blocks should be next in line.
+    for (int run = 0; run < NumRuns; ++run) {
+        auto const spans = get_spans(150);
+        auto requested = tr_bitfield{ 300 };
+        for (auto const& [begin, end] : spans) {
+            requested.set_span(begin, end);
+        }
+        EXPECT_EQ(150U, requested.count());
+        EXPECT_EQ(100U, requested.count(0, 100));
+        EXPECT_EQ(50U, requested.count(100, 300));
+    }
+}
+
 TEST_F(PeerMgrWishlistTest, sentRequestsResortsPiece)
 {
     auto const get_spans = [](size_t n_wanted) {


### PR DESCRIPTION
## Description

Each peer should send exactly one of `bitfield`, `have all`, or `have none` immediately after the BitTorrent handshake.

However, to defend against clients that send these messages more than once, we decrement the piece replication using the old bitfield before accepting the new bitfield.

Notes: Added defense against peers that send duplicated bitfield messages.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
