### PR TITLE
fix: report the real error when a file can't be opened

### DIFF
--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -85,31 +85,42 @@ bool write_entire_buf(tr_sys_file_t const fd, uint64_t file_offset, std::span<ui
                                                                        tr_file_preallocation::None;
     if (auto const found = tor.find_file(file_index)) {
         auto const filename = found->filename<tr_pathbuf>();
-        return open_files.get(tor_id, file_index, writable, filename, prealloc, file_size);
-    }
+        if (auto file = open_files.get(tor_id, file_index, writable, filename, prealloc, file_size, error); file) {
+            return file;
+        }
 
+        // The file exists but can't be opened, e.g. no file descriptors
+        // are left or its permissions changed. `error` is set so that
+        // the caller doesn't mistake this for success and discard the
+        // data it wanted to write.
+    }
     // do we want to create it?
-    auto err = ENOENT;
-    if (writable) {
+    else if (writable) {
         auto const base = tor.current_dir().sv();
         auto const suffix = session.isIncompleteFileNamingEnabled() ? tr_torrent_files::PartialFileSuffix : ""sv;
         auto const filename = tr_pathbuf{ base, '/', tor.file_subpath(file_index), suffix };
-        if (auto file = open_files.get(tor_id, file_index, writable, filename, prealloc, file_size); file) {
+        if (auto file = open_files.get(tor_id, file_index, writable, filename, prealloc, file_size, error); file) {
             // make a note that we just created a file
             session.add_file_created();
             return file;
         }
-
-        err = errno;
     }
 
-    error.set(
-        err,
-        fmt::format(
-            fmt::runtime(_("Couldn't get '{path}': {error} ({error_code})")),
-            fmt::arg("path", tor.file_subpath(file_index)),
-            fmt::arg("error", tr_strerror(err)),
-            fmt::arg("error_code", err)));
+    if (error) {
+        // open_files.get() reports why but not which file; the message
+        // reaches the user via the torrent's local error, so put the
+        // filename back in
+        error.prefix_message(
+            fmt::format(fmt::runtime(_("Couldn't get '{path}': ")), fmt::arg("path", tor.file_subpath(file_index))));
+    } else { // the file doesn't exist, and we can't create it
+        error.set(
+            ENOENT,
+            fmt::format(
+                fmt::runtime(_("Couldn't get '{path}': {error} ({error_code})")),
+                fmt::arg("path", tor.file_subpath(file_index)),
+                fmt::arg("error", tr_strerror(ENOENT)),
+                fmt::arg("error_code", ENOENT)));
+    }
     return {};
 }
 

--- a/libtransmission/open-files.cc
+++ b/libtransmission/open-files.cc
@@ -138,7 +138,8 @@ tr_open_files::Handle tr_open_files::get(
     bool writable,
     std::string_view const filename,
     tr_file_preallocation allocation,
-    uint64_t file_size)
+    uint64_t file_size,
+    tr_error& error)
 {
     // is there already an entry
     auto key = make_key(tor_id, file_num);
@@ -163,7 +164,6 @@ tr_open_files::Handle tr_open_files::get(
     // holds it is done.
 
     // create subfolders, if any
-    auto error = tr_error{};
     if (writable) {
         if (auto const dir = tr_sys_path_dirname(filename); !tr_sys_dir_create(dir, TR_SYS_DIR_CREATE_PARENTS, 0777, &error)) {
             tr_logAddError(
@@ -232,7 +232,7 @@ tr_open_files::Handle tr_open_files::get(
     // and one of the updated torrent's files is smaller.
     // https://bugs.launchpad.net/ubuntu/+source/transmission/+bug/318249
     if (resize_needed && !tr_sys_file_truncate(fd, file_size, &error)) {
-        tr_logAddWarn(
+        tr_logAddError(
             fmt::format(
                 fmt::runtime(_("Couldn't truncate '{path}': {error} ({error_code})")),
                 fmt::arg("path", filename),

--- a/libtransmission/open-files.h
+++ b/libtransmission/open-files.h
@@ -94,7 +94,8 @@ public:
         bool writable,
         std::string_view filename,
         tr_file_preallocation allocation,
-        uint64_t file_size);
+        uint64_t file_size,
+        tr_error& error);
 
     void close_all();
     void close_torrent(tr_torrent_id_t tor_id);

--- a/tests/libtransmission/CMakeLists.txt
+++ b/tests/libtransmission/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(libtransmission-test
         getopt-test.cc
         handshake-test.cc
         history-test.cc
+        inout-test.cc
         ip-cache-test.cc
         json-test.cc
         local-data-test.cc

--- a/tests/libtransmission/inout-test.cc
+++ b/tests/libtransmission/inout-test.cc
@@ -1,0 +1,70 @@
+// This file copyright Transmission authors and contributors.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosaic LLC.
+// License text can be found in the licenses/ folder.
+
+#include <chrono>
+#include <functional>
+#include <future>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <libtransmission/transmission.h>
+
+#include <libtransmission/block-info.h>
+#include <libtransmission/file.h>
+#include <libtransmission/inout.h>
+#include <libtransmission/torrent.h>
+
+#include "test-fixtures.h"
+
+using InOutTest = tr::test::SessionTest;
+
+TEST_F(InOutTest, writeFailsWhenExistingFileCannotBeOpened)
+{
+    auto* const tor = zeroTorrentInit(ZeroTorrentState::Complete);
+    auto constexpr MaxWaitMsec = 5000;
+
+    auto const path = tr_torrentFindFile(tor, 0U);
+    ASSERT_FALSE(std::empty(path));
+
+    // tr_ioWrite() must run in the session thread; block until it's done
+    auto const run_in_session_thread = [this, MaxWaitMsec](std::function<void()> fn) {
+        auto const promise = std::make_shared<std::promise<void>>();
+        auto future = promise->get_future();
+        session_->run_in_session_thread([fn = std::move(fn), promise]() {
+            fn();
+            promise->set_value();
+        });
+        ASSERT_EQ(std::future_status::ready, future.wait_for(std::chrono::milliseconds{ MaxWaitMsec }));
+    };
+
+    auto err = tr_error_code_t{};
+    auto const write_block = [session = session_, tor, &err]() {
+        auto const buf = std::vector<uint8_t>(tr_block_info::BlockSize);
+        err = tr_ioWrite(*tor, session->openFiles(), tor->block_loc(0U), buf);
+    };
+
+    // Neither the fixture nor verify go through the fd pool, so warm it
+    // with a write that succeeds: this is the steady state of a torrent
+    // that's been receiving blocks from peers.
+    run_in_session_thread(write_block);
+    ASSERT_EQ(0, err);
+
+    // Evict the pooled fd, then make the path unopenable by replacing
+    // the file with a directory.
+    run_in_session_thread([session = session_, tor]() { session->openFiles().close_torrent(tor->id()); });
+    ASSERT_TRUE(tr_sys_path_remove(path));
+    ASSERT_TRUE(tr_sys_dir_create(path, 0, 0700));
+
+    // The next write has to reopen the path. It must report the failure
+    // to its caller: returning success would make the caller discard the
+    // data, leaving pieces that later fail verification. Turning that
+    // into the torrent's local error is on_block_written()'s job, which
+    // TorrentDiskIoTest.failedWriteStopsTorrent covers.
+    run_in_session_thread(write_block);
+    EXPECT_NE(0, err);
+}

--- a/tests/libtransmission/open-files-test.cc
+++ b/tests/libtransmission/open-files-test.cc
@@ -39,6 +39,7 @@ TEST_F(OpenFilesTest, getCachedFailsIfNotCached)
 
 TEST_F(OpenFilesTest, getOpensIfNotCached)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     auto filename = tr_pathbuf{ sandboxDir(), "/test-file.txt" };
     createFileWithContents(filename, Contents);
@@ -47,7 +48,7 @@ TEST_F(OpenFilesTest, getOpensIfNotCached)
     EXPECT_FALSE(session_->openFiles().get(0, 0, false));
 
     // confirm that we can cache the file
-    auto const file = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents));
+    auto const file = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents), error);
     ASSERT_TRUE(file);
     EXPECT_NE(TR_BAD_SYS_FILE, file->fd());
 
@@ -61,23 +62,25 @@ TEST_F(OpenFilesTest, getOpensIfNotCached)
 
 TEST_F(OpenFilesTest, getCacheSucceedsIfCached)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     auto filename = tr_pathbuf{ sandboxDir(), "/test-file.txt" };
     createFileWithContents(filename, Contents);
 
     EXPECT_FALSE(session_->openFiles().get(0, 0, false));
-    EXPECT_TRUE(session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents)));
+    EXPECT_TRUE(session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents), error));
     EXPECT_TRUE(session_->openFiles().get(0, 0, false));
 }
 
 TEST_F(OpenFilesTest, getCachedReturnsTheSameFd)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     auto filename = tr_pathbuf{ sandboxDir(), "/test-file.txt" };
     createFileWithContents(filename, Contents);
 
     EXPECT_FALSE(session_->openFiles().get(0, 0, false));
-    auto const file1 = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents));
+    auto const file1 = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents), error);
     auto const file2 = session_->openFiles().get(0, 0, false);
     ASSERT_TRUE(file1);
     ASSERT_TRUE(file2);
@@ -87,13 +90,14 @@ TEST_F(OpenFilesTest, getCachedReturnsTheSameFd)
 
 TEST_F(OpenFilesTest, getCachedFailsIfWrongPermissions)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     auto filename = tr_pathbuf{ sandboxDir(), "/test-file.txt" };
     createFileWithContents(filename, Contents);
 
     // cache it in ro mode
     EXPECT_FALSE(session_->openFiles().get(0, 0, false));
-    EXPECT_TRUE(session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents)));
+    EXPECT_TRUE(session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents), error));
 
     // now try to get it in r/w mode
     EXPECT_TRUE(session_->openFiles().get(0, 0, false));
@@ -102,22 +106,23 @@ TEST_F(OpenFilesTest, getCachedFailsIfWrongPermissions)
 
 TEST_F(OpenFilesTest, opensInReadOnlyUnlessWritableIsRequested)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     auto filename = tr_pathbuf{ sandboxDir(), "/test-file.txt" };
     createFileWithContents(filename, Contents);
 
     // cache a file read-only mode
-    auto const file = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents));
+    auto const file = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents), error);
     ASSERT_TRUE(file);
 
     // confirm that writing to it fails
-    auto error = tr_error{};
     EXPECT_FALSE(tr_sys_file_write(file->fd(), std::data(Contents), std::size(Contents), nullptr, &error));
     EXPECT_TRUE(error);
 }
 
 TEST_F(OpenFilesTest, createsMissingFileIfWriteRequested)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     auto filename = tr_pathbuf{ sandboxDir(), "/test-file.txt" };
     EXPECT_FALSE(tr_sys_path_exists(filename));
@@ -126,7 +131,7 @@ TEST_F(OpenFilesTest, createsMissingFileIfWriteRequested)
     EXPECT_FALSE(file);
     EXPECT_FALSE(tr_sys_path_exists(filename));
 
-    file = session_->openFiles().get(0, 0, true, filename, PreallocateFull, std::size(Contents));
+    file = session_->openFiles().get(0, 0, true, filename, PreallocateFull, std::size(Contents), error);
     ASSERT_TRUE(file);
     EXPECT_NE(TR_BAD_SYS_FILE, file->fd());
     EXPECT_TRUE(tr_sys_path_exists(filename));
@@ -134,12 +139,13 @@ TEST_F(OpenFilesTest, createsMissingFileIfWriteRequested)
 
 TEST_F(OpenFilesTest, closeFileClosesTheFile)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     auto filename = tr_pathbuf{ sandboxDir(), "/test-file.txt" };
     createFileWithContents(filename, Contents);
 
     // cache a file read-only mode
-    EXPECT_TRUE(session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents)));
+    EXPECT_TRUE(session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents), error));
     EXPECT_TRUE(session_->openFiles().get(0, 0, false));
 
     // close the file
@@ -151,11 +157,12 @@ TEST_F(OpenFilesTest, closeFileClosesTheFile)
 
 TEST_F(OpenFilesTest, closingAFileLeavesItReadableForItsHolders)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     auto filename = tr_pathbuf{ sandboxDir(), "/test-file.txt" };
     createFileWithContents(filename, Contents);
 
-    auto const file = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents));
+    auto const file = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents), error);
     ASSERT_TRUE(file);
 
     // Uncache it while we're still holding it. An LRU eviction and a
@@ -172,15 +179,16 @@ TEST_F(OpenFilesTest, closingAFileLeavesItReadableForItsHolders)
 
 TEST_F(OpenFilesTest, reopeningWritableLeavesTheReadOnlyHolderAlone)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     auto filename = tr_pathbuf{ sandboxDir(), "/test-file.txt" };
     createFileWithContents(filename, Contents);
 
-    auto const ro = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents));
+    auto const ro = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents), error);
     ASSERT_TRUE(ro);
 
     // asking for write access drops the read-only entry and opens a new one
-    auto const rw = session_->openFiles().get(0, 0, true, filename, PreallocateFull, std::size(Contents));
+    auto const rw = session_->openFiles().get(0, 0, true, filename, PreallocateFull, std::size(Contents), error);
     ASSERT_TRUE(rw);
     EXPECT_NE(ro, rw);
 
@@ -193,16 +201,17 @@ TEST_F(OpenFilesTest, reopeningWritableLeavesTheReadOnlyHolderAlone)
 
 TEST_F(OpenFilesTest, closeTorrentClosesTheTorrentFiles)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     static auto constexpr TorId = tr_torrent_id_t{ 0 };
 
     auto filename = tr_pathbuf{ sandboxDir(), "/a.txt" };
     createFileWithContents(filename, Contents);
-    EXPECT_TRUE(session_->openFiles().get(TorId, 1, false, filename, PreallocateFull, std::size(Contents)));
+    EXPECT_TRUE(session_->openFiles().get(TorId, 1, false, filename, PreallocateFull, std::size(Contents), error));
 
     filename.assign(sandboxDir(), "/b.txt");
     createFileWithContents(filename, Contents);
-    EXPECT_TRUE(session_->openFiles().get(TorId, 3, false, filename, PreallocateFull, std::size(Contents)));
+    EXPECT_TRUE(session_->openFiles().get(TorId, 3, false, filename, PreallocateFull, std::size(Contents), error));
 
     // confirm that closing a different torrent does not affect these files
     session_->openFiles().close_torrent(TorId + 1);
@@ -238,8 +247,9 @@ TEST_F(OpenFilesTest, servesConcurrentCallersWhileFilesAreClosed)
             for (auto pass = 0; pass < NumPasses; ++pass) {
                 auto const file_num = (reader + pass) % NumFiles;
                 auto const filename = tr_pathbuf{ sandboxDir(), fmt::format("/file-{:d}.txt"sv, file_num) };
+                auto error = tr_error{};
                 auto const file = session_->openFiles()
-                                      .get(TorId, file_num, false, filename, PreallocateFull, std::size(Contents));
+                                      .get(TorId, file_num, false, filename, PreallocateFull, std::size(Contents), error);
                 if (!file) {
                     ++bad_reads;
                     continue;
@@ -272,6 +282,7 @@ TEST_F(OpenFilesTest, servesConcurrentCallersWhileFilesAreClosed)
 
 TEST_F(OpenFilesTest, closesLeastRecentlyUsedFile)
 {
+    auto error = tr_error{};
     static auto constexpr Contents = "Hello, World!\n"sv;
     static auto constexpr TorId = tr_torrent_id_t{ 0 };
     static auto constexpr LargerThanCacheLimit = 100;
@@ -281,7 +292,7 @@ TEST_F(OpenFilesTest, closesLeastRecentlyUsedFile)
     // supplant older ones.
     for (int i = 0; i < LargerThanCacheLimit; ++i) {
         auto filename = tr_pathbuf{ sandboxDir(), fmt::format("/file-{:d}.txt"sv, i) };
-        EXPECT_TRUE(session_->openFiles().get(TorId, i, true, filename, PreallocateFull, std::size(Contents)));
+        EXPECT_TRUE(session_->openFiles().get(TorId, i, true, filename, PreallocateFull, std::size(Contents), error));
     }
 
     // Do a lookup-only for the files again *in the same order*. By following the


### PR DESCRIPTION
Same defect as transmission/transmission#9050, which came out of the transmission/transmission#9049 review; this port carries the review refinements along.

### The bug

`tr_open_files::get()` builds a `tr_error` for every failure branch, logs it, and throws it away. `get_fd()` can't tell an unopenable existing file from a missing one: it returns the empty optional without setting the caller's error, so `write_bytes()` treats the failed open as success and silently discards the data it was asked to write. The pieces are marked complete and later turn up corrupt on verify. The create branch guesses at the cause via `errno`, which `get()` never sets, so it reports whatever unrelated call last set it (on Windows it is never set: `file-win32.cc` reports via `GetLastError()` only).

### The fix

- `tr_open_files::get()` grows a `tr_error` out-param and reports the real failure from all four branches (dir-create, open, preallocate, truncate).
- `get_fd()` uses it for both the open-existing and the create branches, and prefixes the message with the filename via `tr_error::prefix_message()` so the torrent's local error still names the file that broke.
- The truncate branch's log line moves from warn to error to match its behavior: failing there has always aborted the open.

### Tests

New `inout-test.cc` regression test: warm the fd pool with a write that succeeds, evict it with `close_torrent()`, replace the file with a directory, then write another block through `tr_ioWrite`. The second write has to reopen the path, and it must report the failure to its caller; on unfixed `main` it returns success and the data is gone. Turning that error into the torrent's local error and stop is `on_block_written()`'s job since #202, and `TorrentDiskIoTest.failedWriteStopsTorrent` covers that side. Verified the test fails with the fix reverted, and the full libtransmission suite is green with it applied.

Notes: Fixed silent data loss when a torrent's file exists but can't be reopened for writing, e.g. after running out of file descriptors or a permissions change.
