### PR TITLE
feat: add icon for finished torrents in filterbar

### DIFF
--- a/qt/FilterBar.cc
+++ b/qt/FilterBar.cc
@@ -58,7 +58,7 @@ FilterBarComboBox* FilterBar::createActivityCombo()
     add_row(ShowMode::ShowSeeding, tr("Seeding"), icons::Type::TorrentStateSeeding);
     add_row(ShowMode::ShowDownloading, tr("Downloading"), icons::Type::TorrentStateDownloading);
     add_row(ShowMode::ShowPaused, tr("Paused"), icons::Type::TorrentStatePaused);
-    add_row(ShowMode::ShowFinished, tr("Finished"), {});
+    add_row(ShowMode::ShowFinished, tr("Finished"), icons::Type::TorrentStateFinished);
     add_row(ShowMode::ShowVerifying, tr("Verifying"), icons::Type::TorrentStateVerifying);
     add_row(ShowMode::ShowError, tr("Error"), icons::Type::TorrentStateError);
 

--- a/qt/NativeIcon.cc
+++ b/qt/NativeIcon.cc
@@ -402,6 +402,12 @@ struct Info {
         fallback = QStyle::SP_MediaPause;
         break;
 
+    case Type::TorrentStateFinished:
+        sf_symbol_name = "checkmark.circle";
+        segoe_codepoint = 0xE73EU; // CheckMark
+        xdg_icon_name = "checkmark";
+        break;
+
     case Type::VerifyTorrent:
         [[fallthrough]];
 

--- a/qt/NativeIcon.h
+++ b/qt/NativeIcon.h
@@ -60,6 +60,7 @@ enum class Type : uint8_t {
     TorrentStateSeeding,
     TorrentStateDownloading,
     TorrentStatePaused,
+    TorrentStateFinished,
     TorrentStateVerifying,
     TorrentStateError
 };


### PR DESCRIPTION
## Description

The filterbar dropdown menu was missing an icon for torrents that are finished:

<img width="157" height="186" alt="finished_after" src="https://github.com/user-attachments/assets/58ab7964-80ea-4746-b40d-52d8f935f20b" />

Cherry-picked from https://github.com/transmission/transmission/commit/601cc5854580cfe8ae1aef06fd0e2c4f7087c9d6; author @fauxpark

Notes: Added a filterbar icon for finished torrents.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
