### PR TITLE
fix: upper size limit for magnet metadata

### DIFF
--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -34,7 +34,7 @@ public:
 
     [[nodiscard]] static constexpr auto is_valid_metadata_size(int64_t const size) noexcept
     {
-        return size > 0 && size <= MaxMetadataSize;
+        return 0 < size && size <= MaxMetadataSize;
     }
 
     bool set_metadata_piece(int64_t piece, void const* data, size_t len);

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -34,7 +34,7 @@ public:
 
     [[nodiscard]] static constexpr auto is_valid_metadata_size(int64_t const size) noexcept
     {
-        return size > 0;
+        return size > 0 && size <= MaxMetadataSize;
     }
 
     bool set_metadata_piece(int64_t piece, void const* data, size_t len);
@@ -73,4 +73,7 @@ private:
     int64_t piece_count_ = {};
 
     std::string log_name_;
+
+    // Arbitrary upper limit on magnet metadata to defend against memory exhaustion attacks
+    static constexpr auto MaxMetadataSize = 8 * 1024 * 1024; // 8 MiB
 };


### PR DESCRIPTION
## Description

Notes: Implemented size limits on peer messages to guard against memory exhaustion.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
