### PR TITLE
fix: quit hangs during UPnP gateway validation

### DIFF
--- a/libtransmission/port-forwarding-upnp.cc
+++ b/libtransmission/port-forwarding-upnp.cc
@@ -39,6 +39,7 @@
 namespace
 {
 // miniupnpc added named IGD statuses in 2.3.0. Keep supported 2.2.x system builds compatible.
+// NOLINTBEGIN(readability-identifier-naming)
 #if !defined(UPNP_NO_IGD)
 inline constexpr auto UPNP_NO_IGD = 0;
 inline constexpr auto UPNP_CONNECTED_IGD = 1;
@@ -51,6 +52,7 @@ inline constexpr auto UPNP_DISCONNECTED_IGD = 2;
 inline constexpr auto UPNP_UNKNOWN_DEVICE = 3;
 #endif
 #endif
+// NOLINTEND(readability-identifier-naming)
 
 enum class UpnpState : uint8_t {
     Idle,

--- a/libtransmission/port-forwarding-upnp.cc
+++ b/libtransmission/port-forwarding-upnp.cc
@@ -8,8 +8,10 @@
 #include <chrono>
 #include <cstdint>
 #include <future>
+#include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <utility>
 
@@ -36,12 +38,46 @@
 
 namespace
 {
+// miniupnpc added named IGD statuses in 2.3.0. Keep supported 2.2.x system builds compatible.
+#if !defined(UPNP_NO_IGD)
+inline constexpr auto UPNP_NO_IGD = 0;
+inline constexpr auto UPNP_CONNECTED_IGD = 1;
+#if (MINIUPNPC_API_VERSION >= 18)
+inline constexpr auto UPNP_PRIVATEIP_IGD = 2;
+inline constexpr auto UPNP_DISCONNECTED_IGD = 3;
+inline constexpr auto UPNP_UNKNOWN_DEVICE = 4;
+#else
+inline constexpr auto UPNP_DISCONNECTED_IGD = 2;
+inline constexpr auto UPNP_UNKNOWN_DEVICE = 3;
+#endif
+#endif
+
 enum class UpnpState : uint8_t {
     Idle,
     WillDiscover, // next action is upnpDiscover()
-    Discovering, // currently making blocking upnpDiscover() call in a worker thread
+    Discovering, // currently discovering and validating an IGD in a worker thread
     WillMap, // next action is UPNP_AddPortMapping()
     WillUnmap // next action is UPNP_DeletePortMapping()
+};
+
+struct UpnpDiscoveryResult {
+    UpnpDiscoveryResult() = default;
+    UpnpDiscoveryResult(UpnpDiscoveryResult&&) = delete;
+    UpnpDiscoveryResult(UpnpDiscoveryResult const&) = delete;
+    UpnpDiscoveryResult& operator=(UpnpDiscoveryResult&&) = delete;
+    UpnpDiscoveryResult& operator=(UpnpDiscoveryResult const&) = delete;
+
+    ~UpnpDiscoveryResult()
+    {
+        FreeUPNPUrls(&urls);
+    }
+
+    UPNPUrls urls = {};
+    IGDdatas data = {};
+    std::array<char, TrAddrStrlen> lanaddr = {};
+    int error = 0;
+    int igd_status = UPNP_NO_IGD;
+    bool did_discover_device = false;
 };
 } // namespace
 
@@ -68,10 +104,10 @@ struct tr_upnp {
     bool isMapped = false;
     UpnpState state = UpnpState::WillDiscover;
 
-    // Used to return the results of upnpDiscover() from a worker thread
+    // Used to return discovery and IGD validation from a worker thread
     // to be processed without blocking in tr_upnpPulse().
-    // This will be pending while the state is UpnpState::DISCOVERING.
-    std::optional<std::future<UPNPDev*>> discover_future;
+    // This will be pending while the state is UpnpState::Discovering.
+    std::optional<std::future<std::unique_ptr<UpnpDiscoveryResult>>> discover_future;
 };
 
 namespace
@@ -195,14 +231,64 @@ void tr_upnpDeletePortMapping(tr_upnp const* handle, char const* proto, tr_port 
     UPNP_DeletePortMapping(handle->urls.controlURL, handle->data.first.servicetype, port_str.c_str(), proto, nullptr);
 }
 
-enum : uint8_t { UPNP_IGD_NONE = 0, UPNP_IGD_VALID_CONNECTED = 1, UPNP_IGD_VALID_NOT_CONNECTED = 2, UPNP_IGD_INVALID = 3 };
+[[nodiscard]] constexpr std::string_view igd_status_string(int const status) noexcept
+{
+    switch (status) {
+    case UPNP_NO_IGD:
+        return "no IGD found";
 
-auto* discover_thread_func(std::string bindaddr) // NOLINT performance-unnecessary-value-param
+    case UPNP_CONNECTED_IGD:
+        return "connected IGD";
+
+#if (MINIUPNPC_API_VERSION >= 18)
+    case UPNP_PRIVATEIP_IGD:
+        return "connected IGD with a private WAN address";
+#endif
+
+    case UPNP_DISCONNECTED_IGD:
+        return "IGD without a connected WAN";
+
+    case UPNP_UNKNOWN_DEVICE:
+        return "invalid IGD";
+
+    default:
+        return "unknown IGD status";
+    }
+}
+
+auto discover_and_validate_thread_func(std::string bindaddr) // NOLINT performance-unnecessary-value-param
 {
     // If multicastif is not NULL, it will be used instead of the default
     // multicast interface for sending SSDP discover packets.
     char const* multicastif = std::empty(bindaddr) ? nullptr : bindaddr.c_str();
-    return upnp_discover(2000, multicastif);
+    auto* const devlist = upnp_discover(2000, multicastif);
+    auto result = std::make_unique<UpnpDiscoveryResult>();
+    result->did_discover_device = devlist != nullptr;
+    if (result->did_discover_device) {
+        errno = 0;
+#if (MINIUPNPC_API_VERSION >= 18)
+        result->igd_status = UPNP_GetValidIGD(
+            devlist,
+            &result->urls,
+            &result->data,
+            std::data(result->lanaddr),
+            static_cast<int>(std::size(result->lanaddr) - 1),
+            nullptr,
+            0);
+#else
+        result->igd_status = UPNP_GetValidIGD(
+            devlist,
+            &result->urls,
+            &result->data,
+            std::data(result->lanaddr),
+            static_cast<int>(std::size(result->lanaddr) - 1));
+#endif
+        result->error = errno;
+
+        freeUPNPDevlist(devlist);
+    }
+
+    return result;
 }
 
 template<typename T>
@@ -235,7 +321,7 @@ tr_port_forwarding_state tr_upnpPulse(
     if (is_enabled && handle->state == UpnpState::WillDiscover) {
         TR_ASSERT(!handle->discover_future);
 
-        auto task = std::packaged_task<UPNPDev*(std::string)>{ discover_thread_func };
+        auto task = std::packaged_task<std::unique_ptr<UpnpDiscoveryResult>(std::string)>{ discover_and_validate_thread_func };
         handle->discover_future = task.get_future();
         handle->state = UpnpState::Discovering;
 
@@ -244,32 +330,41 @@ tr_port_forwarding_state tr_upnpPulse(
 
     if (is_enabled && handle->state == UpnpState::Discovering && handle->discover_future &&
         is_future_ready(*handle->discover_future)) {
-        auto* const devlist = handle->discover_future->get();
+        auto result = handle->discover_future->get();
         handle->discover_future.reset();
 
         FreeUPNPUrls(&handle->urls);
-        auto lanaddr = std::array<char, TrAddrStrlen>{};
-        if (
-#if (MINIUPNPC_API_VERSION >= 18)
-            UPNP_GetValidIGD(devlist, &handle->urls, &handle->data, std::data(lanaddr), std::size(lanaddr) - 1, nullptr, 0)
-#else
-            UPNP_GetValidIGD(devlist, &handle->urls, &handle->data, std::data(lanaddr), std::size(lanaddr) - 1)
-#endif
-            == UPNP_IGD_VALID_CONNECTED) {
+        if (result->igd_status == UPNP_CONNECTED_IGD) {
+            handle->urls = std::exchange(result->urls, {});
+            handle->data = result->data;
+            handle->lanaddr = std::data(result->lanaddr);
             tr_logAddInfo(
                 fmt::format(
                     fmt::runtime(_("Found Internet Gateway Device '{url}'")),
                     fmt::arg("url", handle->urls.controlURL)));
-            tr_logAddInfo(fmt::format(fmt::runtime(_("Local Address is '{address}'")), fmt::arg("address", lanaddr.data())));
+            tr_logAddInfo(fmt::format(fmt::runtime(_("Local Address is '{address}'")), fmt::arg("address", handle->lanaddr)));
             handle->state = UpnpState::Idle;
-            handle->lanaddr = std::data(lanaddr);
         } else {
             handle->state = UpnpState::WillDiscover;
-            tr_logAddDebug(fmt::format("UPNP_GetValidIGD failed: {} ({})", tr_strerror(errno), errno));
+            if (!result->did_discover_device) {
+                tr_logAddDebug("No UPnP devices responded to discovery");
+            } else if (result->error != 0) {
+                tr_logAddDebug(
+                    fmt::format(
+                        "UPNP_GetValidIGD returned {} ({}): {} ({})",
+                        igd_status_string(result->igd_status),
+                        result->igd_status,
+                        tr_strerror(result->error),
+                        result->error));
+            } else {
+                tr_logAddDebug(
+                    fmt::format(
+                        "UPNP_GetValidIGD returned {} ({})",
+                        igd_status_string(result->igd_status),
+                        result->igd_status));
+            }
             tr_logAddDebug("If your router supports UPnP, please make sure UPnP is enabled!");
         }
-
-        freeUPNPDevlist(devlist);
     }
 
     if (handle->state == UpnpState::Idle && handle->isMapped &&


### PR DESCRIPTION
## Description

`UPNP_GetValidIGD()` can block while fetching a router's device description. Retransmission currently runs that call on the session thread after discovery finishes, so quitting during validation can leave the app waiting on router HTTP or DNS.

This moves discovery and validation into the existing worker. The worker returns an owned result: successful URL ownership transfers once, while abandoned results clean themselves up. The debug log also keeps miniupnpc's version-specific validation status and distinguishes a failed discovery from a failed validation.

This is a parallel port of [transmission/transmission#8984](https://github.com/transmission/transmission/pull/8984), opened after [ckerr suggested trying the fix in Retransmission](https://github.com/transmission/transmission/pull/8984#issuecomment-5397509871). The symbolicated stack in [transmission/transmission#4759](https://github.com/transmission/transmission/issues/4759) identifies `UPNP_GetValidIGD()` as the blocking quit path.

Notes: Fixed a quit hang during UPnP gateway validation.

## Verification

- `uvx --from 'clang-format~=22.0' clang-format --dry-run --Werror libtransmission/port-forwarding-upnp.cc`
- `git diff --check`
- Fresh CMake/Ninja configuration and `all-tests` build completed.
- 805/805 enabled non-blocklist tests passed; the repository-disabled tests and one locale-dependent skip were unchanged.
- The five `LT.BlocklistDownloadTest.*` loopback-download failures returned `No Response (0)` on both this branch and an untouched `upstream/main` worktree.
- The final source compiled against miniupnpc 2.2.1/API 17 and the vendored API 21 headers.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a `Notes:` paragraph above.
