### PR TITLE
fix: race condition in `tr_sessionGetBusyTorrentCount()`

### DIFF
--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -693,7 +693,7 @@ Response parameters:
 | Key | Value Type | Description
 |:--|:--|:--
 | `active_torrent_count`     | number     | **DEPRECATED** number of running torrents -- use `unpaused_torrent_count`; will be removed in Transmission 5.0.0
-| `busy_torrent_count`       | number     | number of torrents downloading, seeding, or verifying that are not stalled or locally errored
+| `busy`                     | boolean    | true while torrents are running or verifying and any has been active recently, where "recently" honors the `queue_stalled_minutes` setting; clients use this to decide whether to inhibit desktop sleep
 | `download_speed`           | number
 | `paused_torrent_count`     | number     | number of paused (not-running) torrents
 | `torrent_count`            | number     | total number of torrents (`unpaused_torrent_count` + `paused_torrent_count`)
@@ -1152,7 +1152,7 @@ Transmission 4.2.0 (`rpc_version_semver` 6.1.0, `rpc_version`: 20)
 | `session_get` | new arg `recent_relocate_paths`
 | `session_get` | new arg `torrent_complete_verify_enabled`
 | `session_set` | new arg `torrent_complete_verify_enabled`
-| `session_stats` | new arg `busy_torrent_count`
+| `session_stats` | new arg `busy`
 | `session_stats` | new arg `unpaused_torrent_count`
 | `session_get` | new arg `blocklist_date`
 | `session_get` | new arg `blocklist_updates_enabled`

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -943,7 +943,7 @@ void Session::Impl::update()
 
 void Session::Impl::update_sleep_inhibitor()
 {
-    if (gtr_pref_flag_get(TR_KEY_inhibit_desktop_hibernation) && tr_sessionGetBusyTorrentCount(session_) != 0) {
+    if (gtr_pref_flag_get(TR_KEY_inhibit_desktop_hibernation) && tr_sessionIsBusy(session_)) {
         sleep_inhibitor_.inhibit(TR_PROJ_APPNAME_CAPITALIZED, "Torrents are active");
     } else {
         sleep_inhibitor_.uninhibit();

--- a/libtransmission-app/session.cc
+++ b/libtransmission-app/session.cc
@@ -139,11 +139,12 @@ std::optional<tr::Settings> Session::embedded_settings() const
 
 void Session::set_session_type(std::optional<Type> const type)
 {
-    // should_inhibit_sleep() ignores the busy count once we're non-local, so a
-    // non-local session's remembered activity is meaningless -- drop it here so
-    // a later switch back to a local session starts from a clean slate.
+    // should_inhibit_sleep() ignores busyness once we're non-local,
+    // so a non-local session's remembered busyness is meaningless --
+    // drop it here so a later switch back to a local session
+    // starts from a clean slate.
     if (type.value_or(Type::Remote) == Type::Remote) {
-        has_busy_torrents_ = false;
+        busy_ = false;
     }
 
     if (session_type_ != type) {
@@ -153,17 +154,17 @@ void Session::set_session_type(std::optional<Type> const type)
     }
 }
 
-void Session::set_has_busy_torrents(bool const has_busy)
+void Session::set_busy(bool const busy)
 {
-    if (has_busy_torrents_ != has_busy) {
-        has_busy_torrents_ = has_busy;
+    if (busy_ != busy) {
+        busy_ = busy;
         update_sleep_inhibit();
     }
 }
 
 bool Session::should_inhibit_sleep() const
 {
-    return is_local_filesystem() && has_busy_torrents_ && prefs_.get<bool>(TR_KEY_inhibit_desktop_hibernation);
+    return is_local_filesystem() && busy_ && prefs_.get<bool>(TR_KEY_inhibit_desktop_hibernation);
 }
 
 void Session::update_sleep_inhibit()

--- a/libtransmission-app/session.h
+++ b/libtransmission-app/session.h
@@ -76,7 +76,7 @@ public:
 
 protected:
     void set_session_type(std::optional<Type> type);
-    void set_has_busy_torrents(bool has_busy);
+    void set_busy(bool busy);
 
     // The embedded session, or nullptr when there isn't one. Some settings,
     // e.g. the RPC server's, can only be applied to an embedded session.
@@ -101,7 +101,7 @@ private:
     woke::SleepInhibitor sleep_inhibitor_;
     woke::NapInhibitor nap_inhibitor_;
     std::optional<Type> session_type_;
-    bool has_busy_torrents_ = false;
+    bool busy_ = false;
     bool importing_settings_ = false;
     sigslot::scoped_connection prefs_connection_;
 };

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -615,7 +615,7 @@ public:
             break;
 
         case tr_peer_event::Type::ClientGotPieceData:
-            on_client_got_piece_data(s->tor, event.length, tr_time());
+            s->tor->add_downloaded(event.length, tr_time());
             break;
 
         case tr_peer_event::Type::ClientGotHave:
@@ -866,7 +866,7 @@ private:
 
         switch (event.type) {
         case tr_peer_event::Type::ClientGotPieceData:
-            on_client_got_piece_data(s->tor, event.length, tr_time());
+            s->tor->add_downloaded(event.length, tr_time());
             break;
 
         default:
@@ -912,11 +912,6 @@ private:
             TR_ASSERT_MSG(false, "This should be unreachable code");
             break;
         }
-    }
-
-    static void on_client_got_piece_data(tr_torrent* const tor, uint32_t const sent_length, time_t const now)
-    {
-        tor->add_downloaded(sent_length, now);
     }
 
     void on_got_port(tr_peerMsgs* const msgs, tr_peer_event const& event)

--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -608,11 +608,8 @@ public:
         case tr_peer_event::Type::ClientSentPieceData:
             {
                 auto* const tor = s->tor;
-
-                tor->bytes_uploaded_ += event.length;
+                tor->add_uploaded(event.length, tr_time());
                 tr_announcerAddBytes(tor, TR_ANN_UP, event.length);
-                tor->set_date_active(tr_time());
-                tor->session->add_uploaded(event.length);
             }
 
             break;
@@ -919,9 +916,7 @@ private:
 
     static void on_client_got_piece_data(tr_torrent* const tor, uint32_t const sent_length, time_t const now)
     {
-        tor->bytes_downloaded_ += sent_length;
-        tor->set_date_active(now);
-        tor->session->add_downloaded(sent_length);
+        tor->add_downloaded(sent_length, now);
     }
 
     void on_got_port(tr_peerMsgs* const msgs, tr_peer_event const& event)

--- a/libtransmission/quark.cc
+++ b/libtransmission/quark.cc
@@ -86,7 +86,7 @@ auto constexpr MyStatic = std::array<std::string_view, TR_N_KEYS>{
     "blocklist_updates_enabled"sv, // gtk app, qt app
     "blocklist_url"sv, // rpc, tr_session::Settings
     "blocks"sv, // .resume
-    "busy_torrent_count"sv, // rpc
+    "busy"sv, // rpc
     "bytesCompleted"sv, // rpc
     "bytes_completed"sv, // rpc
     "bytes_to_client"sv, // rpc

--- a/libtransmission/quark.h
+++ b/libtransmission/quark.h
@@ -98,7 +98,7 @@ enum // NOLINT(performance-enum-size)
     TR_KEY_blocklist_updates_enabled,
     TR_KEY_blocklist_url,
     TR_KEY_blocks,
-    TR_KEY_busy_torrent_count,
+    TR_KEY_busy,
     TR_KEY_bytes_completed_camel_APICOMPAT,
     TR_KEY_bytes_completed,
     TR_KEY_bytes_to_client,

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1809,7 +1809,7 @@ void add_strings_from_var(std::set<std::string_view>& strings, tr_variant const&
 
     args_out.reserve(std::size(args_out) + 9U);
     args_out.try_emplace(TR_KEY_active_torrent_count, n_running);
-    args_out.try_emplace(TR_KEY_busy_torrent_count, static_cast<int64_t>(session->busy_torrent_count()));
+    args_out.try_emplace(TR_KEY_busy, session->is_busy(tr_time()));
     args_out.try_emplace(TR_KEY_unpaused_torrent_count, n_running);
     args_out.try_emplace(TR_KEY_cumulative_stats, make_stats_map(session->stats().cumulative()));
     args_out.try_emplace(TR_KEY_current_stats, make_stats_map(session->stats().current()));

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -529,7 +529,7 @@ void tr_session::on_now_timer()
     // tr_session upkeep tasks to perform once per second
     tr_timeUpdate(std::chrono::system_clock::to_time_t(now));
     alt_speeds_.check_scheduler();
-    busy_torrent_count_.store(compute_busy_torrent_count(), std::memory_order_relaxed);
+    busy_window_.store(compute_busy_window(), std::memory_order_relaxed);
 
     // set the timer to kick again right after (10ms after) the next second
     auto const target_time = std::chrono::time_point_cast<std::chrono::seconds>(now) + 1s + 10ms;
@@ -602,45 +602,11 @@ size_t tr_session::count_queue_free_slots(tr_direction dir) const noexcept
     return max - active_count;
 }
 
-size_t tr_session::compute_busy_torrent_count() const noexcept
-{
-    auto const stalled_enabled = queueStalledEnabled();
-    auto const stalled_if_idle_for_n_seconds = static_cast<time_t>(queueStalledMinutes() * 60);
-    auto const now = tr_time();
-
-    auto count = size_t{ 0U };
-    for (auto const* const tor : torrents()) {
-        switch (tor->activity()) {
-        case TR_STATUS_DOWNLOAD:
-        case TR_STATUS_SEED:
-        case TR_STATUS_CHECK:
-            break; // an actively-transferring state
-        default:
-            continue; // stopped, queued, or waiting to verify
-        }
-
-        // don't count a locally-errored or stalled torrent as busy
-        if (tor->error().is_local_error()) {
-            continue;
-        }
-
-        if (stalled_enabled) {
-            if (auto const idle = tor->idle_seconds(now); idle && *idle >= stalled_if_idle_for_n_seconds) {
-                continue;
-            }
-        }
-
-        ++count;
-    }
-
-    return count;
-}
-
-size_t tr_sessionGetBusyTorrentCount(tr_session const* session)
+bool tr_sessionIsBusy(tr_session const* session)
 {
     TR_ASSERT(session != nullptr);
 
-    return session->busy_torrent_count();
+    return session->is_busy(time(nullptr));
 }
 
 void tr_session::on_queue_timer()
@@ -2058,6 +2024,8 @@ tr_session::tr_session(std::string_view config_dir, tr::Settings const& settings
     , queue_timer_{ timer_maker_->create([this]() { on_queue_timer(); }) }
     , save_timer_{ timer_maker_->create([this]() { on_save_timer(); }) }
 {
+    busy_window_.store(compute_busy_window(), std::memory_order_relaxed);
+
     now_timer_->start_repeating(1s);
     queue_timer_->start_repeating(QueueInterval);
     save_timer_->start_repeating(SaveInterval);

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -1479,8 +1479,8 @@ private:
     // verified pieces (verify thread), and torrent starts (session thread);
     // busy_window_ mirrors the queue-stalled settings and is refreshed
     // once per second in on_now_timer().
-    std::atomic<size_t> n_started_torrents_{};
-    std::atomic<size_t> n_verify_jobs_{};
+    std::atomic<size_t> n_started_torrents_;
+    std::atomic<size_t> n_verify_jobs_;
     std::atomic<time_t> date_active_{ 0 };
     std::atomic<time_t> busy_window_{ 0 };
 

--- a/libtransmission/session.h
+++ b/libtransmission/session.h
@@ -16,6 +16,7 @@
 #include <cstdint> // uintX_t
 #include <ctime> // time_t
 #include <future>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -800,6 +801,49 @@ public:
         }
     }
 
+    /// busyness
+
+    // Whether any started torrent or running verify job has been active
+    // recently, where "recently" honors the queue-stalled settings.
+    // GUI clients use this to decide whether to inhibit desktop sleep.
+    // Lock-free and safe to call from any thread.
+    [[nodiscard]] bool is_busy(time_t const now) const noexcept
+    {
+        if (n_started_torrents_.load(std::memory_order_relaxed) == 0U && n_verify_jobs_.load(std::memory_order_relaxed) == 0U) {
+            return false;
+        }
+
+        // a date in the future means the clock stepped backwards;
+        // treat that as not busy until the next stamp lands
+        auto const active_at = date_active_.load(std::memory_order_relaxed);
+        return active_at != 0 && active_at <= now && now - active_at < busy_window_.load(std::memory_order_relaxed);
+    }
+
+    void set_date_active(time_t const when) noexcept
+    {
+        date_active_.store(when, std::memory_order_relaxed);
+    }
+
+    void add_started_torrent() noexcept
+    {
+        n_started_torrents_.fetch_add(1U, std::memory_order_relaxed);
+    }
+
+    void remove_started_torrent() noexcept
+    {
+        n_started_torrents_.fetch_sub(1U, std::memory_order_relaxed);
+    }
+
+    void add_verify_job() noexcept
+    {
+        n_verify_jobs_.fetch_add(1U, std::memory_order_relaxed);
+    }
+
+    void remove_verify_job() noexcept
+    {
+        n_verify_jobs_.fetch_sub(1U, std::memory_order_relaxed);
+    }
+
     /// stats
 
     [[nodiscard]] constexpr auto& stats() noexcept
@@ -812,14 +856,16 @@ public:
         return session_stats_;
     }
 
-    constexpr void add_uploaded(uint32_t n_bytes) noexcept
+    void add_uploaded(uint32_t const n_bytes, time_t const now) noexcept
     {
         stats().add_uploaded(n_bytes);
+        set_date_active(now);
     }
 
-    constexpr void add_downloaded(uint32_t n_bytes) noexcept
+    void add_downloaded(uint32_t const n_bytes, time_t const now) noexcept
     {
         stats().add_downloaded(n_bytes);
+        set_date_active(now);
     }
 
     constexpr void add_file_created() noexcept
@@ -1014,14 +1060,6 @@ public:
 
     [[nodiscard]] size_t count_queue_free_slots(tr_direction dir) const noexcept;
 
-    // Number of torrents actively downloading, seeding, verifying, and which
-    // are not stalled or locally errored: the "should desktop stay awake" count.
-    // Safe to call from any thread.
-    [[nodiscard]] size_t busy_torrent_count() const noexcept
-    {
-        return busy_torrent_count_.load(std::memory_order_relaxed);
-    }
-
     [[nodiscard]] bool has_ip_protocol(tr_address_type type) const noexcept
     {
         TR_ASSERT(tr_address::is_valid(type));
@@ -1174,8 +1212,12 @@ private:
     void on_queue_timer();
     void on_save_timer();
 
-    // the uncached count behind busy_torrent_count(); session thread only
-    [[nodiscard]] size_t compute_busy_torrent_count() const noexcept;
+    // How long after its last activity the session still counts as busy.
+    // Session thread only: reads the queue-stalled settings.
+    [[nodiscard]] time_t compute_busy_window() const noexcept
+    {
+        return queueStalledEnabled() ? static_cast<time_t>(queueStalledMinutes()) * 60 : std::numeric_limits<time_t>::max();
+    }
 
     // (Re)arm or disarm the auto-update timer after a blocklist setting changes.
     void on_blocklist_settings_changed();
@@ -1431,9 +1473,16 @@ private:
     // depends-on: alt_speeds_, udp_core_, torrents_
     std::unique_ptr<tr::Timer> now_timer_;
 
-    // cached busy_torrent_count(), refreshed on the session thread in
-    // on_now_timer() so it is readable from any thread (GUI clients, C API)
-    std::atomic<size_t> busy_torrent_count_{ 0U };
+    // is_busy() state, readable lock-free from any thread.
+    // The counts are maintained by the torrent start/stop and verify flows;
+    // date_active_ is stamped by transfers (session and web threads),
+    // verified pieces (verify thread), and torrent starts (session thread);
+    // busy_window_ mirrors the queue-stalled settings and is refreshed
+    // once per second in on_now_timer().
+    std::atomic<size_t> n_started_torrents_{};
+    std::atomic<size_t> n_verify_jobs_{};
+    std::atomic<time_t> date_active_{ 0 };
+    std::atomic<time_t> busy_window_{ 0 };
 
     // depends-on: torrents_
     std::unique_ptr<tr::Timer> queue_timer_;

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -609,6 +609,7 @@ void tr_torrent::start(bool bypass_queue, std::optional<bool> has_any_local_data
     }
 
     is_running_ = true;
+    session->add_started_torrent();
     set_dirty();
     session->run_in_session_thread([this]() { start_in_session_thread(); });
 }
@@ -632,6 +633,7 @@ void tr_torrent::start_in_session_thread()
     is_running_ = true;
     date_started_ = now;
     mark_changed();
+    session->set_date_active(now);
     error().clear();
     finished_seeding_by_idle_ = false;
 
@@ -653,6 +655,11 @@ void tr_torrent::stop_now()
     auto const now = tr_time();
     seconds_downloading_before_current_start_ = seconds_downloading(now);
     seconds_seeding_before_current_start_ = seconds_seeding(now);
+
+    // guarded: stop_now() is also called on torrents that are not running
+    if (is_running_) {
+        session->remove_started_torrent();
+    }
 
     is_running_ = false;
     is_stopping_ = false;
@@ -1620,6 +1627,7 @@ void tr_torrent::VerifyMediator::on_verify_started()
 {
     tr_logAddDebugTor(tor_, "Verifying torrent");
     time_started_ = tr_time();
+    tor_->session->add_verify_job();
     tor_->set_verify_state(VerifyState::Active);
 }
 
@@ -1632,6 +1640,7 @@ void tr_torrent::VerifyMediator::on_piece_checked(tr_piece_index_t const piece, 
 
     tor_->checked_pieces_.set(piece, true);
     tor_->mark_changed();
+    tor_->session->set_date_active(tr_time());
     tor_->verify_progress_ = std::clamp(
         static_cast<float>(piece + 1U) / static_cast<float>(tor_->metainfo_.piece_count()),
         0.0F,
@@ -1641,7 +1650,10 @@ void tr_torrent::VerifyMediator::on_piece_checked(tr_piece_index_t const piece, 
 // (usually called from tr_verify_worker's thread)
 void tr_torrent::VerifyMediator::on_verify_done(bool const aborted)
 {
+    // guarded: aborted jobs may finish without ever having started
     if (time_started_.has_value()) {
+        tor_->session->remove_verify_job();
+
         auto const total_size = tor_->total_size();
         auto const duration_secs = tr_time() - *time_started_;
         tr_logAddDebugTor(

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -608,6 +608,7 @@ void tr_torrent::start(bool bypass_queue, std::optional<bool> has_any_local_data
         set_seed_ratio_mode(TR_RATIOLIMIT_UNLIMITED);
     }
 
+    TR_ASSERT(!is_running_); // every running activity() returns early above, keeping add_started_torrent() balanced
     is_running_ = true;
     session->add_started_torrent();
     set_dirty();

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -725,6 +725,20 @@ struct tr_torrent {
         set_dirty();
     }
 
+    void add_uploaded(uint32_t const n_bytes, time_t const now) noexcept
+    {
+        bytes_uploaded_ += n_bytes;
+        set_date_active(now);
+        session->add_uploaded(n_bytes, now);
+    }
+
+    void add_downloaded(uint32_t const n_bytes, time_t const now) noexcept
+    {
+        bytes_downloaded_ += n_bytes;
+        set_date_active(now);
+        session->add_downloaded(n_bytes, now);
+    }
+
     [[nodiscard]] constexpr auto activity() const noexcept
     {
         if (verify_state_ == VerifyState::Active) {

--- a/libtransmission/transmission.h
+++ b/libtransmission/transmission.h
@@ -437,10 +437,11 @@ void tr_sessionSetQueueStalledMinutes(tr_session* session, size_t minutes);
 /** @brief Set whether or not to count torrents idle for over N minutes as 'stalled' */
 void tr_sessionSetQueueStalledEnabled(tr_session* session, bool enabled);
 
-/** @return the number of torrents actively transferring -- downloading, seeding,
-    or verifying -- that are not stalled or locally errored. Cached and safe to call
-    from any thread. GUI clients use this to decide whether to inhibit desktop sleep. */
-[[nodiscard]] size_t tr_sessionGetBusyTorrentCount(tr_session const* session);
+/** @return true while torrents are running or verifying and any has been
+    active recently, where "recently" honors the queue-stalled settings above.
+    GUI clients use this to decide whether to inhibit desktop sleep.
+    Lock-free and safe to call from any thread. */
+[[nodiscard]] bool tr_sessionIsBusy(tr_session const* session);
 
 /** @brief Set a callback that is invoked when the queue starts a torrent */
 void tr_sessionSetQueueStartCallback(tr_session* session, tr_session_queue_start_func callback);

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -47,7 +47,7 @@
 
 using namespace std::literals;
 
-time_t tr::detail::tr_time::current_time = {};
+std::atomic<time_t> tr::detail::tr_time::current_time = {};
 
 // ---
 

--- a/libtransmission/utils.h
+++ b/libtransmission/utils.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <concepts>
 #include <cstddef> // size_t
 #include <cstdint> // uint8_t, uint32_t, uint64_t
@@ -136,8 +137,11 @@ template<std::floating_point T>
 
 namespace tr::detail::tr_time
 {
-extern time_t current_time;
-}
+// atomic so that readers on other threads, e.g. the verify and web
+// threads, get a coherent value without synchronizing with the session
+// thread's once-per-second update
+extern std::atomic<time_t> current_time;
+} // namespace tr::detail::tr_time
 
 /**
  * @brief very inexpensive form of time(nullptr)
@@ -151,13 +155,13 @@ extern time_t current_time;
  */
 [[nodiscard]] static inline time_t tr_time() noexcept
 {
-    return tr::detail::tr_time::current_time;
+    return tr::detail::tr_time::current_time.load(std::memory_order_relaxed);
 }
 
 /** @brief Private libtransmission function to update `tr_time()`'s counter */
-constexpr void tr_timeUpdate(time_t now) noexcept
+inline void tr_timeUpdate(time_t now) noexcept
 {
-    tr::detail::tr_time::current_time = now;
+    tr::detail::tr_time::current_time.store(now, std::memory_order_relaxed);
 }
 
 /** @brief Portability wrapper for `htonll()` that uses the system implementation if available */

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -2062,7 +2062,7 @@ static auto getSettingsFromNSUserDefaults(NSUserDefaults* defaults)
         anyCompleted |= torrent.finishedSeeding;
     }
 
-    BOOL anyActive = tr_sessionGetBusyTorrentCount(self.fLib) != 0;
+    BOOL const anyActive = tr_sessionIsBusy(self.fLib);
     PowerManager.shared.shouldPreventSleep = anyActive && [self.fDefaults boolForKey:@"SleepPrevent"];
 
     if (!NSApp.hidden) {

--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -617,8 +617,8 @@ void Session::updateStats(tr_variant* dict)
         updateStats(*var, cumulative_stats_);
     }
 
-    if (auto const busy = dictFind<int64_t>(dict, TR_KEY_busy_torrent_count); busy) {
-        set_has_busy_torrents(*busy > 0);
+    if (auto const busy = dictFind<bool>(dict, TR_KEY_busy)) {
+        set_busy(*busy);
     }
 
     emit statsUpdated();

--- a/tests/libtransmission-app/session-test.cc
+++ b/tests/libtransmission-app/session-test.cc
@@ -41,8 +41,8 @@ class TestSession : public Session
 {
 public:
     using Session::Session;
+    using Session::set_busy;
     using Session::set_embedded_session;
-    using Session::set_has_busy_torrents;
     using Session::set_session_type;
 };
 
@@ -78,8 +78,8 @@ TEST(AppSessionTest, inhibitsSleepOnlyWhenLocalActiveAndEnabled)
     session.set_session_type(Session::Type::Local); // a local daemon
     EXPECT_FALSE(session.should_inhibit_sleep()); // still nothing active
 
-    session.set_has_busy_torrents(true);
-    EXPECT_TRUE(session.should_inhibit_sleep()); // local + active + enabled
+    session.set_busy(true);
+    EXPECT_TRUE(session.should_inhibit_sleep()); // local + busy + enabled
 
     // toggling the preference is honored immediately
     prefs.set(TR_KEY_inhibit_desktop_hibernation, false);

--- a/tests/libtransmission/session-test.cc
+++ b/tests/libtransmission/session-test.cc
@@ -417,23 +417,23 @@ TEST_F(SessionTest, loadTorrentsThenMagnets)
     EXPECT_TRUE(tor->has_metainfo());
 }
 
-TEST_F(SessionTest, busyTorrentCount)
+TEST_F(SessionTest, isBusy)
 {
-    // no torrents -> none busy
-    EXPECT_EQ(0U, session_->busy_torrent_count());
+    // no torrents -> not busy
+    EXPECT_FALSE(session_->is_busy(tr_time()));
 
-    // a complete torrent added paused -> still none busy
+    // a complete torrent added paused -> not busy once its add-time verify finishes
     auto* const tor = zeroTorrentInit(ZeroTorrentState::Complete);
     ASSERT_NE(nullptr, tor);
-    EXPECT_EQ(0U, session_->busy_torrent_count());
+    EXPECT_TRUE(waitFor([this]() { return !session_->is_busy(tr_time()); }, 5s));
 
-    // once started it seeds (the seed queue is off by default) -> one busy
+    // starting it counts as busy, even with no peer to transfer with
     tr_torrentStart(tor);
-    EXPECT_TRUE(waitFor([this]() { return session_->busy_torrent_count() == 1U; }, 5s));
+    EXPECT_TRUE(waitFor([this]() { return session_->is_busy(tr_time()); }, 5s));
 
-    // stopping it -> none busy again
+    // stopping it -> not busy again, without waiting for the activity to go stale
     tr_torrentStop(tor);
-    EXPECT_TRUE(waitFor([this]() { return session_->busy_torrent_count() == 0U; }, 5s));
+    EXPECT_TRUE(waitFor([this]() { return !session_->is_busy(tr_time()); }, 5s));
 }
 
 namespace

--- a/tests/qt/session-test.cc
+++ b/tests/qt/session-test.cc
@@ -83,6 +83,7 @@ private slots:
     static void initTestCase()
     {
         TR_QT_SKIP_UNLESS_SIGNALS_WORK();
+        qRegisterMetaType<int64_t>("int64_t");
     }
 
     static void download_dir_change_posts_session_set_data()

--- a/tests/qt/session-test.cc
+++ b/tests/qt/session-test.cc
@@ -83,7 +83,6 @@ private slots:
     static void initTestCase()
     {
         TR_QT_SKIP_UNLESS_SIGNALS_WORK();
-        qRegisterMetaType<int64_t>("int64_t");
     }
 
     static void download_dir_change_posts_session_set_data()


### PR DESCRIPTION
## Description

Stacked on #250. Supersedes #241, CC @tearfur
Fixes a regression introduced by #138.

Fixes a race condition and improves performance by replacing `tr_sessionGetBusyTorrentCount()` with `tr_sessionIsBusy()`, which answers the question the count existed for -- "should we be inhibiting desktop hibernation?" -- without a session lock and without periodically walking the torrents.

`tr_session` keeps the answer current with relaxed atomics maintained by rare events: counts of started torrents and running verify jobs, an activity stamp on transfer/verify/start, and a busy window that mirrors the queue-stalled settings. `session_stats` gains a `busy` bool so RPC clients relay the daemon's answer instead of re-implementing the policy or comparing the daemon's clock against their own.

This modifies the RPC contract, but it's non-breaking since the modified pieces never shipped.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.