### PR TITLE
perf: optimize cells reloading in hovering related events

### DIFF
--- a/macosx/SmallTorrentCell.mm
+++ b/macosx/SmallTorrentCell.mm
@@ -187,8 +187,19 @@ static CGFloat const kButtonsSpacing = 3.0;
 
     NSRect rect = self.bounds;
 
-    NSTrackingAreaOptions opts = (NSTrackingMouseEnteredAndExited | NSTrackingActiveInKeyWindow);
-    self.fTrackingArea = [[NSTrackingArea alloc] initWithRect:rect options:opts owner:self userInfo:nil];
+    NSTrackingAreaOptions options = (NSTrackingMouseEnteredAndExited | NSTrackingActiveInKeyWindow);
+    
+    // Check if mouse is currently inside the bounds
+    NSPoint mouseLocation = [self.window mouseLocationOutsideOfEventStream];
+    NSPoint localPoint = [self convertPoint:mouseLocation fromView:nil];
+    if (NSPointInRect(localPoint, self.bounds)) {
+        options |= NSTrackingAssumeInside;
+        [self handleIsHovering:YES];
+    } else {
+        [self handleIsHovering:NO];
+    }
+    
+    self.fTrackingArea = [[NSTrackingArea alloc] initWithRect:rect options:options owner:self userInfo:nil];
     [self addTrackingArea:self.fTrackingArea];
 }
 

--- a/macosx/SmallTorrentCell.mm
+++ b/macosx/SmallTorrentCell.mm
@@ -188,7 +188,7 @@ static CGFloat const kButtonsSpacing = 3.0;
     NSRect rect = self.bounds;
 
     NSTrackingAreaOptions options = (NSTrackingMouseEnteredAndExited | NSTrackingActiveInKeyWindow);
-    
+
     // Check if mouse is currently inside the bounds
     NSPoint mouseLocation = [self.window mouseLocationOutsideOfEventStream];
     NSPoint localPoint = [self convertPoint:mouseLocation fromView:nil];
@@ -198,7 +198,7 @@ static CGFloat const kButtonsSpacing = 3.0;
     } else {
         [self handleIsHovering:NO];
     }
-    
+
     self.fTrackingArea = [[NSTrackingArea alloc] initWithRect:rect options:options owner:self userInfo:nil];
     [self addTrackingArea:self.fTrackingArea];
 }

--- a/macosx/SmallTorrentCell.mm
+++ b/macosx/SmallTorrentCell.mm
@@ -191,16 +191,6 @@ static CGFloat const kButtonsSpacing = 3.0;
     NSTrackingAreaOptions opts = (NSTrackingMouseEnteredAndExited | NSTrackingActiveInKeyWindow);
     self.fTrackingArea = [[NSTrackingArea alloc] initWithRect:rect options:opts owner:self userInfo:nil];
     [self addTrackingArea:self.fTrackingArea];
-
-    //check to see if mouse is already within rect
-    NSPoint mouseLocation = [self.window mouseLocationOutsideOfEventStream];
-    mouseLocation = [self.superview convertPoint:mouseLocation fromView:nil];
-
-    if (NSPointInRect(mouseLocation, rect)) {
-        [self mouseEntered:[[NSEvent alloc] init]];
-    } else {
-        [self mouseExited:[[NSEvent alloc] init]];
-    }
 }
 
 @end

--- a/macosx/SmallTorrentCell.mm
+++ b/macosx/SmallTorrentCell.mm
@@ -44,6 +44,10 @@ static CGFloat const kButtonsSpacing = 3.0;
     [super configureViews];
     // also set alignment as part of priorities ( text inside a textLabel ).
     self.fTorrentStatusField.alignment = NSTextAlignmentRight;
+
+    // initially we set buttons hidden and reveal them on hover.
+    self.fControlButton.hidden = YES;
+    self.fRevealButton.hidden = YES;
 }
 
 // Layout
@@ -152,30 +156,25 @@ static CGFloat const kButtonsSpacing = 3.0;
 }
 
 // show fControlButton and fRevealButton
+- (void)handleIsHovering:(BOOL)isHovering
+{
+    self.fControlButton.hidden = !isHovering;
+    self.fRevealButton.hidden = !isHovering;
+    self.fTorrentStatusField.hidden = isHovering;
+}
+
 - (void)mouseEntered:(NSEvent*)event
 {
     [super mouseEntered:event];
 
-    NSPoint mouseLocation = [self convertPoint:[event locationInWindow] fromView:nil];
-    if (NSPointInRect(mouseLocation, self.fTrackingArea.rect)) {
-        [self.fTorrentTableView hoverEventBeganForView:self];
-    }
+    [self handleIsHovering:YES];
 }
 
 - (void)mouseExited:(NSEvent*)event
 {
     [super mouseExited:event];
 
-    NSPoint mouseLocation = [self convertPoint:[event locationInWindow] fromView:nil];
-    if (!NSPointInRect(mouseLocation, self.fTrackingArea.rect)) {
-        [self.fTorrentTableView hoverEventEndedForView:self];
-    }
-}
-
-- (void)mouseUp:(NSEvent*)event
-{
-    [super mouseUp:event];
-    [self updateTrackingAreas];
+    [self handleIsHovering:NO];
 }
 
 - (void)updateTrackingAreas

--- a/macosx/TorrentCellActionButton.mm
+++ b/macosx/TorrentCellActionButton.mm
@@ -49,10 +49,7 @@
 
     [self handleIsHovering:YES];
 
-    BOOL minimal = [self.fDefaults boolForKey:@"SmallView"];
-    if (!minimal) {
-        [self.torrentTableView hoverEventBeganForView:self];
-    }
+    [self.torrentTableView hoverEventBeganForView:self];
 }
 
 - (void)mouseExited:(NSEvent*)event
@@ -61,10 +58,7 @@
 
     [self handleIsHovering:NO];
 
-    BOOL minimal = [self.fDefaults boolForKey:@"SmallView"];
-    if (!minimal) {
-        [self.torrentTableView hoverEventEndedForView:self];
-    }
+    [self.torrentTableView hoverEventEndedForView:self];
 }
 
 - (void)mouseDown:(NSEvent*)event

--- a/macosx/TorrentCellActionButton.mm
+++ b/macosx/TorrentCellActionButton.mm
@@ -82,12 +82,25 @@
 
 - (void)updateTrackingAreas
 {
+    [super updateTrackingAreas];
+
     if (self.fTrackingArea != nil) {
         [self removeTrackingArea:self.fTrackingArea];
     }
 
-    NSTrackingAreaOptions opts = (NSTrackingMouseEnteredAndExited | NSTrackingActiveAlways);
-    self.fTrackingArea = [[NSTrackingArea alloc] initWithRect:self.bounds options:opts owner:self userInfo:nil];
+    NSTrackingAreaOptions options = (NSTrackingMouseEnteredAndExited | NSTrackingActiveAlways);
+    
+    // Check if mouse is currently inside the bounds
+    NSPoint mouseLocation = [self.window mouseLocationOutsideOfEventStream];
+    NSPoint localPoint = [self convertPoint:mouseLocation fromView:nil];
+    if (NSPointInRect(localPoint, self.bounds)) {
+        options |= NSTrackingAssumeInside;
+        [self handleIsHovering:YES];
+    } else {
+        [self handleIsHovering:NO];
+    }
+    
+    self.fTrackingArea = [[NSTrackingArea alloc] initWithRect:self.bounds options:options owner:self userInfo:nil];
     [self addTrackingArea:self.fTrackingArea];
 }
 

--- a/macosx/TorrentCellActionButton.mm
+++ b/macosx/TorrentCellActionButton.mm
@@ -38,22 +38,33 @@
     return self;
 }
 
+- (void)handleIsHovering:(BOOL)isHovering
+{
+    self.image = isHovering ? self.fImage : self.fAlternativeImage;
+}
+
 - (void)mouseEntered:(NSEvent*)event
 {
     [super mouseEntered:event];
 
-    self.image = self.fImage;
+    [self handleIsHovering:YES];
 
-    [self.torrentTableView hoverEventBeganForView:self];
+    BOOL minimal = [self.fDefaults boolForKey:@"SmallView"];
+    if (!minimal) {
+        [self.torrentTableView hoverEventBeganForView:self];
+    }
 }
 
 - (void)mouseExited:(NSEvent*)event
 {
     [super mouseExited:event];
 
-    self.image = self.fAlternativeImage;
+    [self handleIsHovering:NO];
 
-    [self.torrentTableView hoverEventEndedForView:self];
+    BOOL minimal = [self.fDefaults boolForKey:@"SmallView"];
+    if (!minimal) {
+        [self.torrentTableView hoverEventEndedForView:self];
+    }
 }
 
 - (void)mouseDown:(NSEvent*)event

--- a/macosx/TorrentCellActionButton.mm
+++ b/macosx/TorrentCellActionButton.mm
@@ -89,7 +89,7 @@
     }
 
     NSTrackingAreaOptions options = (NSTrackingMouseEnteredAndExited | NSTrackingActiveAlways);
-    
+
     // Check if mouse is currently inside the bounds
     NSPoint mouseLocation = [self.window mouseLocationOutsideOfEventStream];
     NSPoint localPoint = [self convertPoint:mouseLocation fromView:nil];
@@ -99,7 +99,7 @@
     } else {
         [self handleIsHovering:NO];
     }
-    
+
     self.fTrackingArea = [[NSTrackingArea alloc] initWithRect:self.bounds options:options owner:self userInfo:nil];
     [self addTrackingArea:self.fTrackingArea];
 }

--- a/macosx/TorrentCellControlButton.mm
+++ b/macosx/TorrentCellControlButton.mm
@@ -85,12 +85,14 @@
 
 - (void)updateTrackingAreas
 {
+    [super updateTrackingAreas];
+
     if (self.fTrackingArea != nil) {
         [self removeTrackingArea:self.fTrackingArea];
     }
 
-    NSTrackingAreaOptions opts = (NSTrackingMouseEnteredAndExited | NSTrackingActiveAlways);
-    self.fTrackingArea = [[NSTrackingArea alloc] initWithRect:self.bounds options:opts owner:self userInfo:nil];
+    NSTrackingAreaOptions options = (NSTrackingMouseEnteredAndExited | NSTrackingActiveAlways);
+    self.fTrackingArea = [[NSTrackingArea alloc] initWithRect:self.bounds options:options owner:self userInfo:nil];
     [self addTrackingArea:self.fTrackingArea];
 }
 

--- a/macosx/TorrentCellRevealButton.mm
+++ b/macosx/TorrentCellRevealButton.mm
@@ -65,12 +65,14 @@
 
 - (void)updateTrackingAreas
 {
+    [super updateTrackingAreas];
+
     if (self.fTrackingArea != nil) {
         [self removeTrackingArea:self.fTrackingArea];
     }
 
-    NSTrackingAreaOptions opts = (NSTrackingMouseEnteredAndExited | NSTrackingActiveAlways);
-    self.fTrackingArea = [[NSTrackingArea alloc] initWithRect:self.bounds options:opts owner:self userInfo:nil];
+    NSTrackingAreaOptions options = (NSTrackingMouseEnteredAndExited | NSTrackingActiveAlways);
+    self.fTrackingArea = [[NSTrackingArea alloc] initWithRect:self.bounds options:options owner:self userInfo:nil];
     [self addTrackingArea:self.fTrackingArea];
 }
 

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -28,6 +28,31 @@ static CGFloat const kErrorImageSize = 20.0;
 
 static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
+@interface TorrentTableViewHoveringData : NSObject<NSCopying>
+@property(nonatomic, nullable, copy) NSNumber* hoveredRow;
+@property(nonatomic, nullable, copy) NSString* statusText;
+@property(nonatomic, readonly) BOOL isHovered;
+@end
+@implementation TorrentTableViewHoveringData
+- (BOOL)isHoveredForRow:(NSInteger)row
+{
+    return self.hoveredRow != nil && self.hoveredRow.integerValue == row;
+}
+
+- (BOOL)isHovered
+{
+    return self.hoveredRow != nil && self.hoveredRow.integerValue != -1;
+}
+
+- (nonnull id)copyWithZone:(nullable NSZone*)zone
+{
+    auto copy = (TorrentTableViewHoveringData*)[[self.class alloc] init];
+    copy.hoveredRow = self.hoveredRow;
+    copy.statusText = self.statusText;
+    return copy;
+}
+@end
+
 @interface TorrentTableView ()
 
 @property(nonatomic) IBOutlet Controller* fController;
@@ -45,7 +70,7 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 @property(nonatomic) BOOL fActionPopoverShown;
 @property(nonatomic) NSView* fPositioningView;
 
-@property(nonatomic) NSDictionary* fHoverEventDict;
+@property(nonatomic) TorrentTableViewHoveringData* hoveringData;
 
 @end
 
@@ -54,6 +79,7 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 - (instancetype)initWithCoder:(NSCoder*)decoder
 {
     if ((self = [super initWithCoder:decoder])) {
+        self.hoveringData = [[TorrentTableViewHoveringData alloc] init];
         _fDefaults = NSUserDefaults.standardUserDefaults;
 
         NSData* groupData;
@@ -220,15 +246,11 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
                 torrent.shortStatusString :
                 torrent.remainingTimeString;
 
-            if (self.fHoverEventDict) {
-                NSInteger row = [self rowForItem:item];
-                NSInteger hoverRow = [self.fHoverEventDict[@"row"] integerValue];
-
-                if (row == hoverRow) {
-                    torrentCell.fTorrentStatusField.hidden = YES;
-                    torrentCell.fControlButton.hidden = NO;
-                    torrentCell.fRevealButton.hidden = NO;
-                }
+            NSInteger row = [self rowForItem:item];
+            if ([self.hoveringData isHoveredForRow:row]) {
+                torrentCell.fTorrentStatusField.hidden = YES;
+                torrentCell.fControlButton.hidden = NO;
+                torrentCell.fRevealButton.hidden = NO;
             } else {
                 torrentCell.fTorrentStatusField.hidden = NO;
                 torrentCell.fControlButton.hidden = YES;
@@ -270,12 +292,12 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
             // set torrent status
             NSString* status;
-            if (self.fHoverEventDict) {
+            if (self.hoveringData.isHovered) {
                 NSInteger row = [self rowForItem:item];
-                NSInteger hoverRow = [self.fHoverEventDict[@"row"] integerValue];
+                NSInteger hoverRow = self.hoveringData.hoveredRow.integerValue;
 
                 if (row == hoverRow) {
-                    status = self.fHoverEventDict[@"string"];
+                    status = self.hoveringData.statusText;
                 }
             }
             torrentCell.fTorrentStatusField.stringValue = status ?: torrent.statusString;
@@ -582,10 +604,12 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
     NSInteger row = [self rowForView:view];
     Torrent* torrent = [self itemAtRow:row];
 
+    auto previouslyHovered = (TorrentTableViewHoveringData*)[self.hoveringData copy];
     BOOL minimal = [self.fDefaults boolForKey:@"SmallView"];
     if (minimal) {
         if ([view isKindOfClass:[SmallTorrentCell class]]) {
-            self.fHoverEventDict = @{ @"row" : [NSNumber numberWithInteger:row] };
+            self.hoveringData.hoveredRow = @(row);
+            self.hoveringData.statusText = nil;
         } else if ([view isKindOfClass:[TorrentCellActionButton class]]) {
             SmallTorrentCell* smallCell = [self viewAtColumn:0 row:row makeIfNecessary:NO];
             smallCell.fIconView.hidden = YES;
@@ -611,11 +635,19 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
         }
 
         if (statusString) {
-            self.fHoverEventDict = @{ @"string" : statusString, @"row" : [NSNumber numberWithInteger:row] };
+            self.hoveringData.hoveredRow = @(row);
+            self.hoveringData.statusText = statusString;
         }
     }
 
-    [self reloadVisibleRows];
+    if (previouslyHovered.isHovered) {
+        NSMutableIndexSet* indexSet = [[NSMutableIndexSet alloc] init];
+        [indexSet addIndex:previouslyHovered.hoveredRow.integerValue];
+        [indexSet addIndex:row];
+        [self reloadDataForRowIndexes:indexSet columnIndexes:[NSIndexSet indexSetWithIndex:0]];
+    } else {
+        [self reloadDataForRowIndexes:[NSIndexSet indexSetWithIndex:row] columnIndexes:[NSIndexSet indexSetWithIndex:0]];
+    }
 }
 
 - (void)hoverEventEndedForView:(id)view
@@ -635,8 +667,17 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
     }
 
     if (update) {
-        self.fHoverEventDict = nil;
-        [self reloadDataForRowIndexes:[NSIndexSet indexSetWithIndex:row] columnIndexes:[NSIndexSet indexSetWithIndex:0]];
+        auto previouslyHovered = (TorrentTableViewHoveringData*)[self.hoveringData copy];
+        self.hoveringData.hoveredRow = nil;
+        self.hoveringData.statusText = nil;
+        if (previouslyHovered.isHovered) {
+            NSMutableIndexSet* indexSet = [[NSMutableIndexSet alloc] init];
+            [indexSet addIndex:previouslyHovered.hoveredRow.integerValue];
+            [indexSet addIndex:row];
+            [self reloadDataForRowIndexes:indexSet columnIndexes:[NSIndexSet indexSetWithIndex:0]];
+        } else {
+            [self reloadDataForRowIndexes:[NSIndexSet indexSetWithIndex:row] columnIndexes:[NSIndexSet indexSetWithIndex:0]];
+        }
     }
 }
 

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -571,7 +571,7 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 - (void)updateStatusTextForTorrent:(nullable Torrent*)torrent
 {
     NSInteger const row = [self rowForItem:torrent];
-    
+
     // if torrent is nil, row will be -1.
     if (row < 0) {
         return;
@@ -586,7 +586,7 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 {
     BOOL minimal = [self.fDefaults boolForKey:@"SmallView"];
     NSInteger row = [self rowForView:view];
-    
+
     if (minimal) {
         if ([view isKindOfClass:[TorrentCellActionButton class]]) {
             SmallTorrentCell* smallCell = [self viewAtColumn:0 row:row makeIfNecessary:NO];
@@ -631,7 +631,7 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 {
     BOOL minimal = [self.fDefaults boolForKey:@"SmallView"];
     NSInteger row = [self rowForView:view];
-    
+
     if (minimal) {
         if ([view isKindOfClass:[TorrentCellActionButton class]]) {
             SmallTorrentCell* smallCell = [self viewAtColumn:0 row:row makeIfNecessary:NO];
@@ -639,12 +639,12 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
         }
         return;
     }
-    
+
     auto previousHoveredTorrent = self.hoveringData.hoveredTorrent;
-    
+
     self.hoveringData.hoveredTorrent = nil;
     self.hoveringData.statusText = nil;
-    
+
     [self updateStatusTextForTorrent:previousHoveredTorrent];
 }
 

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -28,28 +28,15 @@ static CGFloat const kErrorImageSize = 20.0;
 
 static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
-@interface TorrentTableViewHoveringData : NSObject<NSCopying>
+@interface TorrentTableViewHoveringData : NSObject
 @property(nonatomic, nullable, copy) NSNumber* hoveredRow;
 @property(nonatomic, nullable, copy) NSString* statusText;
 @property(nonatomic, readonly) BOOL isHovered;
 @end
 @implementation TorrentTableViewHoveringData
-- (BOOL)isHoveredForRow:(NSInteger)row
-{
-    return self.hoveredRow != nil && self.hoveredRow.integerValue == row;
-}
-
 - (BOOL)isHovered
 {
-    return self.hoveredRow != nil && self.hoveredRow.integerValue != -1;
-}
-
-- (nonnull id)copyWithZone:(nullable NSZone*)zone
-{
-    auto copy = (TorrentTableViewHoveringData*)[[self.class alloc] init];
-    copy.hoveredRow = self.hoveredRow;
-    copy.statusText = self.statusText;
-    return copy;
+    return self.hoveredRow != nil;
 }
 @end
 
@@ -588,6 +575,12 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
     return YES;
 }
 
+- (void)handleIsHoveringForRow:(NSInteger)row statusText:(NSString*)text
+{
+    auto view = (TorrentCell*)[self viewAtColumn:0 row:row makeIfNecessary:NO];
+    view.fTorrentStatusField.stringValue = text;
+}
+
 - (void)hoverEventBeganForView:(id)view
 {
     BOOL minimal = [self.fDefaults boolForKey:@"SmallView"];
@@ -598,8 +591,6 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
     NSInteger row = [self rowForView:view];
     Torrent* torrent = [self itemAtRow:row];
-
-    auto previouslyHovered = (TorrentTableViewHoveringData*)[self.hoveringData copy];
 
     NSString* statusString;
     if ([view isKindOfClass:[TorrentCellRevealButton class]]) {
@@ -620,18 +611,17 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
         statusString = NSLocalizedString(@"Change transfer settings", "Torrent Table -> tooltip");
     }
 
+    auto previousHoveredRow = self.hoveringData.hoveredRow;
+
     if (statusString) {
         self.hoveringData.hoveredRow = @(row);
         self.hoveringData.statusText = statusString;
+
+        [self handleIsHoveringForRow:row statusText:statusString];
     }
 
-    if (previouslyHovered.isHovered) {
-        NSMutableIndexSet* indexSet = [[NSMutableIndexSet alloc] init];
-        [indexSet addIndex:previouslyHovered.hoveredRow.integerValue];
-        [indexSet addIndex:row];
-        [self reloadDataForRowIndexes:indexSet columnIndexes:[NSIndexSet indexSetWithIndex:0]];
-    } else {
-        [self reloadDataForRowIndexes:[NSIndexSet indexSetWithIndex:row] columnIndexes:[NSIndexSet indexSetWithIndex:0]];
+    if (previousHoveredRow != nil) {
+        [self handleIsHoveringForRow:previousHoveredRow.integerValue statusText:torrent.statusString];
     }
 }
 
@@ -643,18 +633,15 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
         return;
     }
 
-    NSInteger row = [self rowForView:[view superview]];
+    auto previousHoveredRow = self.hoveringData.hoveredRow;
 
-    auto previouslyHovered = (TorrentTableViewHoveringData*)[self.hoveringData copy];
     self.hoveringData.hoveredRow = nil;
     self.hoveringData.statusText = nil;
-    if (previouslyHovered.isHovered) {
-        NSMutableIndexSet* indexSet = [[NSMutableIndexSet alloc] init];
-        [indexSet addIndex:previouslyHovered.hoveredRow.integerValue];
-        [indexSet addIndex:row];
-        [self reloadDataForRowIndexes:indexSet columnIndexes:[NSIndexSet indexSetWithIndex:0]];
-    } else {
-        [self reloadDataForRowIndexes:[NSIndexSet indexSetWithIndex:row] columnIndexes:[NSIndexSet indexSetWithIndex:0]];
+
+    if (previousHoveredRow != nil) {
+        NSInteger row = [self rowForView:view];
+        auto torrent = (Torrent*)[self itemAtRow:row];
+        [self handleIsHoveringForRow:previousHoveredRow.integerValue statusText:torrent.statusString];
     }
 }
 

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -575,10 +575,26 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
     return YES;
 }
 
-- (void)handleIsHoveringForRow:(NSInteger)row statusText:(NSString*)text
+// A row's status field shows the hover tooltip while that row is hovered and the
+// torrent's own status otherwise, matching what outlineView:viewForTableColumn:
+// renders when it builds the cell.
+- (void)updateStatusTextForRow:(NSInteger)row
 {
-    auto view = (TorrentCell*)[self viewAtColumn:0 row:row makeIfNecessary:NO];
-    view.fTorrentStatusField.stringValue = text;
+    if (row < 0 || row >= self.numberOfRows) {
+        return;
+    }
+
+    auto torrent = (Torrent*)[self itemAtRow:row];
+
+    if (![torrent isKindOfClass:[Torrent class]]) {
+        return;
+    }
+
+    BOOL const hovered = self.hoveringData.hoveredRow != nil && self.hoveringData.hoveredRow.integerValue == row;
+
+    auto cell = (TorrentCell*)[self viewAtColumn:0 row:row makeIfNecessary:NO];
+
+    cell.fTorrentStatusField.stringValue = (hovered ? self.hoveringData.statusText : nil) ?: torrent.statusString;
 }
 
 - (void)hoverEventBeganForView:(id)view
@@ -616,13 +632,13 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
     if (statusString) {
         self.hoveringData.hoveredRow = @(row);
         self.hoveringData.statusText = statusString;
-
-        [self handleIsHoveringForRow:row statusText:statusString];
     }
 
     if (previousHoveredRow != nil) {
-        [self handleIsHoveringForRow:previousHoveredRow.integerValue statusText:torrent.statusString];
+        [self updateStatusTextForRow:previousHoveredRow.integerValue];
     }
+
+    [self updateStatusTextForRow:row];
 }
 
 - (void)hoverEventEndedForView:(id)view
@@ -639,9 +655,7 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
     self.hoveringData.statusText = nil;
 
     if (previousHoveredRow != nil) {
-        NSInteger row = [self rowForView:view];
-        auto torrent = (Torrent*)[self itemAtRow:row];
-        [self handleIsHoveringForRow:previousHoveredRow.integerValue statusText:torrent.statusString];
+        [self updateStatusTextForRow:previousHoveredRow.integerValue];
     }
 }
 

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -245,17 +245,6 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
             torrentCell.fTorrentStatusField.stringValue = [self.fDefaults boolForKey:@"DisplaySmallStatusRegular"] ?
                 torrent.shortStatusString :
                 torrent.remainingTimeString;
-
-            NSInteger row = [self rowForItem:item];
-            if ([self.hoveringData isHoveredForRow:row]) {
-                torrentCell.fTorrentStatusField.hidden = YES;
-                torrentCell.fControlButton.hidden = NO;
-                torrentCell.fRevealButton.hidden = NO;
-            } else {
-                torrentCell.fTorrentStatusField.hidden = NO;
-                torrentCell.fControlButton.hidden = YES;
-                torrentCell.fRevealButton.hidden = YES;
-            }
         } else {
             torrentCell = [outlineView makeViewWithIdentifier:@"TorrentCell" owner:self];
             if (!torrentCell) {
@@ -601,43 +590,39 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
 - (void)hoverEventBeganForView:(id)view
 {
+    BOOL minimal = [self.fDefaults boolForKey:@"SmallView"];
+
+    if (minimal) {
+        return;
+    }
+
     NSInteger row = [self rowForView:view];
     Torrent* torrent = [self itemAtRow:row];
 
     auto previouslyHovered = (TorrentTableViewHoveringData*)[self.hoveringData copy];
-    BOOL minimal = [self.fDefaults boolForKey:@"SmallView"];
-    if (minimal) {
-        if ([view isKindOfClass:[SmallTorrentCell class]]) {
-            self.hoveringData.hoveredRow = @(row);
-            self.hoveringData.statusText = nil;
-        } else if ([view isKindOfClass:[TorrentCellActionButton class]]) {
-            SmallTorrentCell* smallCell = [self viewAtColumn:0 row:row makeIfNecessary:NO];
-            smallCell.fIconView.hidden = YES;
-        }
-    } else {
-        NSString* statusString;
-        if ([view isKindOfClass:[TorrentCellRevealButton class]]) {
-            statusString = NSLocalizedString(@"Show the data file in Finder", "Torrent cell -> button info");
-        } else if ([view isKindOfClass:[TorrentCellControlButton class]]) {
-            if (torrent.active)
-                statusString = NSLocalizedString(@"Pause the transfer", "Torrent Table -> tooltip");
-            else {
-                if (NSApp.currentEvent.modifierFlags & NSEventModifierFlagOption) {
-                    statusString = NSLocalizedString(@"Resume the transfer right away", "Torrent cell -> button info");
-                } else if (torrent.waitingToStart) {
-                    statusString = NSLocalizedString(@"Stop waiting to start", "Torrent cell -> button info");
-                } else {
-                    statusString = NSLocalizedString(@"Resume the transfer", "Torrent cell -> button info");
-                }
-            }
-        } else if ([view isKindOfClass:[TorrentCellActionButton class]]) {
-            statusString = NSLocalizedString(@"Change transfer settings", "Torrent Table -> tooltip");
-        }
 
-        if (statusString) {
-            self.hoveringData.hoveredRow = @(row);
-            self.hoveringData.statusText = statusString;
+    NSString* statusString;
+    if ([view isKindOfClass:[TorrentCellRevealButton class]]) {
+        statusString = NSLocalizedString(@"Show the data file in Finder", "Torrent cell -> button info");
+    } else if ([view isKindOfClass:[TorrentCellControlButton class]]) {
+        if (torrent.active)
+            statusString = NSLocalizedString(@"Pause the transfer", "Torrent Table -> tooltip");
+        else {
+            if (NSApp.currentEvent.modifierFlags & NSEventModifierFlagOption) {
+                statusString = NSLocalizedString(@"Resume the transfer right away", "Torrent cell -> button info");
+            } else if (torrent.waitingToStart) {
+                statusString = NSLocalizedString(@"Stop waiting to start", "Torrent cell -> button info");
+            } else {
+                statusString = NSLocalizedString(@"Resume the transfer", "Torrent cell -> button info");
+            }
         }
+    } else if ([view isKindOfClass:[TorrentCellActionButton class]]) {
+        statusString = NSLocalizedString(@"Change transfer settings", "Torrent Table -> tooltip");
+    }
+
+    if (statusString) {
+        self.hoveringData.hoveredRow = @(row);
+        self.hoveringData.statusText = statusString;
     }
 
     if (previouslyHovered.isHovered) {
@@ -652,32 +637,24 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
 - (void)hoverEventEndedForView:(id)view
 {
-    NSInteger row = [self rowForView:[view superview]];
-
-    BOOL update = YES;
     BOOL minimal = [self.fDefaults boolForKey:@"SmallView"];
+
     if (minimal) {
-        if (minimal && ![view isKindOfClass:[SmallTorrentCell class]]) {
-            if ([view isKindOfClass:[TorrentCellActionButton class]]) {
-                SmallTorrentCell* smallCell = [self viewAtColumn:0 row:row makeIfNecessary:NO];
-                smallCell.fIconView.hidden = NO;
-            }
-            update = NO;
-        }
+        return;
     }
 
-    if (update) {
-        auto previouslyHovered = (TorrentTableViewHoveringData*)[self.hoveringData copy];
-        self.hoveringData.hoveredRow = nil;
-        self.hoveringData.statusText = nil;
-        if (previouslyHovered.isHovered) {
-            NSMutableIndexSet* indexSet = [[NSMutableIndexSet alloc] init];
-            [indexSet addIndex:previouslyHovered.hoveredRow.integerValue];
-            [indexSet addIndex:row];
-            [self reloadDataForRowIndexes:indexSet columnIndexes:[NSIndexSet indexSetWithIndex:0]];
-        } else {
-            [self reloadDataForRowIndexes:[NSIndexSet indexSetWithIndex:row] columnIndexes:[NSIndexSet indexSetWithIndex:0]];
-        }
+    NSInteger row = [self rowForView:[view superview]];
+
+    auto previouslyHovered = (TorrentTableViewHoveringData*)[self.hoveringData copy];
+    self.hoveringData.hoveredRow = nil;
+    self.hoveringData.statusText = nil;
+    if (previouslyHovered.isHovered) {
+        NSMutableIndexSet* indexSet = [[NSMutableIndexSet alloc] init];
+        [indexSet addIndex:previouslyHovered.hoveredRow.integerValue];
+        [indexSet addIndex:row];
+        [self reloadDataForRowIndexes:indexSet columnIndexes:[NSIndexSet indexSetWithIndex:0]];
+    } else {
+        [self reloadDataForRowIndexes:[NSIndexSet indexSetWithIndex:row] columnIndexes:[NSIndexSet indexSetWithIndex:0]];
     }
 }
 

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -29,15 +29,10 @@ static CGFloat const kErrorImageSize = 20.0;
 static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
 @interface TorrentTableViewHoveringData : NSObject
-@property(nonatomic, nullable, copy) NSNumber* hoveredRow;
+@property(nonatomic, nullable, weak) Torrent* hoveredTorrent;
 @property(nonatomic, nullable, copy) NSString* statusText;
-@property(nonatomic, readonly) BOOL isHovered;
 @end
 @implementation TorrentTableViewHoveringData
-- (BOOL)isHovered
-{
-    return self.hoveredRow != nil;
-}
 @end
 
 @interface TorrentTableView ()
@@ -268,13 +263,8 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
             // set torrent status
             NSString* status;
-            if (self.hoveringData.isHovered) {
-                NSInteger row = [self rowForItem:item];
-                NSInteger hoverRow = self.hoveringData.hoveredRow.integerValue;
-
-                if (row == hoverRow) {
-                    status = self.hoveringData.statusText;
-                }
+            if (item == self.hoveringData.hoveredTorrent) {
+                status = self.hoveringData.statusText;
             }
             torrentCell.fTorrentStatusField.stringValue = status ?: torrent.statusString;
         }
@@ -578,34 +568,33 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 // A row's status field shows the hover tooltip while that row is hovered and the
 // torrent's own status otherwise, matching what outlineView:viewForTableColumn:
 // renders when it builds the cell.
-- (void)updateStatusTextForRow:(NSInteger)row
+- (void)updateStatusTextForTorrent:(nullable Torrent*)torrent
 {
-    if (row < 0 || row >= self.numberOfRows) {
+    NSInteger const row = [self rowForItem:torrent];
+    
+    // if torrent is nil, row will be -1.
+    if (row < 0) {
         return;
     }
-
-    auto torrent = (Torrent*)[self itemAtRow:row];
-
-    if (![torrent isKindOfClass:[Torrent class]]) {
-        return;
-    }
-
-    BOOL const hovered = self.hoveringData.hoveredRow != nil && self.hoveringData.hoveredRow.integerValue == row;
 
     auto cell = (TorrentCell*)[self viewAtColumn:0 row:row makeIfNecessary:NO];
-
-    cell.fTorrentStatusField.stringValue = (hovered ? self.hoveringData.statusText : nil) ?: torrent.statusString;
+    NSString* const hoverText = torrent == self.hoveringData.hoveredTorrent ? self.hoveringData.statusText : nil;
+    cell.fTorrentStatusField.stringValue = hoverText ?: torrent.statusString;
 }
 
 - (void)hoverEventBeganForView:(id)view
 {
     BOOL minimal = [self.fDefaults boolForKey:@"SmallView"];
-
+    NSInteger row = [self rowForView:view];
+    
     if (minimal) {
+        if ([view isKindOfClass:[TorrentCellActionButton class]]) {
+            SmallTorrentCell* smallCell = [self viewAtColumn:0 row:row makeIfNecessary:NO];
+            smallCell.fIconView.hidden = YES;
+        }
         return;
     }
 
-    NSInteger row = [self rowForView:view];
     Torrent* torrent = [self itemAtRow:row];
 
     NSString* statusString;
@@ -627,36 +616,36 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
         statusString = NSLocalizedString(@"Change transfer settings", "Torrent Table -> tooltip");
     }
 
-    auto previousHoveredRow = self.hoveringData.hoveredRow;
+    auto previousHoveredTorrent = self.hoveringData.hoveredTorrent;
 
     if (statusString) {
-        self.hoveringData.hoveredRow = @(row);
+        self.hoveringData.hoveredTorrent = torrent;
         self.hoveringData.statusText = statusString;
     }
 
-    if (previousHoveredRow != nil) {
-        [self updateStatusTextForRow:previousHoveredRow.integerValue];
-    }
-
-    [self updateStatusTextForRow:row];
+    [self updateStatusTextForTorrent:previousHoveredTorrent];
+    [self updateStatusTextForTorrent:torrent];
 }
 
 - (void)hoverEventEndedForView:(id)view
 {
     BOOL minimal = [self.fDefaults boolForKey:@"SmallView"];
-
+    NSInteger row = [self rowForView:view];
+    
     if (minimal) {
+        if ([view isKindOfClass:[TorrentCellActionButton class]]) {
+            SmallTorrentCell* smallCell = [self viewAtColumn:0 row:row makeIfNecessary:NO];
+            smallCell.fIconView.hidden = NO;
+        }
         return;
     }
-
-    auto previousHoveredRow = self.hoveringData.hoveredRow;
-
-    self.hoveringData.hoveredRow = nil;
+    
+    auto previousHoveredTorrent = self.hoveringData.hoveredTorrent;
+    
+    self.hoveringData.hoveredTorrent = nil;
     self.hoveringData.statusText = nil;
-
-    if (previousHoveredRow != nil) {
-        [self updateStatusTextForRow:previousHoveredRow.integerValue];
-    }
+    
+    [self updateStatusTextForTorrent:previousHoveredTorrent];
 }
 
 - (void)toggleGroupRowRatio

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -587,12 +587,8 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
     BOOL minimal = [self.fDefaults boolForKey:@"SmallView"];
     NSInteger row = [self rowForView:view];
 
-    if (row < 0) {
-        return;
-    }
-
     if (minimal) {
-        if ([view isKindOfClass:[TorrentCellActionButton class]]) {
+        if (row >= 0 && [view isKindOfClass:[TorrentCellActionButton class]]) {
             SmallTorrentCell* smallCell = [self viewAtColumn:0 row:row makeIfNecessary:NO];
             smallCell.fIconView.hidden = YES;
         }
@@ -636,12 +632,8 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
     BOOL minimal = [self.fDefaults boolForKey:@"SmallView"];
     NSInteger row = [self rowForView:view];
 
-    if (row < 0) {
-        return;
-    }
-
     if (minimal) {
-        if ([view isKindOfClass:[TorrentCellActionButton class]]) {
+        if (row >= 0 && [view isKindOfClass:[TorrentCellActionButton class]]) {
             SmallTorrentCell* smallCell = [self viewAtColumn:0 row:row makeIfNecessary:NO];
             smallCell.fIconView.hidden = NO;
         }

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -587,6 +587,10 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
     BOOL minimal = [self.fDefaults boolForKey:@"SmallView"];
     NSInteger row = [self rowForView:view];
 
+    if (row < 0) {
+        return;
+    }
+
     if (minimal) {
         if ([view isKindOfClass:[TorrentCellActionButton class]]) {
             SmallTorrentCell* smallCell = [self viewAtColumn:0 row:row makeIfNecessary:NO];
@@ -631,6 +635,10 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 {
     BOOL minimal = [self.fDefaults boolForKey:@"SmallView"];
     NSInteger row = [self rowForView:view];
+
+    if (row < 0) {
+        return;
+    }
 
     if (minimal) {
         if ([view isKindOfClass:[TorrentCellActionButton class]]) {


### PR DESCRIPTION
### Description
This PR optimizes the cell reloading logic when handling hover-related events in the UI. Previously, hovering over elements triggered redundant or full cell redraws, leading to unnecessary CPU usage and potential UI stuttering in large torrent lists. 

### Changes
* Optimized the conditions under which cells are reloaded during mouse hover events.
* Reduced redundant cell updates to ensure smoother scrolling and UI interaction.
* Fixed unnecessary layout recalculations triggered by hover states.

### Impact
* **Performance:** Lower CPU consumption during list interactions.
* **UX:** Smoother hovering effect and more responsive scrolling, especially visible in configurations with hundreds of active torrents.

### Testing Done
* Verified that hover states (tooltips, highlights) still render correctly.
* Checked for regressions in cell selection and context menu triggers.

### Results

#### Before

https://github.com/user-attachments/assets/b4683a3a-050e-4039-ac75-c9c460dd453b

#### After

https://github.com/user-attachments/assets/03783f90-ec82-469b-b793-32bd12ced6b2