### PR TITLE
Prevent repeated fatal peer-I/O callbacks

### DIFF
--- a/libtransmission/peer-io.cc
+++ b/libtransmission/peer-io.cc
@@ -176,6 +176,7 @@ void tr_peerIo::set_socket(std::shared_ptr<tr_peer_socket> socket_in)
     close(); // tear down the previous socket, if any
 
     socket_ = std::move(socket_in);
+    fatal_error_seen_ = false;
     socket_address_ = socket_->socket_address();
 
     socket_->set_read_cb([weak = weak_from_this()] {
@@ -276,7 +277,7 @@ size_t tr_peerIo::try_write(size_t max)
 {
     static auto constexpr Dir = tr_direction::Up;
 
-    if (max == 0U) {
+    if (max == 0U || fatal_error_seen_) {
         return {};
     }
 
@@ -325,7 +326,7 @@ void tr_peerIo::can_read_wrapper(size_t bytes_transferred)
 {
     // try to consume the input buffer
 
-    if (can_read_ == nullptr) {
+    if (can_read_ == nullptr || fatal_error_seen_) {
         return;
     }
 
@@ -371,7 +372,7 @@ size_t tr_peerIo::try_read(size_t max)
 {
     static auto constexpr Dir = tr_direction::Down;
 
-    if (max == 0U) {
+    if (max == 0U || fatal_error_seen_) {
         return {};
     }
 
@@ -424,9 +425,9 @@ void tr_peerIo::set_enabled(tr_direction dir, bool is_enabled)
     }
 
     if (dir == tr_direction::Up) {
-        socket_->set_write_enabled(is_enabled);
+        socket_->set_write_enabled(is_enabled && !fatal_error_seen_);
     } else {
-        socket_->set_read_enabled(is_enabled);
+        socket_->set_read_enabled(is_enabled && !fatal_error_seen_);
     }
 }
 

--- a/libtransmission/peer-io.h
+++ b/libtransmission/peer-io.h
@@ -144,6 +144,10 @@ public:
 
     size_t flush(tr_direction dir, size_t byte_limit)
     {
+        if (fatal_error_seen_) {
+            return {};
+        }
+
         return dir == tr_direction::Down ? try_read(byte_limit) : try_write(byte_limit);
     }
 
@@ -313,6 +317,13 @@ private:
 
     void call_error_callback(tr_error const& error)
     {
+        // Peer removal is asynchronous. Until it happens, the bandwidth allocator
+        // can try to flush this I/O again, so report only the first fatal error.
+        if (fatal_error_seen_) {
+            return;
+        }
+
+        fatal_error_seen_ = true;
         if (got_error_ != nullptr) {
             got_error_(this, error, user_data_);
         }
@@ -368,6 +379,7 @@ private:
     bool const client_is_seed_;
     bool const is_incoming_;
 
+    bool fatal_error_seen_ = false;
     bool dht_supported_ = false;
     bool extended_protocol_supported_ = false;
     bool fast_extension_supported_ = false;


### PR DESCRIPTION
Fixes #236.

Peer removal is asynchronous. After a fatal transport error is reported, the bandwidth allocator can revisit the same `tr_peerIo` before the peer manager removes it. The failed socket may therefore invoke the error callback repeatedly during subsequent bandwidth and I/O passes.

This change adds a per-socket fatal-error latch in the common error-callback path. After the first fatal error:

* subsequent error callbacks from the same socket are suppressed;
* further read, write, and flush operations are stopped;
* bandwidth pulses cannot re-enable events on the failed socket.

The latch is reset when a replacement socket is installed, preserving the existing socket-replacement behavior and outgoing µTP-to-TCP fallback.

Detailed investigation and high-load before/after measurements are available in #236.

Notes: Avoid repeated disconnect processing and duplicate debug messages when a peer connection fails.

## Checklist

* [x] I have manually written or manually audited all changes in this PR and vouch for them.
* [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
