### PR TITLE
perf: shrink FileListNode with a class cluster

### DIFF
--- a/macosx/FileListNode.h
+++ b/macosx/FileListNode.h
@@ -14,24 +14,23 @@
 @property(nonatomic, weak, readonly) Torrent* torrent;
 
 @property(nonatomic, readonly) uint64_t size;
-@property(nonatomic, readonly) NSImage* icon;
 @property(nonatomic, readonly) BOOL isFolder;
 @property(nonatomic, readonly) NSMutableArray<FileListNode*>* children;
 
 @property(nonatomic, readonly) NSIndexSet* indexes;
 
-- (instancetype)initWithFolderName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent;
-- (instancetype)initWithFileName:(NSString*)name
-                            path:(NSString*)path
-                            size:(uint64_t)size
-                           index:(NSUInteger)index
-                         torrent:(Torrent*)torrent;
-
 - (void)insertChild:(FileListNode*)child;
 - (void)insertIndex:(NSUInteger)index withSize:(uint64_t)size;
 
-@property(nonatomic, readonly) NSString* description;
-
 - (BOOL)updateFromOldName:(NSString*)oldName toNewName:(NSString*)newName inPath:(NSString*)path;
 
+@end
+
+@interface FileListNode (Creation)
++ (instancetype)createWithFolderName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent;
++ (instancetype)createWithFileName:(NSString*)name
+                              path:(NSString*)path
+                              size:(uint64_t)size
+                             index:(NSUInteger)index
+                           torrent:(Torrent*)torrent;
 @end

--- a/macosx/FileListNode.mm
+++ b/macosx/FileListNode.mm
@@ -10,52 +10,37 @@
 
 #import "FileListNode.h"
 
-@interface FileListNode ()
+@interface FileListNode () {
+  @protected
+    uint64_t _size;
+}
+- (instancetype)initWithName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent size:(uint64_t)size;
+@end
 
-@property(nonatomic, readonly) NSMutableIndexSet* indexesInternal;
-@property(nonatomic) NSImage* iconInternal;
+@interface OnlyFileListNode : FileListNode {
+    NSIndexSet* _indexesInternal;
+}
+@end
 
+@interface OnlyFolderListNode : FileListNode {
+    NSMutableIndexSet* _indexesInternal;
+    NSMutableArray* _childrenInternal;
+}
 @end
 
 @implementation FileListNode
 
-- (instancetype)initWithFolderName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent
+- (NSMutableArray<FileListNode*>*)children
 {
-    if ((self = [self initWithFolder:YES name:name path:path torrent:torrent])) {
-        _children = [[NSMutableArray alloc] init];
-        _size = 0;
-    }
-
-    return self;
-}
-
-- (instancetype)initWithFileName:(NSString*)name
-                            path:(NSString*)path
-                            size:(uint64_t)size
-                           index:(NSUInteger)index
-                         torrent:(Torrent*)torrent
-{
-    if ((self = [self initWithFolder:NO name:name path:path torrent:torrent])) {
-        _size = size;
-        [_indexesInternal addIndex:index];
-    }
-
-    return self;
+    return nil;
 }
 
 - (void)insertChild:(FileListNode*)child
 {
-    NSAssert(_isFolder, @"method can only be invoked on folders");
-
-    [_children addObject:child];
 }
 
 - (void)insertIndex:(NSUInteger)index withSize:(uint64_t)size
 {
-    NSAssert(_isFolder, @"method can only be invoked on folders");
-
-    [self.indexesInternal addIndex:index];
-    _size += size;
 }
 
 - (id)copyWithZone:(NSZone*)zone
@@ -66,25 +51,17 @@
 
 - (NSString*)description
 {
-    if (!_isFolder) {
-        return [NSString stringWithFormat:@"%@ (%ld)", _name, _indexesInternal.firstIndex];
-    } else {
-        return [NSString stringWithFormat:@"%@ (folder: %@)", _name, _indexesInternal];
-    }
+    return @"";
 }
 
-- (NSImage*)icon
+- (BOOL)isFolder
 {
-    if (!_iconInternal) {
-        _iconInternal = [NSWorkspace.sharedWorkspace
-            iconForFileType:_isFolder ? NSFileTypeForHFSTypeCode(kGenericFolderIcon) : _name.pathExtension];
-    }
-    return _iconInternal;
+    return NO;
 }
 
 - (NSIndexSet*)indexes
 {
-    return _indexesInternal;
+    return nil;
 }
 
 - (BOOL)updateFromOldName:(NSString*)oldName toNewName:(NSString*)newName inPath:(NSString*)path
@@ -100,7 +77,6 @@
     {
         if ([oldName isEqualToString:self.name]) {
             _name = [newName copy];
-            _iconInternal = nil;
             return YES;
         }
     } else if (lookupPathComponents.count < thesePathComponents.count) //what's being renamed is part of this node's path
@@ -126,19 +102,112 @@
 
 #pragma mark - Private
 
-- (instancetype)initWithFolder:(BOOL)isFolder name:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent
+- (instancetype)initWithName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent size:(uint64_t)size
 {
     if ((self = [super init])) {
-        _isFolder = isFolder;
         _name = [name copy];
         _path = [path copy];
-
-        _indexesInternal = [[NSMutableIndexSet alloc] init];
-
         _torrent = torrent;
+        _size = size;
     }
 
     return self;
 }
 
+@end
+
+@implementation OnlyFileListNode
+
+- (instancetype)initWithFileName:(NSString*)name
+                            path:(NSString*)path
+                            size:(uint64_t)size
+                           index:(NSUInteger)index
+                         torrent:(Torrent*)torrent
+{
+    if ((self = [super initWithName:name path:path torrent:torrent size:size])) {
+        _indexesInternal = [NSIndexSet indexSetWithIndex:index];
+    }
+    return self;
+}
+
+- (NSIndexSet*)indexes
+{
+    return _indexesInternal;
+}
+
+- (void)insertChild:(FileListNode*)child
+{
+    NSAssert(NO, @"method can only be invoked on folders");
+}
+
+- (void)insertIndex:(NSUInteger)index withSize:(uint64_t)size
+{
+    NSAssert(NO, @"method can only be invoked on folders");
+}
+
+- (NSString*)description
+{
+    return [NSString stringWithFormat:@"%@ (%ld)", self.name, _indexesInternal.firstIndex];
+}
+
+@end
+
+@implementation OnlyFolderListNode
+
+- (instancetype)initWithFolderName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent
+{
+    if ((self = [super initWithName:name path:path torrent:torrent size:0])) {
+        _indexesInternal = [[NSMutableIndexSet alloc] init];
+        _childrenInternal = [[NSMutableArray alloc] init];
+    }
+    return self;
+}
+
+- (BOOL)isFolder
+{
+    return YES;
+}
+
+- (NSIndexSet*)indexes
+{
+    return _indexesInternal;
+}
+
+- (NSMutableArray<FileListNode*>*)children
+{
+    return _childrenInternal;
+}
+
+- (void)insertChild:(FileListNode*)child
+{
+    [_childrenInternal addObject:child];
+}
+
+- (void)insertIndex:(NSUInteger)index withSize:(uint64_t)size
+{
+    [_indexesInternal addIndex:index];
+    _size += size;
+}
+
+- (NSString*)description
+{
+    return [NSString stringWithFormat:@"%@ (folder: %@)", self.name, _indexesInternal];
+}
+
+@end
+
+@implementation FileListNode (Creation)
++ (instancetype)createWithFolderName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent
+{
+    return [[OnlyFolderListNode alloc] initWithFolderName:name path:path torrent:torrent];
+}
+
++ (instancetype)createWithFileName:(NSString*)name
+                              path:(NSString*)path
+                              size:(uint64_t)size
+                             index:(NSUInteger)index
+                           torrent:(Torrent*)torrent
+{
+    return [[OnlyFileListNode alloc] initWithFileName:name path:path size:size index:index torrent:torrent];
+}
 @end

--- a/macosx/FileListNode.mm
+++ b/macosx/FileListNode.mm
@@ -2,30 +2,33 @@
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
-#if __has_feature(modules)
-@import AppKit;
-#else
-#import <AppKit/AppKit.h>
-#endif
-
 #import "FileListNode.h"
 
 @interface FileListNode () {
   @protected
     uint64_t _size;
-}
-- (instancetype)initWithName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent size:(uint64_t)size;
-@end
-
-@interface OnlyFileListNode : FileListNode {
     NSIndexSet* _indexesInternal;
 }
+- (instancetype)initWithName:(NSString*)name
+                        path:(NSString*)path
+                     torrent:(Torrent*)torrent
+                        size:(uint64_t)size
+                     indexes:(NSIndexSet*)indexes;
 @end
 
-@interface OnlyFolderListNode : FileListNode {
-    NSMutableIndexSet* _indexesInternal;
-    NSMutableArray* _childrenInternal;
+@interface FileListFileNode : FileListNode
+- (instancetype)initWithFileName:(NSString*)name
+                            path:(NSString*)path
+                            size:(uint64_t)size
+                           index:(NSUInteger)index
+                         torrent:(Torrent*)torrent;
+@end
+
+@interface FileListFolderNode : FileListNode {
+    NSMutableArray<FileListNode*>* _childrenInternal;
 }
+
+- (instancetype)initWithFolderName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent;
 @end
 
 @implementation FileListNode
@@ -37,10 +40,12 @@
 
 - (void)insertChild:(FileListNode*)child
 {
+    [self doesNotRecognizeSelector:_cmd];
 }
 
 - (void)insertIndex:(NSUInteger)index withSize:(uint64_t)size
 {
+    [self doesNotRecognizeSelector:_cmd];
 }
 
 - (id)copyWithZone:(NSZone*)zone
@@ -61,7 +66,7 @@
 
 - (NSIndexSet*)indexes
 {
-    return nil;
+    return _indexesInternal;
 }
 
 - (BOOL)updateFromOldName:(NSString*)oldName toNewName:(NSString*)newName inPath:(NSString*)path
@@ -102,13 +107,18 @@
 
 #pragma mark - Private
 
-- (instancetype)initWithName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent size:(uint64_t)size
+- (instancetype)initWithName:(NSString*)name
+                        path:(NSString*)path
+                     torrent:(Torrent*)torrent
+                        size:(uint64_t)size
+                     indexes:(NSIndexSet*)indexes
 {
     if ((self = [super init])) {
         _name = [name copy];
         _path = [path copy];
         _torrent = torrent;
         _size = size;
+        _indexesInternal = indexes;
     }
 
     return self;
@@ -116,7 +126,7 @@
 
 @end
 
-@implementation OnlyFileListNode
+@implementation FileListFileNode
 
 - (instancetype)initWithFileName:(NSString*)name
                             path:(NSString*)path
@@ -124,25 +134,7 @@
                            index:(NSUInteger)index
                          torrent:(Torrent*)torrent
 {
-    if ((self = [super initWithName:name path:path torrent:torrent size:size])) {
-        _indexesInternal = [NSIndexSet indexSetWithIndex:index];
-    }
-    return self;
-}
-
-- (NSIndexSet*)indexes
-{
-    return _indexesInternal;
-}
-
-- (void)insertChild:(FileListNode*)child
-{
-    NSAssert(NO, @"method can only be invoked on folders");
-}
-
-- (void)insertIndex:(NSUInteger)index withSize:(uint64_t)size
-{
-    NSAssert(NO, @"method can only be invoked on folders");
+    return [self initWithName:name path:path torrent:torrent size:size indexes:[NSIndexSet indexSetWithIndex:index]];
 }
 
 - (NSString*)description
@@ -152,12 +144,11 @@
 
 @end
 
-@implementation OnlyFolderListNode
+@implementation FileListFolderNode
 
 - (instancetype)initWithFolderName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent
 {
-    if ((self = [super initWithName:name path:path torrent:torrent size:0])) {
-        _indexesInternal = [[NSMutableIndexSet alloc] init];
+    if ((self = [super initWithName:name path:path torrent:torrent size:0 indexes:[[NSMutableIndexSet alloc] init]])) {
         _childrenInternal = [[NSMutableArray alloc] init];
     }
     return self;
@@ -166,11 +157,6 @@
 - (BOOL)isFolder
 {
     return YES;
-}
-
-- (NSIndexSet*)indexes
-{
-    return _indexesInternal;
 }
 
 - (NSMutableArray<FileListNode*>*)children
@@ -185,7 +171,7 @@
 
 - (void)insertIndex:(NSUInteger)index withSize:(uint64_t)size
 {
-    [_indexesInternal addIndex:index];
+    [(NSMutableIndexSet*)_indexesInternal addIndex:index];
     _size += size;
 }
 
@@ -199,7 +185,7 @@
 @implementation FileListNode (Creation)
 + (instancetype)createWithFolderName:(NSString*)name path:(NSString*)path torrent:(Torrent*)torrent
 {
-    return [[OnlyFolderListNode alloc] initWithFolderName:name path:path torrent:torrent];
+    return [[FileListFolderNode alloc] initWithFolderName:name path:path torrent:torrent];
 }
 
 + (instancetype)createWithFileName:(NSString*)name
@@ -208,6 +194,6 @@
                              index:(NSUInteger)index
                            torrent:(Torrent*)torrent
 {
-    return [[OnlyFileListNode alloc] initWithFileName:name path:path size:size index:index torrent:torrent];
+    return [[FileListFileNode alloc] initWithFileName:name path:path size:size index:index torrent:torrent];
 }
 @end

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -1796,7 +1796,7 @@ static tr_torrent_rename_done_func makeRenameDoneCallback(NSDictionary* contextI
             }
 
             if (!tempNode) {
-                tempNode = [[FileListNode alloc] initWithFolderName:pathComponents[0] path:@"" torrent:self];
+                tempNode = [FileListNode createWithFolderName:pathComponents[0] path:@"" torrent:self];
             }
 
             [self insertPathForComponents:pathComponents //
@@ -1813,7 +1813,7 @@ static tr_torrent_rename_done_func makeRenameDoneCallback(NSDictionary* contextI
         self.fileList = [[NSArray alloc] initWithArray:tempNode.children];
         self.flatFileList = [[NSArray alloc] initWithArray:flatFileList];
     } else {
-        FileListNode* node = [[FileListNode alloc] initWithFileName:self.name path:@"" size:self.size index:0 torrent:self];
+        FileListNode* node = [FileListNode createWithFileName:self.name path:@"" size:self.size index:0 torrent:self];
         self.fileList = @[ node ];
         self.flatFileList = self.fileList;
     }
@@ -1848,9 +1848,9 @@ static tr_torrent_rename_done_func makeRenameDoneCallback(NSDictionary* contextI
     if (!node) {
         NSString* path = [parent.path stringByAppendingPathComponent:parent.name];
         if (isFolder) {
-            node = [[FileListNode alloc] initWithFolderName:name path:path torrent:self];
+            node = [FileListNode createWithFolderName:name path:path torrent:self];
         } else {
-            node = [[FileListNode alloc] initWithFileName:name path:path size:size index:index torrent:self];
+            node = [FileListNode createWithFileName:name path:path size:size index:index torrent:self];
             [flatFileList addObject:node];
         }
 


### PR DESCRIPTION
This PR reduces memory footprint of FileListNode by splitting it into OnlyFileListNode ( files ) and OnlyFolderListNode.

Results using `class_getInstanceSize`.

| Class | Before Refactor | After Refactor |
|---|---|---|
| File Nodes (OnlyFileListNode) | ~64-72 bytes | 48 bytes |
| Folder Nodes (OnlyFolderListNode) | ~72 bytes | 56 bytes |

Notes: Improved UI code to use less CPU.