### PR TITLE
fix: acquire lock before calling `tr_torrent::torrents()`

### DIFF
--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -605,6 +605,7 @@ size_t tr_session::compute_busy_torrent_count() const noexcept
     auto const now = tr_time();
 
     auto count = size_t{ 0U };
+    auto const lock = unique_lock();
     for (auto const* const tor : torrents()) {
         switch (tor->activity()) {
         case TR_STATUS_DOWNLOAD:


### PR DESCRIPTION
## Description

Regression from #138. CC @ckerr.

Add missing lock in `tr_session::compute_busy_torrent_count` before calling `tr_torrent::torrents()`.

Discovered from CI run https://github.com/retransmission/retransmission/actions/runs/32444522362/job/96661590185?pr=215.

<details>
<summary>fsanitize error</summary>

```
  ==12991==ERROR: AddressSanitizer: heap-use-after-free on address 0x502000032a98 at pc 0x55b861e6c45d bp 0x7f73b45f3e10 sp 0x7f73b45f3e08
  READ of size 8 at 0x502000032a98 thread T1
      #0 0x55b861e6c45c in tr_session::compute_busy_torrent_count() const /home/runner/work/retransmission/retransmission/libtransmission/session.cc:608:32
      #1 0x55b861e6bc81 in tr_session::on_now_timer() /home/runner/work/retransmission/retransmission/libtransmission/session.cc:528:31
      #2 0x55b861eaa83d in tr_session::tr_session(std::basic_string_view<char, std::char_traits<char>>, tr_variant::Map const&)::$_0::operator()() const /home/runner/work/retransmission/retransmission/libtransmission/session.cc:2028:51
      #3 0x55b861eaa7c0 in void std::__invoke_impl<void, tr_session::tr_session(std::basic_string_view<char, std::char_traits<char>>, tr_variant::Map const&)::$_0&>(std::__invoke_other, tr_session::tr_session(std::basic_string_view<char, std::char_traits<char>>, tr_variant::Map const&)::$_0&) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/invoke.h:61:14
      #4 0x55b861eaa6d0 in std::enable_if<is_invocable_r_v<void, tr_session::tr_session(std::basic_string_view<char, std::char_traits<char>>, tr_variant::Map const&)::$_0&>, void>::type std::__invoke_r<void, tr_session::tr_session(std::basic_string_view<char, std::char_traits<char>>, tr_variant::Map const&)::$_0&>(tr_session::tr_session(std::basic_string_view<char, std::char_traits<char>>, tr_variant::Map const&)::$_0&) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/invoke.h:111:2
      #5 0x55b861eaa34c in std::_Function_handler<void (), tr_session::tr_session(std::basic_string_view<char, std::char_traits<char>>, tr_variant::Map const&)::$_0>::_M_invoke(std::_Any_data const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/std_function.h:290:9
      #6 0x55b860b281e7 in std::function<void ()>::operator()() const /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/std_function.h:591:9
      #7 0x55b861f2d582 in tr::(anonymous namespace)::EvTimer::handleTimer() /home/runner/work/retransmission/retransmission/libtransmission/timer-ev.cc:146:9
      #8 0x55b861f2b92a in tr::(anonymous namespace)::EvTimer::onTimer(int, short, void*) /home/runner/work/retransmission/retransmission/libtransmission/timer-ev.cc:138:39
      #9 0x7f73b95f238b  (/lib/x86_64-linux-gnu/libevent_core-2.1.so.7+0x1f38b) (BuildId: c2fbb2410dd28aeae41e58c440dd9ca2e6a65d8c)
      #10 0x7f73b95f3fae in event_base_loop (/lib/x86_64-linux-gnu/libevent_core-2.1.so.7+0x20fae) (BuildId: c2fbb2410dd28aeae41e58c440dd9ca2e6a65d8c)
      #11 0x55b861e518e3 in (anonymous namespace)::tr_session_thread_impl::session_thread_func(event_base*) /home/runner/work/retransmission/retransmission/libtransmission/session-thread.cc:231:9
      #12 0x55b861e5545c in void std::__invoke_impl<void, void ((anonymous namespace)::tr_session_thread_impl::*)(event_base*), (anonymous namespace)::tr_session_thread_impl*, event_base*>(std::__invoke_memfun_deref, void ((anonymous namespace)::tr_session_thread_impl::*&&)(event_base*), (anonymous namespace)::tr_session_thread_impl*&&, event_base*&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/invoke.h:74:14
      #13 0x55b861e55008 in std::__invoke_result<void ((anonymous namespace)::tr_session_thread_impl::*)(event_base*), (anonymous namespace)::tr_session_thread_impl*, event_base*>::type std::__invoke<void ((anonymous namespace)::tr_session_thread_impl::*)(event_base*), (anonymous namespace)::tr_session_thread_impl*, event_base*>(void ((anonymous namespace)::tr_session_thread_impl::*&&)(event_base*), (anonymous namespace)::tr_session_thread_impl*&&, event_base*&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/invoke.h:96:14
      #14 0x55b861e54f34 in void std::thread::_Invoker<std::tuple<void ((anonymous namespace)::tr_session_thread_impl::*)(event_base*), (anonymous namespace)::tr_session_thread_impl*, event_base*>>::_M_invoke<0ul, 1ul, 2ul>(std::_Index_tuple<0ul, 1ul, 2ul>) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/std_thread.h:301:13
      #15 0x55b861e54d98 in std::thread::_Invoker<std::tuple<void ((anonymous namespace)::tr_session_thread_impl::*)(event_base*), (anonymous namespace)::tr_session_thread_impl*, event_base*>>::operator()() /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/std_thread.h:308:11
      #16 0x55b861e54778 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void ((anonymous namespace)::tr_session_thread_impl::*)(event_base*), (anonymous namespace)::tr_session_thread_impl*, event_base*>>>::_M_run() /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/std_thread.h:253:13
      #17 0x7f73b84ecdb3  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xecdb3) (BuildId: 753c6c8608b61d4e67be8f0c890e03e0aa046b8b)
      #18 0x55b86088ffbc in asan_thread_start(void*) asan_interceptors.cpp.o
      #19 0x7f73b809cb83  (/lib/x86_64-linux-gnu/libc.so.6+0x9cb83) (BuildId: 328820b908de8ea1ef79afa8995e302e819163d7)
      #20 0x7f73b8129d6b  (/lib/x86_64-linux-gnu/libc.so.6+0x129d6b) (BuildId: 328820b908de8ea1ef79afa8995e302e819163d7)
  
  0x502000032a98 is located 8 bytes inside of 16-byte region [0x502000032a90,0x502000032aa0)
  freed by thread T0 here:
      #0 0x55b8608d1371 in operator delete(void*) (/home/runner/work/retransmission/retransmission/obj/tests/libtransmission/libtransmission-test+0x285f371) (BuildId: 93485890010e78e0d7a1a560090e94894e2ff181)
      #1 0x55b8613e4d0e in std::__new_allocator<tr_torrent*>::deallocate(tr_torrent**, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/new_allocator.h:172:2
      #2 0x55b862044807 in std::allocator<tr_torrent*>::deallocate(tr_torrent**, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/allocator.h:208:25
      #3 0x55b862044807 in std::allocator_traits<std::allocator<tr_torrent*>>::deallocate(std::allocator<tr_torrent*>&, tr_torrent**, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/alloc_traits.h:513:13
      #4 0x55b862044807 in void std::vector<tr_torrent*, std::allocator<tr_torrent*>>::_M_realloc_insert<tr_torrent* const&>(__gnu_cxx::__normal_iterator<tr_torrent**, std::vector<tr_torrent*, std::allocator<tr_torrent*>>>, tr_torrent* const&)::_Guard::~_Guard() /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/vector.tcc:486:6
      #5 0x55b862043d92 in void std::vector<tr_torrent*, std::allocator<tr_torrent*>>::_M_realloc_insert<tr_torrent* const&>(__gnu_cxx::__normal_iterator<tr_torrent**, std::vector<tr_torrent*, std::allocator<tr_torrent*>>>, tr_torrent* const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/vector.tcc:567:7
      #6 0x55b862040246 in std::vector<tr_torrent*, std::allocator<tr_torrent*>>::insert(__gnu_cxx::__normal_iterator<tr_torrent* const*, std::vector<tr_torrent*, std::allocator<tr_torrent*>>>, tr_torrent* const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/vector.tcc:170:2
      #7 0x55b86203ab35 in tr_torrents::add(tr_torrent*) /home/runner/work/retransmission/retransmission/libtransmission/torrents.cc:71:14
      #8 0x55b861e908e0 in tr_session::addTorrent(tr_torrent*) /home/runner/work/retransmission/retransmission/libtransmission/session.cc:2044:29
      #9 0x55b861fcaff4 in tr_torrent::init(tr_torrent_builder const&) /home/runner/work/retransmission/retransmission/libtransmission/torrent.cc:902:14
      #10 0x55b861fd10ad in tr_torrentNew(tr_torrent_builder*, tr_torrent**) /home/runner/work/retransmission/retransmission/libtransmission/torrent.cc:1052:10
      #11 0x55b860e4ee3a in tr::test::SessionTest::createTorrentAndWaitForVerifyDone(tr_torrent_builder*) /home/runner/work/retransmission/retransmission/tests/libtransmission/test-fixtures.h:339:27
      #12 0x55b8613cf472 in tr::test::SessionTest::torrentInitFromFile(std::basic_string_view<char, std::char_traits<char>>) /home/runner/work/retransmission/retransmission/tests/libtransmission/test-fixtures.h:442:16
      #13 0x55b8613cdff9 in _ZZN32TorrentTest_queueMoveBottom_Test8TestBodyEvENK3$_0clISt17basic_string_viewIcSt11char_traitsIcEEEEDaT_ /home/runner/work/retransmission/retransmission/tests/libtransmission/torrent-test.cc:101:16
      #14 0x55b8613cdeae in tr_torrent* std::__invoke_impl<tr_torrent*, TorrentTest_queueMoveBottom_Test::TestBody()::$_0&, std::basic_string_view<char, std::char_traits<char>> const&>(std::__invoke_other, TorrentTest_queueMoveBottom_Test::TestBody()::$_0&, std::basic_string_view<char, std::char_traits<char>> const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/invoke.h:61:14
      #15 0x55b8613cde2c in std::__invoke_result<TorrentTest_queueMoveBottom_Test::TestBody()::$_0&, std::basic_string_view<char, std::char_traits<char>> const&>::type std::__invoke<TorrentTest_queueMoveBottom_Test::TestBody()::$_0&, std::basic_string_view<char, std::char_traits<char>> const&>(TorrentTest_queueMoveBottom_Test::TestBody()::$_0&, std::basic_string_view<char, std::char_traits<char>> const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/invoke.h:96:14
      #16 0x55b8613cdbd3 in std::ranges::in_out_result<std::basic_string_view<char, std::char_traits<char>> const*, T1> std::ranges::__transform_fn::operator()<std::basic_string_view<char, std::char_traits<char>> const*, std::basic_string_view<char, std::char_traits<char>> const*, tr_torrent**, TorrentTest_queueMoveBottom_Test::TestBody()::$_0, std::identity>(std::basic_string_view<char, std::char_traits<char>> const*, std::basic_string_view<char, std::char_traits<char>> const*, T1, T2, T3) const /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/ranges_algo.h:714:16
      #17 0x55b8613cba5d in std::ranges::in_out_result<std::__conditional<borrowed_range<T>>::type<decltype(ranges::__access::__begin(std::declval<T&>())), std::ranges::dangling>, T0> std::ranges::__transform_fn::operator()<std::array<std::basic_string_view<char, std::char_traits<char>>, 4ul> const&, tr_torrent**, TorrentTest_queueMoveBottom_Test::TestBody()::$_0, std::identity>(T&&, T0, T1, T2) const /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/ranges_algo.h:726:9
      #18 0x55b8613caa1f in TorrentTest_queueMoveBottom_Test::TestBody() /home/runner/work/retransmission/retransmission/tests/libtransmission/torrent-test.cc:100:5
      #19 0x7f73b8ac3f74 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:2664:10
      #20 0x7f73b8a1a6fd in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:2700:14
      #21 0x7f73b89841a7 in testing::Test::Run() /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:2739:5
      #22 0x7f73b89873eb in testing::TestInfo::Run() /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:2885:11
      #23 0x7f73b898b07c in testing::TestSuite::Run() /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:3063:30
      #24 0x7f73b89d0345 in testing::internal::UnitTestImpl::RunAllTests() /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:6054:44
      #25 0x7f73b8aca314 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:2664:10
      #26 0x7f73b8a26b9d in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:2700:14
      #27 0x7f73b89cd82d in testing::UnitTest::Run() /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:5594:10
      #28 0x7f73b96167f0 in RUN_ALL_TESTS() /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/include/gtest/gtest.h:2334:73
      #29 0x7f73b96166aa in main /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest_main.cc:64:10
      #30 0x7f73b802a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 328820b908de8ea1ef79afa8995e302e819163d7)
      #31 0x7f73b802a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 328820b908de8ea1ef79afa8995e302e819163d7)
  
  previously allocated by thread T0 here:
      #0 0x55b8608d0af1 in operator new(unsigned long) (/home/runner/work/retransmission/retransmission/obj/tests/libtransmission/libtransmission-test+0x285eaf1) (BuildId: 93485890010e78e0d7a1a560090e94894e2ff181)
      #1 0x55b8613e434f in std::__new_allocator<tr_torrent*>::allocate(unsigned long, void const*) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/new_allocator.h:151:27
      #2 0x55b8613e3ed1 in std::allocator<tr_torrent*>::allocate(unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/allocator.h:196:32
      #3 0x55b8613e3ed1 in std::allocator_traits<std::allocator<tr_torrent*>>::allocate(std::allocator<tr_torrent*>&, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/alloc_traits.h:478:20
      #4 0x55b8613e3ed1 in std::_Vector_base<tr_torrent*, std::allocator<tr_torrent*>>::_M_allocate(unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/stl_vector.h:380:20
      #5 0x55b862043726 in void std::vector<tr_torrent*, std::allocator<tr_torrent*>>::_M_realloc_insert<tr_torrent* const&>(__gnu_cxx::__normal_iterator<tr_torrent**, std::vector<tr_torrent*, std::allocator<tr_torrent*>>>, tr_torrent* const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/vector.tcc:467:33
      #6 0x55b862040246 in std::vector<tr_torrent*, std::allocator<tr_torrent*>>::insert(__gnu_cxx::__normal_iterator<tr_torrent* const*, std::vector<tr_torrent*, std::allocator<tr_torrent*>>>, tr_torrent* const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/vector.tcc:170:2
      #7 0x55b86203ab35 in tr_torrents::add(tr_torrent*) /home/runner/work/retransmission/retransmission/libtransmission/torrents.cc:71:14
      #8 0x55b861e908e0 in tr_session::addTorrent(tr_torrent*) /home/runner/work/retransmission/retransmission/libtransmission/session.cc:2044:29
      #9 0x55b861fcaff4 in tr_torrent::init(tr_torrent_builder const&) /home/runner/work/retransmission/retransmission/libtransmission/torrent.cc:902:14
      #10 0x55b861fd10ad in tr_torrentNew(tr_torrent_builder*, tr_torrent**) /home/runner/work/retransmission/retransmission/libtransmission/torrent.cc:1052:10
      #11 0x55b860e4ee3a in tr::test::SessionTest::createTorrentAndWaitForVerifyDone(tr_torrent_builder*) /home/runner/work/retransmission/retransmission/tests/libtransmission/test-fixtures.h:339:27
      #12 0x55b8613cf472 in tr::test::SessionTest::torrentInitFromFile(std::basic_string_view<char, std::char_traits<char>>) /home/runner/work/retransmission/retransmission/tests/libtransmission/test-fixtures.h:442:16
      #13 0x55b8613cdff9 in _ZZN32TorrentTest_queueMoveBottom_Test8TestBodyEvENK3$_0clISt17basic_string_viewIcSt11char_traitsIcEEEEDaT_ /home/runner/work/retransmission/retransmission/tests/libtransmission/torrent-test.cc:101:16
      #14 0x55b8613cdeae in tr_torrent* std::__invoke_impl<tr_torrent*, TorrentTest_queueMoveBottom_Test::TestBody()::$_0&, std::basic_string_view<char, std::char_traits<char>> const&>(std::__invoke_other, TorrentTest_queueMoveBottom_Test::TestBody()::$_0&, std::basic_string_view<char, std::char_traits<char>> const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/invoke.h:61:14
      #15 0x55b8613cde2c in std::__invoke_result<TorrentTest_queueMoveBottom_Test::TestBody()::$_0&, std::basic_string_view<char, std::char_traits<char>> const&>::type std::__invoke<TorrentTest_queueMoveBottom_Test::TestBody()::$_0&, std::basic_string_view<char, std::char_traits<char>> const&>(TorrentTest_queueMoveBottom_Test::TestBody()::$_0&, std::basic_string_view<char, std::char_traits<char>> const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/invoke.h:96:14
      #16 0x55b8613cdbd3 in std::ranges::in_out_result<std::basic_string_view<char, std::char_traits<char>> const*, T1> std::ranges::__transform_fn::operator()<std::basic_string_view<char, std::char_traits<char>> const*, std::basic_string_view<char, std::char_traits<char>> const*, tr_torrent**, TorrentTest_queueMoveBottom_Test::TestBody()::$_0, std::identity>(std::basic_string_view<char, std::char_traits<char>> const*, std::basic_string_view<char, std::char_traits<char>> const*, T1, T2, T3) const /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/ranges_algo.h:714:16
      #17 0x55b8613cba5d in std::ranges::in_out_result<std::__conditional<borrowed_range<T>>::type<decltype(ranges::__access::__begin(std::declval<T&>())), std::ranges::dangling>, T0> std::ranges::__transform_fn::operator()<std::array<std::basic_string_view<char, std::char_traits<char>>, 4ul> const&, tr_torrent**, TorrentTest_queueMoveBottom_Test::TestBody()::$_0, std::identity>(T&&, T0, T1, T2) const /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/ranges_algo.h:726:9
      #18 0x55b8613caa1f in TorrentTest_queueMoveBottom_Test::TestBody() /home/runner/work/retransmission/retransmission/tests/libtransmission/torrent-test.cc:100:5
      #19 0x7f73b8ac3f74 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:2664:10
      #20 0x7f73b8a1a6fd in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:2700:14
      #21 0x7f73b89841a7 in testing::Test::Run() /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:2739:5
      #22 0x7f73b89873eb in testing::TestInfo::Run() /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:2885:11
      #23 0x7f73b898b07c in testing::TestSuite::Run() /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:3063:30
      #24 0x7f73b89d0345 in testing::internal::UnitTestImpl::RunAllTests() /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:6054:44
      #25 0x7f73b8aca314 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:2664:10
      #26 0x7f73b8a26b9d in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:2700:14
      #27 0x7f73b89cd82d in testing::UnitTest::Run() /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:5594:10
      #28 0x7f73b96167f0 in RUN_ALL_TESTS() /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/include/gtest/gtest.h:2334:73
      #29 0x7f73b96166aa in main /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest_main.cc:64:10
      #30 0x7f73b802a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 328820b908de8ea1ef79afa8995e302e819163d7)
      #31 0x7f73b802a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 328820b908de8ea1ef79afa8995e302e819163d7)
  
  Thread T1 created by T0 here:
      #0 0x55b860877e45 in pthread_create (/home/runner/work/retransmission/retransmission/obj/tests/libtransmission/libtransmission-test+0x2805e45) (BuildId: 93485890010e78e0d7a1a560090e94894e2ff181)
      #1 0x7f73b84eceb0 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) (/lib/x86_64-linux-gnu/libstdc++.so.6+0xeceb0) (BuildId: 753c6c8608b61d4e67be8f0c890e03e0aa046b8b)
      #2 0x55b861e51ea3 in std::thread::thread<void ((anonymous namespace)::tr_session_thread_impl::*)(event_base*), (anonymous namespace)::tr_session_thread_impl*, event_base*, void>(void ((anonymous namespace)::tr_session_thread_impl::*&&)(event_base*), (anonymous namespace)::tr_session_thread_impl*&&, event_base*&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/std_thread.h:173:2
      #3 0x55b861e50da1 in (anonymous namespace)::tr_session_thread_impl::tr_session_thread_impl() /home/runner/work/retransmission/retransmission/libtransmission/session-thread.cc:147:19
      #4 0x55b861e4f7c4 in std::__detail::_MakeUniq<(anonymous namespace)::tr_session_thread_impl>::__single_object std::make_unique<(anonymous namespace)::tr_session_thread_impl>() /usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/unique_ptr.h:1076:34
      #5 0x55b861e4f6b7 in tr_session_thread::create() /home/runner/work/retransmission/retransmission/libtransmission/session-thread.cc:294:12
      #6 0x55b861e8e0c1 in tr_session::tr_session(std::basic_string_view<char, std::char_traits<char>>, tr_variant::Map const&) /home/runner/work/retransmission/retransmission/libtransmission/session.cc:2022:24
      #7 0x55b861e6a0aa in tr_sessionInit(std::basic_string_view<char, std::char_traits<char>>, bool, tr_variant::Map const&) /home/runner/work/retransmission/retransmission/libtransmission/session.cc:508:31
      #8 0x55b860b454ce in tr::test::SessionTest::sessionInit(tr_variant::Map&) /home/runner/work/retransmission/retransmission/tests/libtransmission/test-fixtures.h:321:16
      #9 0x55b860b2bd7e in tr::test::SessionTest::SetUp() /home/runner/work/retransmission/retransmission/tests/libtransmission/test-fixtures.h:475:20
      #10 0x7f73b8ac3f74 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:2664:10
      #11 0x7f73b8a1a6fd in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:2700:14
      #12 0x7f73b8983f19 in testing::Test::Run() /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:2734:3
      #13 0x7f73b89873eb in testing::TestInfo::Run() /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:2885:11
      #14 0x7f73b898b07c in testing::TestSuite::Run() /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:3063:30
      #15 0x7f73b89d0345 in testing::internal::UnitTestImpl::RunAllTests() /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:6054:44
      #16 0x7f73b8aca314 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:2664:10
      #17 0x7f73b8a26b9d in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:2700:14
      #18 0x7f73b89cd82d in testing::UnitTest::Run() /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest.cc:5594:10
      #19 0x7f73b96167f0 in RUN_ALL_TESTS() /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/include/gtest/gtest.h:2334:73
      #20 0x7f73b96166aa in main /home/runner/work/retransmission/retransmission/third-party/googletest/googletest/src/gtest_main.cc:64:10
      #21 0x7f73b802a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 328820b908de8ea1ef79afa8995e302e819163d7)
      #22 0x7f73b802a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 328820b908de8ea1ef79afa8995e302e819163d7)
      #23 0x55b8607f7684 in _start (/home/runner/work/retransmission/retransmission/obj/tests/libtransmission/libtransmission-test+0x2785684) (BuildId: 93485890010e78e0d7a1a560090e94894e2ff181)
  
  SUMMARY: AddressSanitizer: heap-use-after-free /home/runner/work/retransmission/retransmission/libtransmission/session.cc:608:32 in tr_session::compute_busy_torrent_count() const
  Shadow bytes around the buggy address:
    0x502000032800: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
    0x502000032880: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
    0x502000032900: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
    0x502000032980: fa fa fd fa fa fa fd fa fa fa fd fa fa fa 00 00
    0x502000032a00: fa fa 00 fa fa fa 00 fa fa fa 00 fa fa fa fd fd
  =>0x502000032a80: fa fa fd[fd]fa fa fd fa fa fa 00 00 fa fa 00 00
    0x502000032b00: fa fa fd fd fa fa 00 00 fa fa fd fd fa fa 00 00
    0x502000032b80: fa fa 00 00 fa fa 00 00 fa fa 00 00 fa fa fd fa
    0x502000032c00: fa fa 00 00 fa fa fd fa fa fa 00 fa fa fa fd fa
    0x502000032c80: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
    0x502000032d00: fa fa fd fd fa fa fd fa fa fa fd fa fa fa fd fa
  Shadow byte legend (one shadow byte represents 8 application bytes):
    Addressable:           00
    Partially addressable: 01 02 03 04 05 06 07 
    Heap left redzone:       fa
    Freed heap region:       fd
    Stack left redzone:      f1
    Stack mid redzone:       f2
    Stack right redzone:     f3
    Stack after return:      f5
    Stack use after scope:   f8
    Global redzone:          f9
    Global init order:       f6
    Poisoned by user:        f7
    Container overflow:      fc
    Array cookie:            ac
    Intra object redzone:    bb
    ASan internal:           fe
    Left alloca redzone:     ca
    Right alloca redzone:    cb
  ==12991==ABORTING
```

</details>

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
