### PR TITLE
refactor: encapsulate group cell internal views.

### DIFF
--- a/macosx/GroupCell.h
+++ b/macosx/GroupCell.h
@@ -7,12 +7,11 @@
 
 @interface GroupCell : NSTableCellView
 
-@property(nonatomic) NSImageView* fGroupIndicatorView;
-@property(nonatomic) NSTextField* fGroupTitleField;
+@property(nonatomic) NSImageView* indicatorView;
+@property(nonatomic) NSTextField* titleField;
 
-@property(nonatomic) NSImageView* fGroupDownloadView;
-@property(nonatomic) NSImageView* fGroupUploadAndRatioView;
-@property(nonatomic) NSTextField* fGroupDownloadField;
-@property(nonatomic) NSTextField* fGroupUploadAndRatioField;
+- (void)setDownloadSpeed:(CGFloat)downloadSpeed uploadSpeed:(CGFloat)uploadSpeed ratio:(CGFloat)ratio;
+- (void)setDisplayRatio:(BOOL)displayRatio;
+- (void)setTooltipForTorrentsCount:(NSUInteger)count;
 
 @end

--- a/macosx/GroupCell.h
+++ b/macosx/GroupCell.h
@@ -7,11 +7,12 @@
 
 @interface GroupCell : NSTableCellView
 
-@property(nonatomic) NSImageView* indicatorView;
-@property(nonatomic) NSTextField* titleField;
+- (void)updateImage:(NSImage*)image;
+- (void)updateTitle:(NSString*)title;
+- (void)updateDownloadSpeed:(CGFloat)downloadSpeed uploadSpeed:(CGFloat)uploadSpeed ratio:(CGFloat)ratio;
+- (void)updateDisplayRatio:(BOOL)displayRatio;
+- (void)updateTooltipForTorrentsCount:(NSUInteger)count;
 
-- (void)setDownloadSpeed:(CGFloat)downloadSpeed uploadSpeed:(CGFloat)uploadSpeed ratio:(CGFloat)ratio;
-- (void)setDisplayRatio:(BOOL)displayRatio;
-- (void)setTooltipForTorrentsCount:(NSUInteger)count;
+@property(nonatomic, readonly) CGRect frameForTitle;
 
 @end

--- a/macosx/GroupCell.mm
+++ b/macosx/GroupCell.mm
@@ -3,6 +3,14 @@
 // License text can be found in the licenses/ folder.
 
 #import "GroupCell.h"
+#import "NSStringAdditions.h"
+
+@interface GroupCell ()
+@property(nonatomic, readonly) NSStackView* stackView;
+@property(nonatomic, readonly) NSButton* downloadButton;
+@property(nonatomic, readonly) NSButton* uploadButton;
+@property(nonatomic, readonly) NSButton* ratioButton;
+@end
 
 @implementation GroupCell
 
@@ -20,90 +28,78 @@
 {
     auto indicatorView = [[NSImageView alloc] init];
     indicatorView.imageScaling = NSImageScaleProportionallyDown;
-    self.fGroupIndicatorView = indicatorView;
 
     auto titleField = [[NSTextField alloc] init];
+    titleField.editable = NO;
+    titleField.selectable = NO;
+    titleField.bordered = NO;
+    titleField.font = [NSFont boldSystemFontOfSize:NSFont.smallSystemFontSize];
+    titleField.drawsBackground = NO;
     titleField.textColor = NSColor.secondaryLabelColor;
     titleField.lineBreakMode = NSLineBreakByTruncatingMiddle;
-    self.fGroupTitleField = titleField;
     titleField.allowsExpansionToolTips = YES;
 
-    auto downloadView = [[NSImageView alloc] init];
-    downloadView.imageScaling = NSImageScaleProportionallyDown;
-    self.fGroupDownloadView = downloadView;
+    auto downloadButton = [NSButton buttonWithTitle:@"" image:[NSImage imageNamed:@"DownArrowGroupTemplate"] target:nil action:nil];
+    downloadButton.toolTip = NSLocalizedString(@"Download speed", "Torrent table -> group row -> tooltip");
 
-    auto downloadField = [[NSTextField alloc] init];
-    downloadField.textColor = NSColor.secondaryLabelColor;
-    downloadField.lineBreakMode = NSLineBreakByClipping;
-    self.fGroupDownloadField = downloadField;
+    auto uploadButton = [NSButton buttonWithTitle:@"" image:[NSImage imageNamed:@"UpArrowGroupTemplate"] target:nil action:nil];
+    uploadButton.toolTip = NSLocalizedString(@"Upload speed", "Torrent table -> group row -> tooltip");
+    uploadButton.image.accessibilityDescription = NSLocalizedString(@"UL", "Torrent -> status image");
 
-    auto uploadAndRatioView = [[NSImageView alloc] init];
-    uploadAndRatioView.imageScaling = NSImageScaleProportionallyDown;
-    self.fGroupUploadAndRatioView = uploadAndRatioView;
+    auto ratioButton = [NSButton buttonWithTitle:@"" image:[NSImage imageNamed:@"YingYangGroupTemplate"] target:nil action:nil];
+    ratioButton.toolTip = NSLocalizedString(@"Ratio", "Torrent table -> group row -> tooltip");
+    ratioButton.image.accessibilityDescription = NSLocalizedString(@"Ratio", "Torrent -> status image");
 
-    auto uploadAndRatioField = [[NSTextField alloc] init];
-    uploadAndRatioField.textColor = NSColor.secondaryLabelColor;
-    uploadAndRatioField.lineBreakMode = NSLineBreakByClipping;
-    self.fGroupUploadAndRatioField = uploadAndRatioField;
-
-    for (NSTextField* view in @[ titleField, downloadField, uploadAndRatioField ]) {
-        view.editable = NO;
-        view.selectable = NO;
-        view.bordered = NO;
-        view.font = [NSFont boldSystemFontOfSize:NSFont.smallSystemFontSize];
-        view.drawsBackground = NO;
+    for (NSButton* button in @[ downloadButton, uploadButton, ratioButton ]) {
+        button.imageScaling = NSImageScaleProportionallyDown;
+        button.imagePosition = NSImageLeft;
+        button.bordered = NO;
+        button.font = [NSFont boldSystemFontOfSize:NSFont.smallSystemFontSize];
+        button.contentTintColor = NSColor.secondaryLabelColor;
+        button.lineBreakMode = NSLineBreakByClipping;
     }
 
-    for (NSView* view in @[ indicatorView, titleField, downloadView, downloadField, uploadAndRatioView, uploadAndRatioField ]) {
+    auto stackView = [[NSStackView alloc] initWithFrame:NSZeroRect];
+
+    [stackView addArrangedSubview:downloadButton];
+    [stackView addArrangedSubview:uploadButton];
+    [stackView addArrangedSubview:ratioButton];
+
+    for (NSView* view in @[ indicatorView, titleField, stackView ]) {
         view.translatesAutoresizingMaskIntoConstraints = NO;
         [self addSubview:view];
     }
+
+    _indicatorView = indicatorView;
+    _titleField = titleField;
+    _downloadButton = downloadButton;
+    _uploadButton = uploadButton;
+    _ratioButton = ratioButton;
+    _stackView = stackView;
 }
 
 - (void)setupConstraints
 {
     [NSLayoutConstraint activateConstraints:@[
         // IndicatorView
-        [self.fGroupIndicatorView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:11],
-        [self.fGroupIndicatorView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-        [self.fGroupIndicatorView.widthAnchor constraintEqualToConstant:14],
-        [self.fGroupIndicatorView.heightAnchor constraintEqualToConstant:14],
+        [self.indicatorView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:11],
+        [self.indicatorView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [self.indicatorView.widthAnchor constraintEqualToConstant:14],
+        [self.indicatorView.heightAnchor constraintEqualToConstant:14],
 
         // TitleField
-        [self.fGroupTitleField.leadingAnchor constraintEqualToAnchor:self.fGroupIndicatorView.trailingAnchor constant:5],
-        [self.fGroupTitleField.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [self.titleField.leadingAnchor constraintEqualToAnchor:self.indicatorView.trailingAnchor constant:5],
+        [self.titleField.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
 
-        // DownloadView
-        [self.fGroupTitleField.trailingAnchor constraintEqualToAnchor:self.fGroupDownloadView.leadingAnchor],
-        [self.fGroupDownloadView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-        [self.fGroupDownloadView.widthAnchor constraintEqualToConstant:16],
-        [self.fGroupDownloadView.heightAnchor constraintEqualToConstant:16],
-
-        // DownloadField
-        [self.fGroupDownloadView.trailingAnchor constraintEqualToAnchor:self.fGroupDownloadField.leadingAnchor],
-        [self.fGroupDownloadField.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-        [self.fGroupDownloadField.widthAnchor constraintGreaterThanOrEqualToConstant:60],
-
-        // UploadAndRatioView
-        [self.fGroupUploadAndRatioView.leadingAnchor constraintEqualToAnchor:self.fGroupDownloadField.trailingAnchor constant:8],
-        [self.fGroupUploadAndRatioView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-        [self.fGroupUploadAndRatioView.widthAnchor constraintEqualToConstant:16],
-        [self.fGroupUploadAndRatioView.heightAnchor constraintEqualToConstant:16],
-
-        // UploadAndRatioField
-        [self.fGroupUploadAndRatioField.leadingAnchor constraintEqualToAnchor:self.fGroupUploadAndRatioView.trailingAnchor],
-        [self.fGroupUploadAndRatioField.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-5],
-        [self.fGroupUploadAndRatioField.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-        [self.fGroupUploadAndRatioField.widthAnchor constraintGreaterThanOrEqualToConstant:60],
+        // StackView
+        [self.stackView.leadingAnchor constraintGreaterThanOrEqualToAnchor:self.titleField.trailingAnchor],
+        [self.stackView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-5],
+        [self.stackView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [self.stackView.heightAnchor constraintEqualToConstant:16],
     ]];
 
-    [self.fGroupTitleField setContentCompressionResistancePriority:NSLayoutPriorityDefaultLow
-                                                    forOrientation:NSLayoutConstraintOrientationHorizontal];
-
-    [self.fGroupDownloadField setContentHuggingPriority:NSLayoutPriorityDefaultLow + 1
-                                         forOrientation:NSLayoutConstraintOrientationHorizontal];
-    [self.fGroupUploadAndRatioField setContentHuggingPriority:NSLayoutPriorityDefaultLow + 1
-                                               forOrientation:NSLayoutConstraintOrientationHorizontal];
+    [self.titleField setContentCompressionResistancePriority:NSLayoutPriorityDefaultLow
+                                              forOrientation:NSLayoutConstraintOrientationHorizontal];
 }
 
 - (void)setBackgroundStyle:(NSBackgroundStyle)backgroundStyle
@@ -111,7 +107,33 @@
     [super setBackgroundStyle:backgroundStyle];
 
     auto isEmphasized = backgroundStyle == NSBackgroundStyleEmphasized;
-    self.fGroupTitleField.textColor = isEmphasized ? NSColor.labelColor : NSColor.secondaryLabelColor;
+    self.titleField.textColor = isEmphasized ? NSColor.labelColor : NSColor.secondaryLabelColor;
+}
+
+- (void)setDownloadSpeed:(CGFloat)downloadSpeed uploadSpeed:(CGFloat)uploadSpeed ratio:(CGFloat)ratio
+{
+    _downloadButton.title = [NSString stringForSpeed:downloadSpeed];
+    _uploadButton.title = [NSString stringForSpeed:uploadSpeed];
+    _ratioButton.title = [NSString stringForRatio:ratio];
+}
+
+- (void)setDisplayRatio:(BOOL)displayRatio
+{
+    _downloadButton.hidden = displayRatio;
+    _uploadButton.hidden = displayRatio;
+    _ratioButton.hidden = !displayRatio;
+}
+
+- (void)setTooltipForTorrentsCount:(NSUInteger)count
+{
+    NSString* tooltipGroup;
+    if (count == 1) {
+        tooltipGroup = NSLocalizedString(@"1 transfer", "Torrent table -> group row -> tooltip");
+    } else {
+        tooltipGroup = NSLocalizedString(@"%lu transfers", "Torrent table -> group row -> tooltip");
+        tooltipGroup = [NSString localizedStringWithFormat:tooltipGroup, count];
+    }
+    self.toolTip = tooltipGroup;
 }
 
 @end

--- a/macosx/GroupCell.mm
+++ b/macosx/GroupCell.mm
@@ -5,8 +5,18 @@
 #import "GroupCell.h"
 #import "NSStringAdditions.h"
 
+// Layout
+// Leading Stack
+static CGFloat const kIndicatorSize = 14.0;
+static NSEdgeInsets const kLeadingInsets = NSEdgeInsetsMake(0, 11, 0, 0);
+
+// Trailing Stack
+static CGFloat const kTrailingStackSize = 16.0;
+static NSEdgeInsets const kTrailingInsets = NSEdgeInsetsMake(1, 0, 1, 5);
+
 @interface GroupCell ()
-@property(nonatomic, readonly) NSStackView* stackView;
+@property(nonatomic, readonly) NSStackView* leadingStackView;
+@property(nonatomic, readonly) NSStackView* trailingStackView;
 @property(nonatomic, readonly) NSButton* downloadButton;
 @property(nonatomic, readonly) NSButton* uploadButton;
 @property(nonatomic, readonly) NSButton* ratioButton;
@@ -59,13 +69,19 @@
         button.lineBreakMode = NSLineBreakByClipping;
     }
 
-    auto stackView = [[NSStackView alloc] initWithFrame:NSZeroRect];
+    auto leadingStackView = [[NSStackView alloc] initWithFrame:NSZeroRect];
+    [leadingStackView addArrangedSubview:indicatorView];
+    [leadingStackView addArrangedSubview:titleField];
+    leadingStackView.edgeInsets = kLeadingInsets;
 
-    [stackView addArrangedSubview:downloadButton];
-    [stackView addArrangedSubview:uploadButton];
-    [stackView addArrangedSubview:ratioButton];
+    auto trailingStackView = [[NSStackView alloc] initWithFrame:NSZeroRect];
 
-    for (NSView* view in @[ indicatorView, titleField, stackView ]) {
+    [trailingStackView addArrangedSubview:downloadButton];
+    [trailingStackView addArrangedSubview:uploadButton];
+    [trailingStackView addArrangedSubview:ratioButton];
+    trailingStackView.edgeInsets = kTrailingInsets;
+
+    for (NSView* view in @[ leadingStackView, trailingStackView ]) {
         view.translatesAutoresizingMaskIntoConstraints = NO;
         [self addSubview:view];
     }
@@ -75,27 +91,24 @@
     _downloadButton = downloadButton;
     _uploadButton = uploadButton;
     _ratioButton = ratioButton;
-    _stackView = stackView;
+    _leadingStackView = leadingStackView;
+    _trailingStackView = trailingStackView;
 }
 
 - (void)setupConstraints
 {
     [NSLayoutConstraint activateConstraints:@[
-        // IndicatorView
-        [self.indicatorView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:11],
-        [self.indicatorView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-        [self.indicatorView.widthAnchor constraintEqualToConstant:14],
-        [self.indicatorView.heightAnchor constraintEqualToConstant:14],
+        // Leading Stack
+        [self.leadingStackView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+        [self.leadingStackView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [self.indicatorView.widthAnchor constraintEqualToConstant:kIndicatorSize],
+        [self.indicatorView.heightAnchor constraintEqualToConstant:kIndicatorSize],
 
-        // TitleField
-        [self.titleField.leadingAnchor constraintEqualToAnchor:self.indicatorView.trailingAnchor constant:5],
-        [self.titleField.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-
-        // StackView
-        [self.stackView.leadingAnchor constraintGreaterThanOrEqualToAnchor:self.titleField.trailingAnchor],
-        [self.stackView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-5],
-        [self.stackView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-        [self.stackView.heightAnchor constraintEqualToConstant:16],
+        // Trailing Stack
+        [self.trailingStackView.leadingAnchor constraintGreaterThanOrEqualToAnchor:self.titleField.trailingAnchor],
+        [self.trailingStackView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
+        [self.trailingStackView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [self.trailingStackView.heightAnchor constraintEqualToConstant:kTrailingStackSize],
     ]];
 
     [self.titleField setContentCompressionResistancePriority:NSLayoutPriorityDefaultLow

--- a/macosx/GroupCell.mm
+++ b/macosx/GroupCell.mm
@@ -15,11 +15,13 @@ static CGFloat const kTrailingStackSize = 16.0;
 static NSEdgeInsets const kTrailingInsets = NSEdgeInsetsMake(1, 0, 1, 5);
 
 @interface GroupCell ()
-@property(nonatomic, readonly) NSStackView* leadingStackView;
-@property(nonatomic, readonly) NSStackView* trailingStackView;
-@property(nonatomic, readonly) NSButton* downloadButton;
-@property(nonatomic, readonly) NSButton* uploadButton;
-@property(nonatomic, readonly) NSButton* ratioButton;
+@property(nonatomic, readonly) NSStackView* fLeadingStackView;
+@property(nonatomic, readonly) NSStackView* fTrailingStackView;
+@property(nonatomic, readonly) NSImageView* fIndicatorView;
+@property(nonatomic, readonly) NSTextField* fTitleField;
+@property(nonatomic, readonly) NSButton* fDownloadButton;
+@property(nonatomic, readonly) NSButton* fUploadButton;
+@property(nonatomic, readonly) NSButton* fRatioButton;
 @end
 
 @implementation GroupCell
@@ -39,12 +41,8 @@ static NSEdgeInsets const kTrailingInsets = NSEdgeInsetsMake(1, 0, 1, 5);
     auto indicatorView = [[NSImageView alloc] init];
     indicatorView.imageScaling = NSImageScaleProportionallyDown;
 
-    auto titleField = [[NSTextField alloc] init];
-    titleField.editable = NO;
-    titleField.selectable = NO;
-    titleField.bordered = NO;
+    auto titleField = [NSTextField labelWithString:@""];
     titleField.font = [NSFont boldSystemFontOfSize:NSFont.smallSystemFontSize];
-    titleField.drawsBackground = NO;
     titleField.textColor = NSColor.secondaryLabelColor;
     titleField.lineBreakMode = NSLineBreakByTruncatingMiddle;
     titleField.allowsExpansionToolTips = YES;
@@ -86,33 +84,31 @@ static NSEdgeInsets const kTrailingInsets = NSEdgeInsetsMake(1, 0, 1, 5);
         [self addSubview:view];
     }
 
-    _indicatorView = indicatorView;
-    _titleField = titleField;
-    _downloadButton = downloadButton;
-    _uploadButton = uploadButton;
-    _ratioButton = ratioButton;
-    _leadingStackView = leadingStackView;
-    _trailingStackView = trailingStackView;
+    _fIndicatorView = indicatorView;
+    _fTitleField = titleField;
+    _fDownloadButton = downloadButton;
+    _fUploadButton = uploadButton;
+    _fRatioButton = ratioButton;
+    _fLeadingStackView = leadingStackView;
+    _fTrailingStackView = trailingStackView;
 }
 
 - (void)setupConstraints
 {
     [NSLayoutConstraint activateConstraints:@[
-        // Leading Stack
-        [self.leadingStackView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
-        [self.leadingStackView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-        [self.indicatorView.widthAnchor constraintEqualToConstant:kIndicatorSize],
-        [self.indicatorView.heightAnchor constraintEqualToConstant:kIndicatorSize],
+        [self.fLeadingStackView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+        [self.fLeadingStackView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [self.fIndicatorView.widthAnchor constraintEqualToConstant:kIndicatorSize],
+        [self.fIndicatorView.heightAnchor constraintEqualToConstant:kIndicatorSize],
 
-        // Trailing Stack
-        [self.trailingStackView.leadingAnchor constraintGreaterThanOrEqualToAnchor:self.titleField.trailingAnchor],
-        [self.trailingStackView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
-        [self.trailingStackView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-        [self.trailingStackView.heightAnchor constraintEqualToConstant:kTrailingStackSize],
+        [self.fTrailingStackView.leadingAnchor constraintGreaterThanOrEqualToAnchor:self.fTitleField.trailingAnchor],
+        [self.fTrailingStackView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
+        [self.fTrailingStackView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [self.fTrailingStackView.heightAnchor constraintEqualToConstant:kTrailingStackSize],
     ]];
 
-    [self.titleField setContentCompressionResistancePriority:NSLayoutPriorityDefaultLow
-                                              forOrientation:NSLayoutConstraintOrientationHorizontal];
+    [self.fTitleField setContentCompressionResistancePriority:NSLayoutPriorityDefaultLow
+                                               forOrientation:NSLayoutConstraintOrientationHorizontal];
 }
 
 - (void)setBackgroundStyle:(NSBackgroundStyle)backgroundStyle
@@ -120,24 +116,34 @@ static NSEdgeInsets const kTrailingInsets = NSEdgeInsetsMake(1, 0, 1, 5);
     [super setBackgroundStyle:backgroundStyle];
 
     auto isEmphasized = backgroundStyle == NSBackgroundStyleEmphasized;
-    self.titleField.textColor = isEmphasized ? NSColor.labelColor : NSColor.secondaryLabelColor;
+    self.fTitleField.textColor = isEmphasized ? NSColor.labelColor : NSColor.secondaryLabelColor;
 }
 
-- (void)setDownloadSpeed:(CGFloat)downloadSpeed uploadSpeed:(CGFloat)uploadSpeed ratio:(CGFloat)ratio
+- (void)updateImage:(NSImage*)image
 {
-    _downloadButton.title = [NSString stringForSpeed:downloadSpeed];
-    _uploadButton.title = [NSString stringForSpeed:uploadSpeed];
-    _ratioButton.title = [NSString stringForRatio:ratio];
+    self.fIndicatorView.image = image;
 }
 
-- (void)setDisplayRatio:(BOOL)displayRatio
+- (void)updateTitle:(NSString*)title
 {
-    _downloadButton.hidden = displayRatio;
-    _uploadButton.hidden = displayRatio;
-    _ratioButton.hidden = !displayRatio;
+    self.fTitleField.stringValue = title;
 }
 
-- (void)setTooltipForTorrentsCount:(NSUInteger)count
+- (void)updateDownloadSpeed:(CGFloat)downloadSpeed uploadSpeed:(CGFloat)uploadSpeed ratio:(CGFloat)ratio
+{
+    _fDownloadButton.title = [NSString stringForSpeed:downloadSpeed];
+    _fUploadButton.title = [NSString stringForSpeed:uploadSpeed];
+    _fRatioButton.title = [NSString stringForRatio:ratio];
+}
+
+- (void)updateDisplayRatio:(BOOL)displayRatio
+{
+    _fDownloadButton.hidden = displayRatio;
+    _fUploadButton.hidden = displayRatio;
+    _fRatioButton.hidden = !displayRatio;
+}
+
+- (void)updateTooltipForTorrentsCount:(NSUInteger)count
 {
     NSString* tooltipGroup;
     if (count == 1) {
@@ -147,6 +153,11 @@ static NSEdgeInsets const kTrailingInsets = NSEdgeInsetsMake(1, 0, 1, 5);
         tooltipGroup = [NSString localizedStringWithFormat:tooltipGroup, count];
     }
     self.toolTip = tooltipGroup;
+}
+
+- (CGRect)frameForTitle
+{
+    return self.fTitleField.frame;
 }
 
 @end

--- a/macosx/GroupCell.mm
+++ b/macosx/GroupCell.mm
@@ -11,7 +11,8 @@ static CGFloat const kIndicatorSize = 14.0;
 static NSEdgeInsets const kLeadingInsets = NSEdgeInsetsMake(0, 11, 0, 0);
 
 // Trailing Stack
-static CGFloat const kTrailingStackSize = 16.0;
+static CGFloat const kTrailingStackHeight = 16.0;
+static CGFloat const kButtonWidth = 60.0;
 static NSEdgeInsets const kTrailingInsets = NSEdgeInsetsMake(1, 0, 1, 5);
 
 @interface GroupCell ()
@@ -60,7 +61,7 @@ static NSEdgeInsets const kTrailingInsets = NSEdgeInsetsMake(1, 0, 1, 5);
 
     for (NSButton* button in @[ downloadButton, uploadButton, ratioButton ]) {
         button.imageScaling = NSImageScaleProportionallyDown;
-        button.imagePosition = NSImageLeft;
+        button.imagePosition = NSImageLeading;
         button.bordered = NO;
         button.font = [NSFont boldSystemFontOfSize:NSFont.smallSystemFontSize];
         button.contentTintColor = NSColor.secondaryLabelColor;
@@ -104,11 +105,20 @@ static NSEdgeInsets const kTrailingInsets = NSEdgeInsetsMake(1, 0, 1, 5);
         [self.fTrailingStackView.leadingAnchor constraintGreaterThanOrEqualToAnchor:self.fTitleField.trailingAnchor],
         [self.fTrailingStackView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
         [self.fTrailingStackView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-        [self.fTrailingStackView.heightAnchor constraintEqualToConstant:kTrailingStackSize],
+        [self.fTrailingStackView.heightAnchor constraintEqualToConstant:kTrailingStackHeight],
+
+        [self.fDownloadButton.widthAnchor constraintGreaterThanOrEqualToConstant:kButtonWidth],
+        [self.fUploadButton.widthAnchor constraintGreaterThanOrEqualToConstant:kButtonWidth],
+        [self.fRatioButton.widthAnchor constraintGreaterThanOrEqualToConstant:kButtonWidth]
     ]];
 
     [self.fTitleField setContentCompressionResistancePriority:NSLayoutPriorityDefaultLow
                                                forOrientation:NSLayoutConstraintOrientationHorizontal];
+
+    [self.fDownloadButton setContentHuggingPriority:NSLayoutPriorityDefaultLow + 1
+                                     forOrientation:NSLayoutConstraintOrientationHorizontal];
+    [self.fUploadButton setContentHuggingPriority:NSLayoutPriorityDefaultLow + 1 forOrientation:NSLayoutConstraintOrientationHorizontal];
+    [self.fRatioButton setContentHuggingPriority:NSLayoutPriorityDefaultLow + 1 forOrientation:NSLayoutConstraintOrientationHorizontal];
 }
 
 - (void)setBackgroundStyle:(NSBackgroundStyle)backgroundStyle
@@ -116,7 +126,12 @@ static NSEdgeInsets const kTrailingInsets = NSEdgeInsetsMake(1, 0, 1, 5);
     [super setBackgroundStyle:backgroundStyle];
 
     auto isEmphasized = backgroundStyle == NSBackgroundStyleEmphasized;
-    self.fTitleField.textColor = isEmphasized ? NSColor.labelColor : NSColor.secondaryLabelColor;
+    auto color = isEmphasized ? NSColor.labelColor : NSColor.secondaryLabelColor;
+
+    self.fTitleField.textColor = color;
+    self.fDownloadButton.contentTintColor = color;
+    self.fUploadButton.contentTintColor = color;
+    self.fRatioButton.contentTintColor = color;
 }
 
 - (void)updateImage:(NSImage*)image
@@ -131,16 +146,16 @@ static NSEdgeInsets const kTrailingInsets = NSEdgeInsetsMake(1, 0, 1, 5);
 
 - (void)updateDownloadSpeed:(CGFloat)downloadSpeed uploadSpeed:(CGFloat)uploadSpeed ratio:(CGFloat)ratio
 {
-    _fDownloadButton.title = [NSString stringForSpeed:downloadSpeed];
-    _fUploadButton.title = [NSString stringForSpeed:uploadSpeed];
-    _fRatioButton.title = [NSString stringForRatio:ratio];
+    self.fDownloadButton.title = [NSString stringForSpeed:downloadSpeed];
+    self.fUploadButton.title = [NSString stringForSpeed:uploadSpeed];
+    self.fRatioButton.title = [NSString stringForRatio:ratio];
 }
 
 - (void)updateDisplayRatio:(BOOL)displayRatio
 {
-    _fDownloadButton.hidden = displayRatio;
-    _fUploadButton.hidden = displayRatio;
-    _fRatioButton.hidden = !displayRatio;
+    self.fDownloadButton.hidden = displayRatio;
+    self.fUploadButton.hidden = displayRatio;
+    self.fRatioButton.hidden = !displayRatio;
 }
 
 - (void)updateTooltipForTorrentsCount:(NSUInteger)count
@@ -157,7 +172,7 @@ static NSEdgeInsets const kTrailingInsets = NSEdgeInsetsMake(1, 0, 1, 5);
 
 - (CGRect)frameForTitle
 {
-    return self.fTitleField.frame;
+    return self.fLeadingStackView.frame;
 }
 
 @end

--- a/macosx/TorrentGroup.h
+++ b/macosx/TorrentGroup.h
@@ -6,6 +6,12 @@
 
 @class Torrent;
 
+@interface TorrentGroupData : NSObject
+@property(nonatomic, readonly) CGFloat ratio;
+@property(nonatomic, readonly) CGFloat uploadRate;
+@property(nonatomic, readonly) CGFloat downloadRate;
+@end
+
 @interface TorrentGroup : NSObject
 
 - (instancetype)initWithGroup:(NSInteger)group;
@@ -17,5 +23,7 @@
 @property(nonatomic, readonly) CGFloat ratio;
 @property(nonatomic, readonly) CGFloat uploadRate;
 @property(nonatomic, readonly) CGFloat downloadRate;
+
+@property(nonatomic, readonly) TorrentGroupData* aggregatedData;
 
 @end

--- a/macosx/TorrentGroup.h
+++ b/macosx/TorrentGroup.h
@@ -6,11 +6,11 @@
 
 @class Torrent;
 
-@interface TorrentGroupData : NSObject
-@property(nonatomic, readonly) CGFloat ratio;
-@property(nonatomic, readonly) CGFloat uploadRate;
-@property(nonatomic, readonly) CGFloat downloadRate;
-@end
+typedef struct {
+    CGFloat ratio;
+    CGFloat uploadRate;
+    CGFloat downloadRate;
+} TorrentGroupData;
 
 @interface TorrentGroup : NSObject
 
@@ -20,10 +20,6 @@
 @property(nonatomic, readonly) NSInteger groupOrderValue;
 @property(nonatomic, readonly) NSMutableArray<Torrent*>* torrents;
 
-@property(nonatomic, readonly) CGFloat ratio;
-@property(nonatomic, readonly) CGFloat uploadRate;
-@property(nonatomic, readonly) CGFloat downloadRate;
-
-@property(nonatomic, readonly) TorrentGroupData* aggregatedData;
+@property(nonatomic, readonly) TorrentGroupData aggregatedData;
 
 @end

--- a/macosx/TorrentGroup.mm
+++ b/macosx/TorrentGroup.mm
@@ -8,6 +8,23 @@
 #import "GroupsController.h"
 #import "Torrent.h"
 
+@interface TorrentGroupData ()
+- (instancetype)initWithRatio:(CGFloat)ratio uploadRate:(CGFloat)uploadRate downloadRate:(CGFloat)downloadRate;
+@end
+
+@implementation TorrentGroupData
+- (instancetype)initWithRatio:(CGFloat)ratio uploadRate:(CGFloat)uploadRate downloadRate:(CGFloat)downloadRate
+{
+    self = [super init];
+    if (self) {
+        _ratio = ratio;
+        _uploadRate = uploadRate;
+        _downloadRate = downloadRate;
+    }
+    return self;
+}
+@end
+
 @implementation TorrentGroup
 
 - (instancetype)initWithGroup:(NSInteger)group
@@ -58,6 +75,29 @@
     }
 
     return rate;
+}
+
+- (TorrentGroupData*)aggregatedData
+{
+    uint64_t uploaded = 0;
+    uint64_t total_size = 0;
+
+    CGFloat uploadRate = 0.0;
+
+    CGFloat downloadRate = 0.0;
+
+    for (Torrent* torrent in self.torrents) {
+        uploaded += torrent.uploadedTotal;
+        total_size += torrent.totalSizeSelected;
+
+        downloadRate += torrent.downloadRate;
+        uploadRate += torrent.uploadRate;
+    }
+
+    CGFloat ratio = tr_getRatio(uploaded, total_size);
+
+    auto result = [[TorrentGroupData alloc] initWithRatio:ratio uploadRate:uploadRate downloadRate:downloadRate];
+    return result;
 }
 
 @end

--- a/macosx/TorrentGroup.mm
+++ b/macosx/TorrentGroup.mm
@@ -8,23 +8,6 @@
 #import "GroupsController.h"
 #import "Torrent.h"
 
-@interface TorrentGroupData ()
-- (instancetype)initWithRatio:(CGFloat)ratio uploadRate:(CGFloat)uploadRate downloadRate:(CGFloat)downloadRate;
-@end
-
-@implementation TorrentGroupData
-- (instancetype)initWithRatio:(CGFloat)ratio uploadRate:(CGFloat)uploadRate downloadRate:(CGFloat)downloadRate
-{
-    self = [super init];
-    if (self) {
-        _ratio = ratio;
-        _uploadRate = uploadRate;
-        _downloadRate = downloadRate;
-    }
-    return self;
-}
-@end
-
 @implementation TorrentGroup
 
 - (instancetype)initWithGroup:(NSInteger)group
@@ -46,38 +29,7 @@
     return [GroupsController.groups rowValueForIndex:self.groupIndex];
 }
 
-- (CGFloat)ratio
-{
-    uint64_t uploaded = 0, total_size = 0;
-    for (Torrent* torrent in self.torrents) {
-        uploaded += torrent.uploadedTotal;
-        total_size += torrent.totalSizeSelected;
-    }
-
-    return tr_getRatio(uploaded, total_size);
-}
-
-- (CGFloat)uploadRate
-{
-    CGFloat rate = 0.0;
-    for (Torrent* torrent in self.torrents) {
-        rate += torrent.uploadRate;
-    }
-
-    return rate;
-}
-
-- (CGFloat)downloadRate
-{
-    CGFloat rate = 0.0;
-    for (Torrent* torrent in self.torrents) {
-        rate += torrent.downloadRate;
-    }
-
-    return rate;
-}
-
-- (TorrentGroupData*)aggregatedData
+- (TorrentGroupData)aggregatedData
 {
     uint64_t uploaded = 0;
     uint64_t total_size = 0;
@@ -96,7 +48,7 @@
 
     CGFloat ratio = tr_getRatio(uploaded, total_size);
 
-    auto result = [[TorrentGroupData alloc] initWithRatio:ratio uploadRate:uploadRate downloadRate:downloadRate];
+    auto result = (TorrentGroupData){ ratio, uploadRate, downloadRate };
     return result;
 }
 

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -321,20 +321,19 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
         NSColor* groupColor = groupIndex != -1 ? [GroupsController.groups colorForIndex:groupIndex] :
                                                  [NSColor colorWithWhite:1.0 alpha:0];
-        groupCell.indicatorView.image = [NSImage discIconWithColor:groupColor insetFactor:0];
+        [groupCell updateImage:[NSImage discIconWithColor:groupColor insetFactor:0]];
 
         NSString* groupName = groupIndex != -1 ? [GroupsController.groups nameForIndex:groupIndex] :
                                                  NSLocalizedString(@"No Group", "Group table row");
-
-        groupCell.titleField.stringValue = groupName;
+        [groupCell updateTitle:groupName];
 
         auto aggregatedData = group.aggregatedData;
-        [groupCell setDownloadSpeed:aggregatedData.downloadRate uploadSpeed:aggregatedData.uploadRate ratio:aggregatedData.ratio];
+        [groupCell updateDownloadSpeed:aggregatedData.downloadRate uploadSpeed:aggregatedData.uploadRate ratio:aggregatedData.ratio];
 
         BOOL displayGroupRowRatio = [self.fDefaults boolForKey:@"DisplayGroupRowRatio"];
-        [groupCell setDisplayRatio:displayGroupRowRatio];
+        [groupCell updateDisplayRatio:displayGroupRowRatio];
 
-        [groupCell setTooltipForTorrentsCount:group.torrents.count];
+        [groupCell updateTooltipForTorrentsCount:group.torrents.count];
 
         return groupCell;
     }
@@ -752,7 +751,7 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
     //check if click is within the status/ratio rect
     GroupCell* groupCell = [self viewAtColumn:0 row:row makeIfNecessary:NO];
-    NSRect titleRect = groupCell.titleField.frame;
+    NSRect titleRect = groupCell.frameForTitle;
     CGFloat maxX = NSMaxX(titleRect);
 
     return point.x > maxX;

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -321,53 +321,20 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
         NSColor* groupColor = groupIndex != -1 ? [GroupsController.groups colorForIndex:groupIndex] :
                                                  [NSColor colorWithWhite:1.0 alpha:0];
-        groupCell.fGroupIndicatorView.image = [NSImage discIconWithColor:groupColor insetFactor:0];
+        groupCell.indicatorView.image = [NSImage discIconWithColor:groupColor insetFactor:0];
 
         NSString* groupName = groupIndex != -1 ? [GroupsController.groups nameForIndex:groupIndex] :
                                                  NSLocalizedString(@"No Group", "Group table row");
 
-        groupCell.fGroupTitleField.stringValue = groupName;
+        groupCell.titleField.stringValue = groupName;
 
-        groupCell.fGroupDownloadField.stringValue = [NSString stringForSpeed:group.downloadRate];
-        groupCell.fGroupDownloadView.image = [NSImage imageNamed:@"DownArrowGroupTemplate"];
-
-        NSString* tooltipDownload = NSLocalizedString(@"Download speed", "Torrent table -> group row -> tooltip");
-        groupCell.fGroupDownloadField.toolTip = tooltipDownload;
-        groupCell.fGroupDownloadView.toolTip = tooltipDownload;
+        auto aggregatedData = group.aggregatedData;
+        [groupCell setDownloadSpeed:aggregatedData.downloadRate uploadSpeed:aggregatedData.uploadRate ratio:aggregatedData.ratio];
 
         BOOL displayGroupRowRatio = [self.fDefaults boolForKey:@"DisplayGroupRowRatio"];
-        groupCell.fGroupDownloadField.hidden = displayGroupRowRatio;
-        groupCell.fGroupDownloadView.hidden = displayGroupRowRatio;
+        [groupCell setDisplayRatio:displayGroupRowRatio];
 
-        if (displayGroupRowRatio) {
-            groupCell.fGroupUploadAndRatioView.image = [NSImage imageNamed:@"YingYangGroupTemplate"];
-            groupCell.fGroupUploadAndRatioView.image.accessibilityDescription = NSLocalizedString(@"Ratio", "Torrent -> status image");
-
-            groupCell.fGroupUploadAndRatioField.stringValue = [NSString stringForRatio:group.ratio];
-
-            NSString* tooltipRatio = NSLocalizedString(@"Ratio", "Torrent table -> group row -> tooltip");
-            groupCell.fGroupUploadAndRatioField.toolTip = tooltipRatio;
-            groupCell.fGroupUploadAndRatioView.toolTip = tooltipRatio;
-        } else {
-            groupCell.fGroupUploadAndRatioView.image = [NSImage imageNamed:@"UpArrowGroupTemplate"];
-            groupCell.fGroupUploadAndRatioView.image.accessibilityDescription = NSLocalizedString(@"UL", "Torrent -> status image");
-
-            groupCell.fGroupUploadAndRatioField.stringValue = [NSString stringForSpeed:group.uploadRate];
-
-            NSString* tooltipUpload = NSLocalizedString(@"Upload speed", "Torrent table -> group row -> tooltip");
-            groupCell.fGroupUploadAndRatioField.toolTip = tooltipUpload;
-            groupCell.fGroupUploadAndRatioView.toolTip = tooltipUpload;
-        }
-
-        NSString* tooltipGroup;
-        NSUInteger count = group.torrents.count;
-        if (count == 1) {
-            tooltipGroup = NSLocalizedString(@"1 transfer", "Torrent table -> group row -> tooltip");
-        } else {
-            tooltipGroup = NSLocalizedString(@"%lu transfers", "Torrent table -> group row -> tooltip");
-            tooltipGroup = [NSString localizedStringWithFormat:tooltipGroup, count];
-        }
-        groupCell.toolTip = tooltipGroup;
+        [groupCell setTooltipForTorrentsCount:group.torrents.count];
 
         return groupCell;
     }
@@ -785,7 +752,7 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
     //check if click is within the status/ratio rect
     GroupCell* groupCell = [self viewAtColumn:0 row:row makeIfNecessary:NO];
-    NSRect titleRect = groupCell.fGroupTitleField.frame;
+    NSRect titleRect = groupCell.titleField.frame;
     CGFloat maxX = NSMaxX(titleRect);
 
     return point.x > maxX;


### PR DESCRIPTION
## Description
This PR significantly improves the encapsulation and layout architecture of `GroupCell` in the macOS interface. It modernizes how group status data (speeds and ratio) is managed and rendered.

### Key Changes:
* **Enhanced Encapsulation**: Removed internal UI subviews (`NSTextField` and `NSImageView` instances) from the public header (`GroupCell.h`). 
* **Clean API Surface**: Exposed high-level, business-logic-driven methods (`setDownloadSpeed:uploadSpeed:ratio:`, `setDisplayRatio:`, `setTooltipForTorrentsCount:`) to handle data updates, keeping the rendering logic internal to the cell.
* **UI Simplification**: Combined separate icon/text pairs into borderless `NSButton` components and encapsulated them inside a private `NSStackView` to automate layout and drastically reduce manual Autolayout boilerplate.
* **Modernized Property Names**: Renamed old properties (`fGroupIndicatorView` -> `indicatorView`) to match modern objective-c naming conventions.

## Motivation and Context
Previously, external controllers had to interact directly with the cell's underlying subviews to update the UI. By encapsulating these views and providing a dedicated public API, we reduce coupling, enforce better separation of concerns, and make the UI layer much more maintainable.
