### PR TITLE
fix(gtk): save message log in chronological order

### DIFF
--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -389,7 +389,7 @@ void addLatestMessagesToStore(
 
         char const* name = !std::empty(message.name) ? message.name.c_str() : default_name.c_str();
 
-        auto row_it = store->prepend();
+        auto row_it = store->append();
         auto& row = *row_it;
         row[message_log_cols.tr_msg] = &message;
         row[message_log_cols.name] = name;


### PR DESCRIPTION
## Description

The GTK message log prepends rows to its underlying `Gtk::ListStore`, while the window displays them through a model sorted by sequence number. Since `doSave()` iterates over the underlying store directly, saved logs are written in reverse chronological order.

Append new rows instead so that the underlying model is chronological as well. The order shown in the message log window remains unchanged because it is still sorted by sequence number.

Notes: Fixed a bug that caused message logs to be saved in reverse chronological order.

## Checklist

* [x] I have manually written or manually audited all changes in this PR and vouch for them.
* [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.