### PR TITLE
fix: apply honor-session-limits change to both directions

### DIFF
--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -252,8 +252,9 @@ void tr_torrentUseSessionLimits(tr_torrent* const tor, bool const enabled)
 {
     tr_return_if_fail(tr_isTorrent(tor));
 
-    if (tor->bandwidth().honor_parent_limits(tr_direction::Up, enabled) ||
-        tor->bandwidth().honor_parent_limits(tr_direction::Down, enabled)) {
+    auto const changed_up = tor->bandwidth().honor_parent_limits(tr_direction::Up, enabled);
+    auto const changed_down = tor->bandwidth().honor_parent_limits(tr_direction::Down, enabled);
+    if (changed_up || changed_down) {
         tor->set_dirty();
     }
 }

--- a/tests/libtransmission/torrent-test.cc
+++ b/tests/libtransmission/torrent-test.cc
@@ -7,7 +7,7 @@
 #include <cstddef>
 #include <ranges>
 
-#include <libtransmission/transmission.h>
+#include <libtransmission/types.h>
 
 #include <libtransmission/torrent.h>
 

--- a/tests/libtransmission/torrent-test.cc
+++ b/tests/libtransmission/torrent-test.cc
@@ -7,9 +7,8 @@
 #include <cstddef>
 #include <ranges>
 
-#include <libtransmission/types.h>
-
 #include <libtransmission/torrent.h>
+#include <libtransmission/types.h>
 
 #include "test-fixtures.h"
 

--- a/tests/libtransmission/torrent-test.cc
+++ b/tests/libtransmission/torrent-test.cc
@@ -7,6 +7,8 @@
 #include <cstddef>
 #include <ranges>
 
+#include <libtransmission/transmission.h>
+
 #include <libtransmission/torrent.h>
 
 #include "test-fixtures.h"
@@ -67,6 +69,23 @@ TEST_F(TorrentTest, queueMoveDown)
     for (size_t i = 0; i < ExpectedQueuePosition.size(); ++i) {
         EXPECT_EQ(ExpectedQueuePosition[i], torrents[i]->queue_position()) << i;
     }
+}
+
+TEST_F(TorrentTest, useSessionLimitsAffectsBothDirections)
+{
+    auto* const tor = torrentInitFromFile(TorFilenames[0]);
+    ASSERT_NE(nullptr, tor);
+
+    EXPECT_TRUE(tor->bandwidth().are_parent_limits_honored(tr_direction::Up));
+    EXPECT_TRUE(tor->bandwidth().are_parent_limits_honored(tr_direction::Down));
+
+    tr_torrentUseSessionLimits(tor, false);
+    EXPECT_FALSE(tor->bandwidth().are_parent_limits_honored(tr_direction::Up));
+    EXPECT_FALSE(tor->bandwidth().are_parent_limits_honored(tr_direction::Down));
+
+    tr_torrentUseSessionLimits(tor, true);
+    EXPECT_TRUE(tor->bandwidth().are_parent_limits_honored(tr_direction::Up));
+    EXPECT_TRUE(tor->bandwidth().are_parent_limits_honored(tr_direction::Down));
 }
 
 TEST_F(TorrentTest, queueMoveTop)


### PR DESCRIPTION
## Description

`tr_torrentUseSessionLimits()` used short-circuit evaluation to combine two setter calls. When the upload setting changed, the download setter was skipped, leaving the torrent unexpectedly subject to the session download limit.

Evaluate both directions before checking whether either changed, and add regression coverage for disabling and re-enabling the limits.

This is a parallel port of transmission/transmission#8960.

Notes: Fixed per-torrent session speed-limit overrides so they apply to both downloads and uploads.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.