### PR TITLE
perf: optimize file list reloading and fix cell destruction

### DIFF
--- a/macosx/FileOutlineController.mm
+++ b/macosx/FileOutlineController.mm
@@ -59,8 +59,9 @@ typedef NS_ENUM(NSUInteger, FilePriorityMenuTag) { //
 
 - (void)setTorrent:(Torrent*)torrent
 {
-    // Save the previous row count to compute the diff for the batch update
-    NSInteger oldRowCount = self.fOutline.numberOfRows;
+    
+    // Close all folders.
+    [self.fOutline collapseItem:nil collapseChildren:YES];
 
     // 1. Update the underlying data source
     _torrent = torrent;
@@ -74,15 +75,16 @@ typedef NS_ENUM(NSUInteger, FilePriorityMenuTag) { //
     [self.fOutline beginUpdates];
 
     // Remove the old rows from the root (parent: nil)
-    if (oldRowCount > 0) {
-        NSIndexSet* oldIndexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, oldRowCount)];
+    NSInteger oldRootCount = self.fOutline.numberOfRows;
+    if (oldRootCount > 0) {
+        auto oldIndexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, oldRootCount)];
         [self.fOutline removeItemsAtIndexes:oldIndexes inParent:nil withAnimation:NSTableViewAnimationEffectNone];
     }
 
     // Insert the new rows. AppKit will re-map existing NSTableCellViews directly into these new indices
-    NSInteger newRowCount = self.fFileList.count;
+    NSUInteger newRowCount = self.fFileList.count;
     if (newRowCount > 0) {
-        NSIndexSet* newIndexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, newRowCount)];
+        auto newIndexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, newRowCount)];
         [self.fOutline insertItemsAtIndexes:newIndexes inParent:nil withAnimation:NSTableViewAnimationEffectNone];
     }
 

--- a/macosx/FileOutlineController.mm
+++ b/macosx/FileOutlineController.mm
@@ -59,19 +59,20 @@ typedef NS_ENUM(NSUInteger, FilePriorityMenuTag) { //
 
 - (void)setTorrent:(Torrent*)torrent
 {
-    
-    // Close all folders.
-    [self.fOutline collapseItem:nil collapseChildren:YES];
-
-    // 1. Update the underlying data source
-    _torrent = torrent;
-    [self.fFileList setArray:torrent.fileList ?: @[]];
+    // 1. Clear filter and perform necessary updates.
     self.filterText = nil;
 
-    // 2. Clear selection before mutating the layout to prevent selection artifacts
+    // 2. Close all folders (we need to calculate number of rows).
+    [self.fOutline collapseItem:nil collapseChildren:YES];
+
+    // 3. Clear selection before mutating the layout to prevent selection artifacts
     [self.fOutline deselectAll:nil];
 
-    // 3. Perform a safe batch update to preserve view hierarchy and reuse NSViews
+    // 4. Set new DataSource
+    _torrent = torrent;
+    [self.fFileList setArray:torrent.fileList ?: @[]];
+
+    // 5. Perform a safe batch update to preserve view hierarchy and reuse NSViews
     [self.fOutline beginUpdates];
 
     // Remove the old rows from the root (parent: nil)
@@ -81,7 +82,7 @@ typedef NS_ENUM(NSUInteger, FilePriorityMenuTag) { //
         [self.fOutline removeItemsAtIndexes:oldIndexes inParent:nil withAnimation:NSTableViewAnimationEffectNone];
     }
 
-    // Insert the new rows. AppKit will re-map existing NSTableCellViews directly into these new indices
+    // Insert the new rows.
     NSUInteger newRowCount = self.fFileList.count;
     if (newRowCount > 0) {
         auto newIndexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, newRowCount)];

--- a/macosx/FileOutlineController.mm
+++ b/macosx/FileOutlineController.mm
@@ -62,32 +62,28 @@ typedef NS_ENUM(NSUInteger, FilePriorityMenuTag) { //
     // 1. Clear filter and perform necessary updates.
     self.filterText = nil;
 
-    // 2. Close all folders (we need to calculate number of rows).
-    [self.fOutline collapseItem:nil collapseChildren:YES];
-
-    // 3. Clear selection before mutating the layout to prevent selection artifacts
+    // 2. Clear selection before mutating the layout to prevent selection artifacts
     [self.fOutline deselectAll:nil];
 
-    // 4. Set new DataSource
+    // 3. Remember old number of top items.
+    NSUInteger const oldRootCount = self.fFileList.count;
+    auto oldIndexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, oldRootCount)];
+
+    // 4. Set new dataSource
     _torrent = torrent;
     [self.fFileList setArray:torrent.fileList ?: @[]];
+
+    NSUInteger const newRowCount = self.fFileList.count;
+    auto newIndexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, newRowCount)];
 
     // 5. Perform a safe batch update to preserve view hierarchy and reuse NSViews
     [self.fOutline beginUpdates];
 
     // Remove the old rows from the root (parent: nil)
-    NSInteger oldRootCount = self.fOutline.numberOfRows;
-    if (oldRootCount > 0) {
-        auto oldIndexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, oldRootCount)];
-        [self.fOutline removeItemsAtIndexes:oldIndexes inParent:nil withAnimation:NSTableViewAnimationEffectNone];
-    }
+    [self.fOutline removeItemsAtIndexes:oldIndexes inParent:nil withAnimation:NSTableViewAnimationEffectNone];
 
     // Insert the new rows.
-    NSUInteger newRowCount = self.fFileList.count;
-    if (newRowCount > 0) {
-        auto newIndexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, newRowCount)];
-        [self.fOutline insertItemsAtIndexes:newIndexes inParent:nil withAnimation:NSTableViewAnimationEffectNone];
-    }
+    [self.fOutline insertItemsAtIndexes:newIndexes inParent:nil withAnimation:NSTableViewAnimationEffectNone];
 
     [self.fOutline endUpdates];
 }

--- a/macosx/FileOutlineController.mm
+++ b/macosx/FileOutlineController.mm
@@ -59,14 +59,34 @@ typedef NS_ENUM(NSUInteger, FilePriorityMenuTag) { //
 
 - (void)setTorrent:(Torrent*)torrent
 {
+    // Save the previous row count to compute the diff for the batch update
+    NSInteger oldRowCount = self.fOutline.numberOfRows;
+
+    // 1. Update the underlying data source
     _torrent = torrent;
-
     [self.fFileList setArray:torrent.fileList ?: @[]];
-
     self.filterText = nil;
 
-    [self.fOutline reloadData];
-    [self.fOutline deselectAll:nil]; //do this after reloading the data #4575
+    // 2. Clear selection before mutating the layout to prevent selection artifacts
+    [self.fOutline deselectAll:nil];
+
+    // 3. Perform a safe batch update to preserve view hierarchy and reuse NSViews
+    [self.fOutline beginUpdates];
+
+    // Remove the old rows from the root (parent: nil)
+    if (oldRowCount > 0) {
+        NSIndexSet* oldIndexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, oldRowCount)];
+        [self.fOutline removeItemsAtIndexes:oldIndexes inParent:nil withAnimation:NSTableViewAnimationEffectNone];
+    }
+
+    // Insert the new rows. AppKit will re-map existing NSTableCellViews directly into these new indices
+    NSInteger newRowCount = self.fFileList.count;
+    if (newRowCount > 0) {
+        NSIndexSet* newIndexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, newRowCount)];
+        [self.fOutline insertItemsAtIndexes:newIndexes inParent:nil withAnimation:NSTableViewAnimationEffectNone];
+    }
+
+    [self.fOutline endUpdates];
 }
 
 - (void)setFilterText:(NSString*)text


### PR DESCRIPTION
## Description
This PR optimizes the data reloading pipeline inside the FileOutlineView (`NSOutlineView`) when switching between items (e.g., torrents/folders). 

Previously, using `reloadData` forced AppKit to completely drop and re-create `NSTableCellView` instances from scratch. This led to unnecessary layout passes, performance drops, and potential out-of-bounds crashes during mouse interaction loops.

### Key Changes:
1. **Moved Selection Reset**: `deselectAll:` is now strictly called *before* mutating the backing array, preventing AppKit from triggering delegate notifications or evaluating layout states on invalid/stale indexes.
2. **Introduced Batch Updates**: Replaced destructive full reloads with an atomic `beginUpdates`/`endUpdates` cycle using `NSTableViewAnimationEffectNone`.
3. **Preserved View Hierarchy**: AppKit now successfully retains existing `NSTableCellView` objects inside the view hierarchy and re-maps them directly via the reuse pool inside `viewForTableColumn:`, dramatically increasing performance.

## How to Test
1. Select a torrent with a large file list in the TorrentsTableView.
2. Observe instantaneous switching without UI stutters or visible cell "blinking".
3. Verify that `Instruments (Allocations / Layout)`