### PR TITLE
fix: ignore peerIo error if disconnecting

### DIFF
--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1941,6 +1941,13 @@ ReadState tr_peerMsgsImpl::can_read(tr_peerIo* io, void* vmsgs, size_t* piece)
 void tr_peerMsgsImpl::got_error(tr_peerIo* /*io*/, tr_error const& error, void* vmsgs)
 {
     auto* const msgs = static_cast<tr_peerMsgsImpl*>(vmsgs);
+    if (msgs->is_disconnecting()) {
+        logdbg(
+            msgs,
+            fmt::format("ignoring peer I/O error as peer is disconnecting anyway: {} ({})", error.message(), error.code()));
+        return;
+    }
+
     logdbg(msgs, fmt::format("peer I/O error, disconnecting: {} ({})", error.message(), error.code()));
     msgs->disconnect_soon();
 }


### PR DESCRIPTION
## Description

Fixes #236.

Avoid duplicate logs and processing when a peer is disconnecting.

This can happen because:
1. A peer is not immediately disconnected when `tr_peerMsgs::disconnect_soon()` is called.
2. `tr_bandwidth` can trigger `try_read()` or `try_write` multiple times before `tr_peerMgr::reconnect_pulse()` disconnects the peer for real.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
