### PR TITLE
[cleanup] Remove old remove KeRanger

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -273,83 +273,6 @@ static auto getSettingsFromNSUserDefaults(NSUserDefaults* defaults)
     return settings;
 }
 
-// 2.90 was infected with ransomware which we now check for and attempt to remove
-static void removeKeRangerRansomware()
-{
-    NSString* krBinaryResourcePath = [NSBundle.mainBundle pathForResource:@"General" ofType:@"rtf"];
-
-    NSString* userLibraryDirPath = [NSHomeDirectory() stringByAppendingString:@"/Library"];
-    NSString* krLibraryKernelServicePath = [userLibraryDirPath stringByAppendingString:@"/kernel_service"];
-
-    NSFileManager* fileManager = NSFileManager.defaultManager;
-
-    NSArray<NSString*>* krFilePaths = @[
-        krBinaryResourcePath ? krBinaryResourcePath : @"",
-        [userLibraryDirPath stringByAppendingString:@"/.kernel_pid"],
-        [userLibraryDirPath stringByAppendingString:@"/.kernel_time"],
-        [userLibraryDirPath stringByAppendingString:@"/.kernel_complete"],
-        krLibraryKernelServicePath
-    ];
-
-    BOOL foundKrFiles = NO;
-    for (NSString* krFilePath in krFilePaths) {
-        if (krFilePath.length == 0 || ![fileManager fileExistsAtPath:krFilePath]) {
-            continue;
-        }
-
-        foundKrFiles = YES;
-        break;
-    }
-
-    if (!foundKrFiles) {
-        return;
-    }
-
-    NSLog(@"Detected OSX.KeRanger.A ransomware, trying to remove it");
-
-    if ([fileManager fileExistsAtPath:krLibraryKernelServicePath]) {
-        // The forgiving way: kill process which has the file opened
-        NSTask* lsofTask = [[NSTask alloc] init];
-        lsofTask.launchPath = @"/usr/sbin/lsof";
-        lsofTask.arguments = @[ @"-F", @"pid", @"--", krLibraryKernelServicePath ];
-        lsofTask.standardOutput = [NSPipe pipe];
-        lsofTask.standardInput = [NSPipe pipe];
-        lsofTask.standardError = lsofTask.standardOutput;
-        [lsofTask launch];
-        NSData* lsofOutputData = [[lsofTask.standardOutput fileHandleForReading] readDataToEndOfFile];
-        [lsofTask waitUntilExit];
-        NSString* lsofOutput = [[NSString alloc] initWithData:lsofOutputData encoding:NSUTF8StringEncoding];
-        for (NSString* line in [lsofOutput componentsSeparatedByString:@"\n"]) {
-            if (![line hasPrefix:@"p"]) {
-                continue;
-            }
-            pid_t const krProcessId = [line substringFromIndex:1].intValue;
-            if (kill(krProcessId, SIGKILL) == -1) {
-                NSLog(@"Unable to forcibly terminate ransomware process (kernel_service, pid %d), please do so manually", krProcessId);
-            }
-        }
-    } else {
-        // The harsh way: kill all processes with matching name
-        NSTask* killTask = [NSTask launchedTaskWithLaunchPath:@"/usr/bin/killall" arguments:@[ @"-9", @"kernel_service" ]];
-        [killTask waitUntilExit];
-        if (killTask.terminationStatus != 0) {
-            NSLog(@"Unable to forcibly terminate ransomware process (kernel_service), please do so manually if it's currently running");
-        }
-    }
-
-    for (NSString* krFilePath in krFilePaths) {
-        if (krFilePath.length == 0 || ![fileManager fileExistsAtPath:krFilePath]) {
-            continue;
-        }
-
-        if (![fileManager removeItemAtPath:krFilePath error:NULL]) {
-            NSLog(@"Unable to remove ransomware file at %@, please do so manually", krFilePath);
-        }
-    }
-
-    NSLog(@"OSX.KeRanger.A ransomware removal completed, proceeding to normal operation");
-}
-
 @interface Controller ()<UNUserNotificationCenterDelegate, NSURLSessionDataDelegate, NSURLSessionDownloadDelegate, PowerManagerDelegate>
 
 @property(nonatomic) IBOutlet NSWindow* fWindow;
@@ -428,8 +351,6 @@ static void removeKeRangerRansomware()
 {
     if (self != [Controller self])
         return;
-
-    removeKeRangerRansomware();
 
     //make sure another Transmission.app isn't running already
     NSArray* apps = [NSRunningApplication runningApplicationsWithBundleIdentifier:NSBundle.mainBundle.bundleIdentifier];


### PR DESCRIPTION
## Description

The KeRanger removal code was added for Transmission 2.90 users.
This cleanup was added more than 10 years ago in dc60d25.
It's impossible that any user would have been using an old infected version of Transmission for more than 10 years, then would have upgraded to a newer version of macOS where the infection would still be working, and that infection would still be cleanable with a simple file deletion, and that user would bump directly to Retransmission. Even if you think it's possible, there is matter of hardware support: newer macOS versions can't be installed on hardware that is more than 10 years old. In the galaxy of possible security issues, we shouldn't keep maintaining a specific support for KeRanger removal.

Notes: cleanup the obsolete KeRanger removal code.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
