### PR TITLE
test: prevent resume tests from racing verification

### DIFF
--- a/tests/libtransmission/resume-test.cc
+++ b/tests/libtransmission/resume-test.cc
@@ -153,6 +153,10 @@ protected:
         builder.set_paused(true);
         EXPECT_TRUE(builder.set_metainfo(benc));
 
+        // Model an existing torrent with resume data. Save the metainfo first
+        // so tr_torrentNew() does not start background verification.
+        EXPECT_TRUE(builder.save(builder.metainfo().torrent_file(session_->torrentDir())));
+
         auto serde = tr_variant_serde::benc();
         auto const filename = builder.metainfo().resume_file(session_->resumeDir());
         EXPECT_TRUE(serde.to_file(tr_variant{ std::move(resume) }, filename)) << serde.error_;


### PR DESCRIPTION
Fixes #243

## Summary

`ResumeTest::torrentInit()` wrote a `.resume` file but did not save the corresponding `.torrent` file before calling `tr_torrentNew()`.

As a result, the torrent was treated as newly added and background verification could start. `ResumeTest.savedMtimesListWrittenWithoutZeroLengthFiles` reads the checked-piece state immediately after loading the resume data, so its result depended on whether the verifier had already run.

Save the metainfo before constructing the torrent so the test helper models an existing torrent loading its resume data and no background verification races the assertions.
