### PR TITLE
perf: hoist `tr_time()`

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -2506,7 +2506,11 @@ namespace connect_helpers
 }
 
 /* smaller value is better */
-[[nodiscard]] uint64_t getPeerCandidateScore(tr_torrent const* tor, tr_peer_info const& peer_info, uint8_t salt)
+[[nodiscard]] uint64_t getPeerCandidateScore(
+    tr_torrent const* tor,
+    tr_peer_info const& peer_info,
+    uint8_t salt,
+    time_t const now)
 {
     auto i = uint64_t{};
     auto score = uint64_t{};
@@ -2541,7 +2545,7 @@ namespace connect_helpers
     score = addValToKey(score, 2U, i);
 
     // prefer recently-started torrents
-    i = tor->started_recently(tr_time()) ? 0 : 1;
+    i = tor->started_recently(now) ? 0 : 1;
     score = addValToKey(score, 1U, i);
 
     /* prefer torrents we're downloading with */
@@ -2625,7 +2629,7 @@ void get_peer_candidates(size_t global_peer_limit, tr_torrents& torrents, tr_pee
 
         for (auto const& peer_info : std::views::values(swarm->connectable_pool)) {
             if (is_peer_candidate(tor, *peer_info, now)) {
-                candidates.emplace_back(getPeerCandidateScore(tor, *peer_info, salter()), tor, peer_info.get());
+                candidates.emplace_back(getPeerCandidateScore(tor, *peer_info, salter(), now), tor, peer_info.get());
             }
         }
     }

--- a/libtransmission/peer-msgs.cc
+++ b/libtransmission/peer-msgs.cc
@@ -1788,8 +1788,9 @@ ReadResult tr_peerMsgsImpl::read_piece_data(MessageReader& payload)
         }
     }
 
-    peer_info->set_latest_piece_data_time(tr_time());
-    bytes_sent_to_client.add(tr_time(), len);
+    auto const now = tr_time();
+    peer_info->set_latest_piece_data_time(now);
+    bytes_sent_to_client.add(now, len);
     publish(tr_peer_event::GotPieceData(len));
 
     if (loc.block_offset == 0U && len == block_size) // simple case: one message has entire block
@@ -1853,9 +1854,10 @@ void tr_peerMsgsImpl::did_write(tr_peerIo* /*io*/, size_t bytes_written, bool wa
     auto const msgs = static_cast<tr_peerMsgsImpl*>(vmsgs)->shared_from_this();
 
     if (was_piece_data) {
-        msgs->peer_info->set_latest_piece_data_time(tr_time());
+        auto const now = tr_time();
+        msgs->peer_info->set_latest_piece_data_time(now);
         msgs->publish(tr_peer_event::SentPieceData(bytes_written));
-        msgs->bytes_sent_to_peer.add(tr_time(), bytes_written);
+        msgs->bytes_sent_to_peer.add(now, bytes_written);
     }
 }
 

--- a/tests/qt/session-test.cc
+++ b/tests/qt/session-test.cc
@@ -83,6 +83,7 @@ private slots:
     static void initTestCase()
     {
         TR_QT_SKIP_UNLESS_SIGNALS_WORK();
+        qRegisterMetaType<int64_t>("int64_t");
     }
 
     static void download_dir_change_posts_session_set_data()


### PR DESCRIPTION
## Description

In cases where `tr_time()` is being called inside a loop, or back-to-back, hoist it into a local variable so there's only one call instead of N. This is consistent with how the rest of the codebase hoists the current time into a local variable. It's also a small performance win, though `tr_time()` is pretty inexpensive already.

Notes: Improved libtransmission code to use less CPU.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
