### PR TITLE
refactor: simplify log impl

### DIFF
--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -39,8 +39,6 @@ using namespace std::literals;
 
 namespace
 {
-inline constexpr auto MaxQueueLength = 10000U;
-
 // TODO(c++20): switch to std::chrono::zoned_time, GCC 13.1, clang 19 (or clang 21 with std::format), fmt 11.2
 template<typename T>
 inline constexpr bool HasTmGmtoffV = requires(T t) { t.tm_gmtoff; };
@@ -48,18 +46,33 @@ inline constexpr bool HasTmGmtoffV = requires(T t) { t.tm_gmtoff; };
 class tr_log_state
 {
 public:
-    [[nodiscard]] auto unique_lock()
+    [[nodiscard]] tr_log_messages take_queue()
     {
-        return std::unique_lock(message_mutex_);
+        auto const lock = std::scoped_lock{ queue_mutex_ };
+
+        return std::exchange(queue_, {});
+    }
+
+    void append_to_queue(tr_log_message&& message)
+    {
+        auto const lock = std::scoped_lock{ queue_mutex_ };
+
+        queue_.push_back(std::move(message));
+        if (std::size(queue_) > MaxQueueLength) {
+            queue_.pop_front();
+        }
     }
 
     tr_log_level level = TR_LOG_ERROR;
 
     bool queue_enabled_ = false;
 
-    tr_log_messages queue_;
+private:
+    static constexpr auto MaxQueueLength = 10000U;
 
-    std::recursive_mutex message_mutex_;
+    std::mutex queue_mutex_;
+
+    tr_log_messages queue_;
 };
 
 auto log_state = tr_log_state{};
@@ -67,17 +80,15 @@ auto log_state = tr_log_state{};
 // ---
 
 void logAddImpl(
-    [[maybe_unused]] std::string_view file,
-    [[maybe_unused]] long line,
-    [[maybe_unused]] tr_log_level level,
+    [[maybe_unused]] std::string_view const file,
+    [[maybe_unused]] long const line,
+    [[maybe_unused]] tr_log_level const level,
     std::string&& msg,
-    [[maybe_unused]] std::string_view name)
+    [[maybe_unused]] std::string_view const name)
 {
     if (std::empty(msg)) {
         return;
     }
-
-    auto const lock = log_state.unique_lock();
 
 #if defined(__ANDROID__)
 
@@ -113,17 +124,15 @@ void logAddImpl(
 #else
 
     if (log_state.queue_enabled_) {
-        auto& newmsg = log_state.queue_.emplace_back();
-        newmsg.level = level;
-        newmsg.when = std::chrono::system_clock::now();
-        newmsg.message = std::move(msg);
-        newmsg.file = file;
-        newmsg.line = line;
-        newmsg.name = name;
-
-        if (std::size(log_state.queue_) > MaxQueueLength) {
-            log_state.queue_.pop_front();
-        }
+        log_state.append_to_queue(
+            {
+                .level = level,
+                .file = file,
+                .line = line,
+                .when = std::chrono::system_clock::now(),
+                .name = std::string{ name },
+                .message = std::move(msg),
+            });
     } else {
         auto buf = std::array<char, 64U>{};
         auto const timestr = tr_logGetTimeStr(std::data(buf), std::size(buf));
@@ -161,9 +170,7 @@ void tr_logSetQueueEnabled(bool is_enabled)
 
 tr_log_messages tr_logGetQueue()
 {
-    auto const lock = log_state.unique_lock();
-
-    return std::exchange(log_state.queue_, {});
+    return log_state.take_queue();
 }
 
 void tr_logClearQueue()
@@ -231,8 +238,6 @@ void tr_logAddMessage(char const* file, long line, tr_log_level level, std::stri
         errno = err;
         return;
     }
-
-    auto const lock = log_state.unique_lock();
 
     // don't log the same warning ad infinitum.
     // at some point, it stops being useful.

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -95,6 +95,9 @@ void logAddImpl(
     int prio;
 
     switch (level) {
+    case TR_LOG_OFF:
+        prio = ANDROID_LOG_SILENT;
+        break;
     case TR_LOG_CRITICAL:
         prio = ANDROID_LOG_FATAL;
         break;

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -43,6 +43,25 @@ namespace
 template<typename T>
 inline constexpr bool HasTmGmtoffV = requires(T t) { t.tm_gmtoff; };
 
+class errno_saver
+{
+    errno_saver() noexcept
+        : errno_{ errno }
+    {
+    }
+
+    ~errno_saver()
+    {
+        errno = errno_;
+    }
+
+    errno_saver(errno_saver const&) = delete;
+    errno_saver& operator=(errno_saver const&) = delete;
+
+private:
+    int const errno_;
+};
+
 class tr_log_state
 {
 public:
@@ -233,12 +252,10 @@ void tr_logAddMessage(char const* file, long line, tr_log_level level, std::stri
         name = name_fallback;
     }
 
-    // message logging shouldn't affect errno
-    int const err = errno;
+    auto const errno_lock = errno_saver{};
 
     // skip unwanted messages
     if (!tr_logLevelIsActive(level)) {
-        errno = err;
         return;
     }
 
@@ -253,7 +270,6 @@ void tr_logAddMessage(char const* file, long line, tr_log_level level, std::stri
         ++count;
         last_one = count == MaxRepeat;
         if (count > MaxRepeat) {
-            errno = err;
             return;
         }
     }
@@ -264,8 +280,6 @@ void tr_logAddMessage(char const* file, long line, tr_log_level level, std::stri
         char const* final_msg = _("Too many messages like this! I won't log this message anymore this session.");
         logAddImpl(filename, line, level, final_msg, name);
     }
-
-    errno = err;
 }
 
 // ---

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -43,6 +43,8 @@ namespace
 template<typename T>
 inline constexpr bool HasTmGmtoffV = requires(T t) { t.tm_gmtoff; };
 
+tr_log_level log_level_ = TR_LOG_ERROR;
+
 class errno_saver
 {
     errno_saver() noexcept
@@ -81,8 +83,6 @@ public:
             queue_.pop_front();
         }
     }
-
-    tr_log_level level = TR_LOG_ERROR;
 
     bool queue_enabled_ = false;
 
@@ -172,17 +172,17 @@ void logAddImpl(
 
 tr_log_level tr_logGetLevel()
 {
-    return log_state.level;
+    return log_level_;
 }
 
-bool tr_logLevelIsActive(tr_log_level level)
+bool tr_logLevelIsActive(tr_log_level const level)
 {
-    return tr_logGetLevel() >= level;
+    return log_level_ >= level;
 }
 
-void tr_logSetLevel(tr_log_level level)
+void tr_logSetLevel(tr_log_level const level)
 {
-    log_state.level = level;
+    log_level_ = level;
 }
 
 void tr_logSetQueueEnabled(bool is_enabled)

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -45,28 +45,6 @@ inline constexpr bool HasTmGmtoffV = requires(T t) { t.tm_gmtoff; };
 
 tr_log_level log_level = TR_LOG_ERROR;
 
-class errno_saver
-{
-public:
-    errno_saver() noexcept
-        : errno_{ errno }
-    {
-    }
-
-    ~errno_saver()
-    {
-        errno = errno_;
-    }
-
-    errno_saver(errno_saver&&) = delete;
-    errno_saver(errno_saver const&) = delete;
-    errno_saver& operator=(errno_saver&&) = delete;
-    errno_saver& operator=(errno_saver const&) = delete;
-
-private:
-    int const errno_;
-};
-
 class tr_log_queue
 {
 public:
@@ -265,10 +243,12 @@ void tr_logAddMessage(char const* file, long line, tr_log_level level, std::stri
         name = name_fallback;
     }
 
-    auto const errno_lock = errno_saver{};
+    // message logging shouldn't affect errno
+    int const err = errno;
 
     // skip unwanted messages
     if (!tr_logLevelIsActive(level)) {
+        errno = err;
         return;
     }
 
@@ -283,6 +263,7 @@ void tr_logAddMessage(char const* file, long line, tr_log_level level, std::stri
         ++count;
         last_one = count == MaxRepeat;
         if (count > MaxRepeat) {
+            errno = err;
             return;
         }
     }
@@ -293,6 +274,8 @@ void tr_logAddMessage(char const* file, long line, tr_log_level level, std::stri
         char const* final_msg = _("Too many messages like this! I won't log this message anymore this session.");
         logAddImpl(filename, line, level, final_msg, name);
     }
+
+    errno = err;
 }
 
 // ---

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -43,10 +43,11 @@ namespace
 template<typename T>
 inline constexpr bool HasTmGmtoffV = requires(T t) { t.tm_gmtoff; };
 
-tr_log_level log_level_ = TR_LOG_ERROR;
+tr_log_level log_level = TR_LOG_ERROR;
 
 class errno_saver
 {
+public:
     errno_saver() noexcept
         : errno_{ errno }
     {
@@ -57,24 +58,26 @@ class errno_saver
         errno = errno_;
     }
 
+    errno_saver(errno_saver&&) = delete;
     errno_saver(errno_saver const&) = delete;
+    errno_saver& operator=(errno_saver&&) = delete;
     errno_saver& operator=(errno_saver const&) = delete;
 
 private:
     int const errno_;
 };
 
-class tr_log_state
+class tr_log_queue
 {
 public:
-    [[nodiscard]] tr_log_messages take_queue()
+    [[nodiscard]] tr_log_messages take()
     {
         auto const lock = std::scoped_lock{ queue_mutex_ };
 
         return std::exchange(queue_, {});
     }
 
-    void append_to_queue(tr_log_message&& message)
+    void append(tr_log_message&& message)
     {
         auto const lock = std::scoped_lock{ queue_mutex_ };
 
@@ -84,7 +87,15 @@ public:
         }
     }
 
-    bool queue_enabled_ = false;
+    constexpr void set_enabled(bool const is_enabled) noexcept
+    {
+        is_enabled_ = is_enabled;
+    }
+
+    [[nodiscard]] constexpr bool is_enabled() const noexcept
+    {
+        return is_enabled_;
+    }
 
 private:
     static constexpr auto MaxQueueLength = 10000U;
@@ -92,9 +103,11 @@ private:
     std::mutex queue_mutex_;
 
     tr_log_messages queue_;
+
+    bool is_enabled_ = false;
 };
 
-auto log_state = tr_log_state{};
+auto log_queue = tr_log_queue{};
 
 // ---
 
@@ -145,8 +158,8 @@ void logAddImpl(
 
 #else
 
-    if (log_state.queue_enabled_) {
-        log_state.append_to_queue(
+    if (log_queue.is_enabled()) {
+        log_queue.append(
             {
                 .level = level,
                 .file = file,
@@ -172,27 +185,27 @@ void logAddImpl(
 
 tr_log_level tr_logGetLevel()
 {
-    return log_level_;
+    return log_level;
 }
 
 bool tr_logLevelIsActive(tr_log_level const level)
 {
-    return log_level_ >= level;
+    return log_level >= level;
 }
 
 void tr_logSetLevel(tr_log_level const level)
 {
-    log_level_ = level;
+    log_level = level;
 }
 
-void tr_logSetQueueEnabled(bool is_enabled)
+void tr_logSetQueueEnabled(bool const is_enabled)
 {
-    log_state.queue_enabled_ = is_enabled;
+    log_queue.set_enabled(is_enabled);
 }
 
 tr_log_messages tr_logGetQueue()
 {
-    return log_state.take_queue();
+    return log_queue.take();
 }
 
 void tr_logClearQueue()


### PR DESCRIPTION
## Description

Small cleanups in `libtransmission/log.cc`:

- Use a `std::mutex` instead of a `std::recursive_mutex` to lock the queue; the latter was overkill. This is the perf improvement.
- Use designated initializers when instantiating the `tr_log_message` struct
- Move queue trimming logic into `tr_log_queue` struct
- Minor const correctness

Notes: Improved libtransmission code to use less CPU.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
