### PR TITLE
fix(qt): use qt type for `Session::blocklistUpdated` signal

### DIFF
--- a/qt/Session.cc
+++ b/qt/Session.cc
@@ -561,12 +561,14 @@ void Session::updateBlocklist()
             // failure here or the progress dialog is left with no result.
             [this](RpcResponse const& r) { emit blocklistUpdateFailed(QString::fromStdString(r.errmsg)); })
         .add([this](RpcResponse const& r) {
-            auto const n_rules = dictFind<int>(r.args.get(), TR_KEY_blocklist_size).value_or(0);
-            setBlocklistSize(n_rules);
-            // Announce success only for this manual update. setBlocklistSize() no longer
-            // emits blocklistUpdated(), so a background session_get refresh can't flash a
-            // spurious "Update succeeded!" in the dialog.
-            emit blocklistUpdated(n_rules);
+            if (auto const* const map = r.args->get_if<tr_variant::Map>()) {
+                auto const n_rules = map->value_if<int64_t>(TR_KEY_blocklist_size).value_or(0);
+                setBlocklistSize(n_rules);
+                // Announce success only for this manual update. setBlocklistSize() no longer
+                // emits blocklistUpdated(), so a background session_get refresh can't flash a
+                // spurious "Update succeeded!" in the dialog.
+                emit blocklistUpdated(n_rules);
+            }
         })
         .run();
 }

--- a/qt/Session.h
+++ b/qt/Session.h
@@ -139,7 +139,7 @@ signals:
     void portTested(std::optional<bool> status, PortTestIpProtocol ip_protocol);
     void statsUpdated();
     void sessionUpdated();
-    void blocklistUpdated(int64_t);
+    void blocklistUpdated(qint64);
     void blocklistUpdateFailed(QString const& message);
     void torrentsUpdated(tr_variant* torrent_list, bool complete_list);
     void torrentsRemoved(tr_variant* torrent_list);


### PR DESCRIPTION
## Description

Use `qint64` for the `Session::blocklistUpdated` signal, so that we don't need to manually register `int64_t` as a metatype.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
