### PR TITLE
build: require at least GCC 12

### DIFF
--- a/.github/actions/finalize-ccache/action.yml
+++ b/.github/actions/finalize-ccache/action.yml
@@ -6,9 +6,6 @@ inputs:
   trim-age:
     description: Age passed to ccache --evict-older-than
     default: 7d
-  ignore-trim-errors:
-    description: Continue saving when the installed ccache cannot trim by age
-    default: 'false'
 runs:
   using: composite
   steps:
@@ -22,9 +19,8 @@ runs:
       if: ${{ github.ref == 'refs/heads/main' }}
       shell: bash
       env:
-        IGNORE_TRIM_ERRORS: ${{ inputs.ignore-trim-errors }}
         TRIM_AGE: ${{ inputs.trim-age }}
-      run: ccache --evict-older-than "$TRIM_AGE" || [ "$IGNORE_TRIM_ERRORS" = 'true' ]
+      run: ccache --evict-older-than "$TRIM_AGE"
     - name: Save replacement snapshot
       if: ${{ github.ref == 'refs/heads/main' }}
       uses: actions/cache/save@v5

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -109,6 +109,7 @@ runs:
             libarchive-dev
             libcurl4-openssl-dev
             libevent-dev
+            libfmt-dev
             libminiupnpc-dev
             libnatpmp-dev
             libpsl-dev
@@ -124,12 +125,6 @@ runs:
           # https://github.com/transmission/transmission/pull/6900
           if [ "$DISTRO" = 'debian' ]; then
             BASE_PACKAGES+=(libgtest-dev)
-          fi
-
-          if [ ! "$DISTRO" = 'debian' ] || [ ! "$DISTRO_VERSION" = '11' ]; then
-            BASE_PACKAGES+=(
-              libfmt-dev
-            )
           fi
 
           # Compiler packages

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -52,7 +52,6 @@ runs:
 
           # Transmission-specific libraries with Fedora names
           dnf install -y \
-            fast_float-devel \
             fmt-devel \
             libarchive-devel \
             libcurl-devel \
@@ -129,7 +128,6 @@ runs:
 
           if [ ! "$DISTRO" = 'debian' ] || [ ! "$DISTRO_VERSION" = '11' ]; then
             BASE_PACKAGES+=(
-              libfast-float-dev
               libfmt-dev
             )
           fi
@@ -239,7 +237,6 @@ runs:
 
         # Transmission-specific libraries
         BASE_PACKAGES+=(
-          fast_float
           fmt
           libarchive
           libevent

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -52,6 +52,7 @@ runs:
 
           # Transmission-specific libraries with Fedora names
           dnf install -y \
+            fast_float-devel \
             fmt-devel \
             libarchive-devel \
             libcurl-devel \
@@ -109,6 +110,7 @@ runs:
             libarchive-dev
             libcurl4-openssl-dev
             libevent-dev
+            libfast-float-dev
             libfmt-dev
             libminiupnpc-dev
             libnatpmp-dev
@@ -232,6 +234,7 @@ runs:
 
         # Transmission-specific libraries
         BASE_PACKAGES+=(
+          fast_float
           fmt
           libarchive
           libevent

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -713,7 +713,6 @@ jobs:
             build-base \
             cmake \
             curl-dev \
-            fast_float \
             fmt-dev \
             gettext-dev \
             git \
@@ -1122,7 +1121,6 @@ jobs:
 
           if [ '${{ matrix.use-legacy-packages }}' = 'true' ]; then
             set -- "$@" \
-              -DUSE_SYSTEM_FAST_FLOAT=OFF \
               -DUSE_SYSTEM_FMT=OFF
           else
             set -- "$@" -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold
@@ -1570,7 +1568,6 @@ jobs:
               curl \
               cmake \
               dht \
-              fast_float \
               libevent \
               libfmt \
               libnatpmp \
@@ -1743,7 +1740,6 @@ jobs:
             pkg_add -I -v \
               curl \
               cmake \
-              fast-float \
               fmt \
               gtar-- \
               libevent \
@@ -1827,7 +1823,6 @@ jobs:
             until /usr/sbin/pkg_add -u \
               curl \
               cmake \
-              fast_float \
               fmtlib \
               libevent \
               libpsl \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1047,11 +1047,9 @@ jobs:
           - version: oldstable
             gtk: gtk3
             qt: qt5
-            use-legacy-packages: true
           - version: stable
             gtk: gtk4
             qt: qt6
-            use-legacy-packages: false
     container:
       image: debian:${{ matrix.version }}-slim
     steps:
@@ -1060,13 +1058,6 @@ jobs:
           echo '${{ toJSON(needs) }}'
           echo '${{ toJSON(runner) }}'
           cat /etc/os-release
-      - name: Warn if oldoldstable moved past Debian 11
-        if: ${{ matrix.version == 'oldoldstable' }}
-        run: |
-          . /etc/os-release
-          if [ "$VERSION_ID" != '11' ]; then
-            echo "::warning title=Debian oldoldstable changed::debian:oldoldstable currently resolves to Debian $VERSION_ID. Consider removing matrix.use-legacy-packages if legacy package workarounds are no longer needed."
-          fi
       - name: Get Composite Actions
         uses: actions/checkout@v6
         with:
@@ -1080,8 +1071,7 @@ jobs:
           enable-gtk: ${{ needs.what-to-make.outputs.make-gtk == 'true' && matrix.gtk || 'false' }}
           enable-qt: ${{ needs.what-to-make.outputs.make-qt == 'true' && matrix.qt || 'false' }}
           use-sudo: false
-          # Debian 11 (oldoldstable) has no mold package and its GCC 10 predates -fuse-ld=mold.
-          enable-mold: ${{ matrix.use-legacy-packages != true }}
+          enable-mold: true
           enable-ccache: true
       - name: Setup ccache
         uses: ./.github/actions/setup-ccache
@@ -1096,13 +1086,14 @@ jobs:
         run: mkdir src && tar xf transmission*.tar.* -C src --strip-components 1
       - name: Configure
         run: |
-          set -- \
+          cmake \
             -S src \
             -B obj \
             -G Ninja \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold \
             -DCMAKE_INSTALL_PREFIX=pfx \
             -DENABLE_CLI=${{ (needs.what-to-make.outputs.make-cli == 'true') && 'ON' || 'OFF' }} \
             -DENABLE_DAEMON=${{ (needs.what-to-make.outputs.make-daemon == 'true') && 'ON' || 'OFF' }} \
@@ -1122,15 +1113,6 @@ jobs:
             -DUSE_SYSTEM_SMALL=OFF \
             -DUSE_SYSTEM_UTP=OFF \
             -DUSE_SYSTEM_WIDE_INTEGER=OFF
-
-          if [ '${{ matrix.use-legacy-packages }}' = 'true' ]; then
-            set -- "$@" \
-              -DUSE_SYSTEM_FMT=OFF
-          else
-            set -- "$@" -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold
-          fi
-
-          cmake "$@"
       - name: Build
         run: cmake --build obj --config Release
       - name: Test
@@ -1148,7 +1130,6 @@ jobs:
       - name: Finalize ccache
         uses: ./.github/actions/finalize-ccache
         with:
-          ignore-trim-errors: ${{ matrix.use-legacy-packages }}
           trim-age: 3d
       - name: Show ccache stats
         if: always()

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -713,6 +713,7 @@ jobs:
             build-base \
             cmake \
             curl-dev \
+            fast_float \
             fmt-dev \
             gettext-dev \
             git \
@@ -1553,6 +1554,7 @@ jobs:
               curl \
               cmake \
               dht \
+              fast_float \
               libevent \
               libfmt \
               libnatpmp \
@@ -1725,6 +1727,7 @@ jobs:
             pkg_add -I -v \
               curl \
               cmake \
+              fast-float \
               fmt \
               gtar-- \
               libevent \
@@ -1808,6 +1811,7 @@ jobs:
             until /usr/sbin/pkg_add -u \
               curl \
               cmake \
+              fast_float \
               fmtlib \
               libevent \
               libpsl \

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1040,7 +1040,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - version: oldoldstable
+          # Debian _typically_ releases every 2 years, and each has 5 years of support+LTS.
+          # So the `oldstable` tag is the oldest Docker tag we can use without ever ending up
+          # testing on an EOL release, while not needing periodic updates to the workflow.
+          # Ref: https://wiki.debian.org/DebianReleases
+          - version: oldstable
             gtk: gtk3
             qt: qt5
             use-legacy-packages: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,10 +28,6 @@
 	path = third-party/fmt
 	# synced with https://github.com/fmtlib/fmt.git
 	url = https://github.com/transmissiontorrent/fmt.git
-[submodule "third-party/fast_float"]
-	path = third-party/fast_float
-	# synced with https://github.com/fastfloat/fast_float.git
-	url = https://github.com/transmissiontorrent/fast_float.git
 [submodule "third-party/wide-integer"]
 	path = third-party/wide-integer
 	# synced with https://github.com/ckormanyos/wide-integer.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,6 +28,10 @@
 	path = third-party/fmt
 	# synced with https://github.com/fmtlib/fmt.git
 	url = https://github.com/transmissiontorrent/fmt.git
+[submodule "third-party/fast_float"]
+	path = third-party/fast_float
+	# synced with https://github.com/fastfloat/fast_float.git
+	url = https://github.com/transmissiontorrent/fast_float.git
 [submodule "third-party/wide-integer"]
 	path = third-party/wide-integer
 	# synced with https://github.com/ckormanyos/wide-integer.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,9 +52,6 @@ set(CURL_MINIMUM 7.28.0)
 set(ZLIB_MINIMUM 1.2.1)
 set(WOLFSSL_MINIMUM 3.4)
 set(EVENT2_MINIMUM 2.1.0)
-# fast_float's version file is configured with `COMPATIBILITY SameMajorVersion`
-# The version range currently distributed varies greatly (e.g. Debian Trixie -> 8.0.0, Ubuntu 24.04 -> 3.9.0)
-# set(FAST_FLOAT_MINIMUM 3...8)
 set(FMT_MINIMUM 8.0.1)
 set(GIOMM_MINIMUM 2.26.0)
 set(GLIBMM_MINIMUM 2.60.0)
@@ -91,7 +88,6 @@ tr_auto_option(RUN_CLANG_TIDY "Run clang-tidy on the code" ${USE_SYSTEM_DEFAULT}
 tr_auto_option(USE_SYSTEM_ARCHIVE "Use system libarchive library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_EVENT2 "Use system event2 library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_DHT "Use system dht library" ${USE_SYSTEM_DEFAULT})
-tr_auto_option(USE_SYSTEM_FAST_FLOAT "Use system fast_float library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_FMT "Use system fmt library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_MINIUPNPC "Use system miniupnpc library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_NATPMP "Use system natpmp library" ${USE_SYSTEM_DEFAULT})
@@ -662,15 +658,6 @@ if(ENABLE_UTP)
         CMAKE_ARGS
             -DLIBUTP_SHARED:BOOL=OFF)
 endif()
-
-tr_add_external_auto_library(FAST_FLOAT FastFloat
-    SUBPROJECT
-    SOURCE_DIR fast_float
-    CMAKE_ARGS
-        -DFASTFLOAT_INSTALL=OFF
-        -DFASTFLOAT_TEST=OFF
-        -DFASTFLOAT_SANITIZE=OFF
-        -DFASTFLOAT_CXX_STANDARD=${CMAKE_CXX_STANDARD})
 
 tr_add_external_auto_library(FMT fmt
     SUBPROJECT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,9 @@ set(CURL_MINIMUM 7.28.0)
 set(ZLIB_MINIMUM 1.2.1)
 set(WOLFSSL_MINIMUM 3.4)
 set(EVENT2_MINIMUM 2.1.0)
+# fast_float's version file is configured with `COMPATIBILITY SameMajorVersion`
+# The version range currently distributed varies greatly (e.g. Debian Trixie -> 8.0.0, Ubuntu 24.04 -> 3.9.0)
+# set(FAST_FLOAT_MINIMUM 3...8)
 set(FMT_MINIMUM 8.0.1)
 set(GIOMM_MINIMUM 2.26.0)
 set(GLIBMM_MINIMUM 2.60.0)
@@ -88,6 +91,7 @@ tr_auto_option(RUN_CLANG_TIDY "Run clang-tidy on the code" ${USE_SYSTEM_DEFAULT}
 tr_auto_option(USE_SYSTEM_ARCHIVE "Use system libarchive library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_EVENT2 "Use system event2 library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_DHT "Use system dht library" ${USE_SYSTEM_DEFAULT})
+tr_auto_option(USE_SYSTEM_FAST_FLOAT "Use system fast_float library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_FMT "Use system fmt library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_MINIUPNPC "Use system miniupnpc library" ${USE_SYSTEM_DEFAULT})
 tr_auto_option(USE_SYSTEM_NATPMP "Use system natpmp library" ${USE_SYSTEM_DEFAULT})
@@ -658,6 +662,15 @@ if(ENABLE_UTP)
         CMAKE_ARGS
             -DLIBUTP_SHARED:BOOL=OFF)
 endif()
+
+tr_add_external_auto_library(FAST_FLOAT FastFloat
+    SUBPROJECT
+    SOURCE_DIR fast_float
+    CMAKE_ARGS
+        -DFASTFLOAT_INSTALL=OFF
+        -DFASTFLOAT_TEST=OFF
+        -DFASTFLOAT_SANITIZE=OFF
+        -DFASTFLOAT_CXX_STANDARD=${CMAKE_CXX_STANDARD})
 
 tr_add_external_auto_library(FMT fmt
     SUBPROJECT

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -4693,6 +4693,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/dht",
+					"third-party/fast_float/include",
 					"third-party/wide-integer",
 					"third-party/simdutf/include",
 					"third-party/libwoke/include",
@@ -4715,6 +4716,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/dht",
+					"third-party/fast_float/include",
 					"third-party/fmt/include",
 					"third-party/sigslot/include",
 					"third-party/small/include",
@@ -4943,6 +4945,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/dht",
+					"third-party/fast_float/include",
 					"third-party/wide-integer",
 					"third-party/simdutf/include",
 					"third-party/libwoke/include",
@@ -4965,6 +4968,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/dht",
+					"third-party/fast_float/include",
 					"third-party/fmt/include",
 					"third-party/sigslot/include",
 					"third-party/small/include",
@@ -5274,6 +5278,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/dht",
+					"third-party/fast_float/include",
 					"third-party/wide-integer",
 					"third-party/simdutf/include",
 					"third-party/libwoke/include",
@@ -5296,6 +5301,7 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/dht",
+					"third-party/fast_float/include",
 					"third-party/fmt/include",
 					"third-party/sigslot/include",
 					"third-party/small/include",

--- a/Transmission.xcodeproj/project.pbxproj
+++ b/Transmission.xcodeproj/project.pbxproj
@@ -4693,7 +4693,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/dht",
-					"third-party/fast_float/include",
 					"third-party/wide-integer",
 					"third-party/simdutf/include",
 					"third-party/libwoke/include",
@@ -4716,7 +4715,6 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/dht",
-					"third-party/fast_float/include",
 					"third-party/fmt/include",
 					"third-party/sigslot/include",
 					"third-party/small/include",
@@ -4945,7 +4943,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/dht",
-					"third-party/fast_float/include",
 					"third-party/wide-integer",
 					"third-party/simdutf/include",
 					"third-party/libwoke/include",
@@ -4968,7 +4965,6 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/dht",
-					"third-party/fast_float/include",
 					"third-party/fmt/include",
 					"third-party/sigslot/include",
 					"third-party/small/include",
@@ -5278,7 +5274,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/dht",
-					"third-party/fast_float/include",
 					"third-party/wide-integer",
 					"third-party/simdutf/include",
 					"third-party/libwoke/include",
@@ -5301,7 +5296,6 @@
 				SYSTEM_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"third-party/dht",
-					"third-party/fast_float/include",
 					"third-party/fmt/include",
 					"third-party/sigslot/include",
 					"third-party/small/include",

--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -191,8 +191,8 @@ namespace
 auto onFileAdded(tr_session* session, std::string_view dirname, std::string_view basename)
 {
     auto const lowercase = tr_strlower(basename);
-    auto const is_torrent = tr_strv_ends_with(lowercase, ".torrent"sv);
-    auto const is_magnet = tr_strv_ends_with(lowercase, ".magnet"sv);
+    auto const is_torrent = lowercase.ends_with(".torrent"sv);
+    auto const is_magnet = lowercase.ends_with(".magnet"sv);
 
     if (!is_torrent && !is_magnet) {
         return Watchdir::Action::Done;

--- a/gtk/FilterBar.cc
+++ b/gtk/FilterBar.cc
@@ -196,12 +196,12 @@ bool FilterBar::Impl::tracker_filter_model_update()
         std::string sitename;
         std::string announce_url;
 
-        TR_CONSTEXPR_STR auto operator<=>(site_info const& that) const noexcept
+        constexpr auto operator<=>(site_info const& that) const noexcept
         {
             return sitename <=> that.sitename;
         }
 
-        TR_CONSTEXPR_STR auto operator==(site_info const& that) const
+        constexpr auto operator==(site_info const& that) const
         {
             return sitename == that.sitename;
         }

--- a/gtk/MainWindow.cc
+++ b/gtk/MainWindow.cc
@@ -817,8 +817,7 @@ bool MainWindow::for_each_selected_torrent_until(std::function<bool(Glib::RefPtr
     bool result = false;
 
 #if GTKMM_CHECK_VERSION(4, 0, 0)
-    auto const selected_items = selection->get_selection(); // TODO(C++20): Move into the `for`
-    for (auto const position : *selected_items) {
+    for (auto const selected_items = selection->get_selection(); auto const position : *selected_items) {
         if (callback(gtr_ptr_dynamic_cast<Torrent>(model->get_object(position)))) {
             result = true;
             break;

--- a/gtk/Session.cc
+++ b/gtk/Session.cc
@@ -763,7 +763,7 @@ bool Session::Impl::add(Glib::ustring const& name_in, bool const do_start, bool 
     // `gio::File` doesn't seem to know how to stringify magnet links correctly.
     // Unfortunately there are some code paths that unavoidably use `gio::File`
     // e.g. Gtk::Application::on_open() so we have to do this:
-    if (auto constexpr BrokenMagnetLinkPrefix = "magnet:///?"sv; tr_strv_starts_with(name.raw(), BrokenMagnetLinkPrefix)) {
+    if (auto constexpr BrokenMagnetLinkPrefix = "magnet:///?"sv; name.raw().starts_with(BrokenMagnetLinkPrefix)) {
         name.replace(0, std::size(BrokenMagnetLinkPrefix), "magnet:?");
     }
 

--- a/libtransmission-app/converters.cc
+++ b/libtransmission-app/converters.cc
@@ -45,75 +45,6 @@ consteval LookupTable<std::remove_cv_t<T>, N> to_lookup(std::pair<std::string_vi
 
 // ---
 
-struct TrYearMonthDay {
-    int year = 0;
-    unsigned month = 0;
-    unsigned day = 0;
-    bool valid = false;
-
-    [[nodiscard]] constexpr bool ok() const noexcept
-    {
-        return valid;
-    }
-};
-
-// c++20 (P0355) replace with std::chrono::year_month_day() after Debian 11 is EOL
-[[nodiscard]] constexpr TrYearMonthDay tr_year_month_day(int year, unsigned month, unsigned day)
-{
-    auto const is_leap_year = [](int y) constexpr {
-        return (y % 4 == 0) && ((y % 100) != 0 || (y % 400) == 0);
-    };
-
-    auto const days_in_month = [&](int y, unsigned m) constexpr {
-        switch (m) {
-        case 1:
-        case 3:
-        case 5:
-        case 7:
-        case 8:
-        case 10:
-        case 12:
-            return 31;
-        case 4:
-        case 6:
-        case 9:
-        case 11:
-            return 30;
-        case 2:
-            return is_leap_year(y) ? 29 : 28;
-        default:
-            return 0;
-        }
-    };
-
-    auto const is_valid_ymd = [&](int y, unsigned m, unsigned d) constexpr {
-        if (m < 1 || m > 12) {
-            return false;
-        }
-
-        auto const dim = days_in_month(y, m);
-        return d >= 1 && std::cmp_less_equal(d, dim);
-    };
-
-    return TrYearMonthDay{ .year = year, .month = month, .day = day, .valid = is_valid_ymd(year, month, day) };
-}
-
-// c++20 (P0355) replace with std::chrono::sys_days{} after Debian 11 is EOL
-// Returns days since 1970-01-01. Based on Howard Hinnant's civil calendar algorithms.
-[[nodiscard]] constexpr std::chrono::sys_days tr_sys_days(TrYearMonthDay const& ymd)
-{
-    auto const days_from_civil = [](int year, unsigned month, unsigned day) constexpr {
-        year -= static_cast<int>(month <= 2);
-        auto const era = (year >= 0 ? year : year - 399) / 400;
-        auto const yoe = static_cast<unsigned>(year - (era * 400));
-        auto const doy = (((153 * (month + (month > 2 ? -3 : 9))) + 2) / 5) + day - 1;
-        auto const doe = (yoe * 365) + (yoe / 4) - (yoe / 100) + doy;
-        return (static_cast<int64_t>(era) * 146097) + static_cast<int64_t>(doe) - 719468;
-    };
-
-    return std::chrono::sys_days{ std::chrono::days{ days_from_civil(ymd.year, ymd.month, ymd.day) } };
-}
-
 auto constexpr ShowKeys = to_lookup<ShowMode>({
     { "show_active", ShowMode::ShowActive },
     { "show_all", ShowMode::ShowAll },
@@ -241,7 +172,7 @@ tr_variant from_stats_mode(StatsMode const& src)
 
 // ---
 
-// c++20(P0355): use std::chrono::parse if/when it's ever available
+// c++20(P0355): use std::chrono::parse, GCC 14.1, clang https://github.com/llvm/llvm-project/issues/166051
 [[nodiscard]] std::optional<std::chrono::sys_seconds> parse_sys_seconds(std::string_view str)
 {
     auto const sv = tr_strv_strip(str);
@@ -272,13 +203,16 @@ tr_variant from_stats_mode(StatsMode const& src)
         return {};
     }
 
-    auto const ymd = tr_year_month_day(year, static_cast<unsigned>(month), static_cast<unsigned>(day));
+    auto const ymd = std::chrono::year_month_day{
+        std::chrono::year{ year },
+        std::chrono::month{ static_cast<unsigned>(month) },
+        std::chrono::day{ static_cast<unsigned>(day) },
+    };
     if (!ymd.ok()) {
         return {};
     }
 
-    auto const day_point = std::chrono::time_point_cast<std::chrono::seconds>(tr_sys_days(ymd));
-    auto const local_tp = day_point + std::chrono::hours{ hour } + std::chrono::minutes{ minute } +
+    auto const local_tp = std::chrono::sys_days{ ymd } + std::chrono::hours{ hour } + std::chrono::minutes{ minute } +
         std::chrono::seconds{ second };
 
     if (std::size(sv) == 20U) {
@@ -317,6 +251,7 @@ tr_variant from_stats_mode(StatsMode const& src)
     auto const tp = std::chrono::time_point_cast<std::chrono::seconds>(src);
     auto const tt = std::chrono::system_clock::to_time_t(tp);
 
+    // TODO(c++20): switch to std::chrono::zoned_time, GCC 13.1, clang 19 (or clang 21 with std::format), fmt 11.2
     // prefer localtime with TZ offset data when we can get it.
     if constexpr (HasTmGmtoffV<std::tm>) {
         if (auto const* local = std::localtime(&tt)) {

--- a/libtransmission-app/interop.cc
+++ b/libtransmission-app/interop.cc
@@ -16,7 +16,6 @@
 #include <libtransmission/file-utils.h> // tr_file_read()
 #include <libtransmission/file.h> // tr_sys_path_resolve()
 #include <libtransmission/magnet-metainfo.h>
-#include <libtransmission/string-utils.h> // tr_strv_starts_with()
 #include <libtransmission/torrent-metainfo.h> // tr_torrent_metainfo
 #include <libtransmission/tr-strbuf.h>
 #include <libtransmission/web-utils.h> // tr_urlIsValid()
@@ -79,7 +78,7 @@ namespace
 [[nodiscard]] std::string local_filename(std::string_view const arg)
 {
     auto constexpr Scheme = "file://"sv;
-    if (!tr_strv_starts_with(arg, Scheme)) {
+    if (!arg.starts_with(Scheme)) {
         return std::string{ arg };
     }
 

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -282,7 +282,6 @@ target_link_libraries(${TR_NAME}
         libarchive::libarchive
         ZLIB::ZLIB
         CURL::libcurl
-        FastFloat::fast_float
         psl::psl
         natpmp::natpmp
         miniupnpc::miniupnpc

--- a/libtransmission/CMakeLists.txt
+++ b/libtransmission/CMakeLists.txt
@@ -282,6 +282,7 @@ target_link_libraries(${TR_NAME}
         libarchive::libarchive
         ZLIB::ZLIB
         CURL::libcurl
+        FastFloat::fast_float
         psl::psl
         natpmp::natpmp
         miniupnpc::miniupnpc

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -128,7 +128,7 @@ std::optional<std::string> tr_announce_list::announce_to_scrape(std::string_view
     }
 
     // some torrents with UDP announce URLs don't have /announce
-    if (tr_strv_starts_with(announce, "udp:"sv)) {
+    if (announce.starts_with("udp:"sv)) {
         return std::string{ announce };
     }
 

--- a/libtransmission/announce-list.cc
+++ b/libtransmission/announce-list.cc
@@ -275,7 +275,7 @@ bool tr_announce_list::parse(std::string_view text)
     auto current_tier_size = size_t{ 0 };
     auto line = std::string_view{};
     while (tr_strv_sep(&text, &line, '\n')) {
-        if (tr_strv_ends_with(line, '\r')) {
+        if (line.ends_with('\r')) {
             line = line.substr(0, std::size(line) - 1);
         }
 

--- a/libtransmission/announce-list.h
+++ b/libtransmission/announce-list.h
@@ -12,7 +12,6 @@
 #include <string_view>
 #include <vector>
 
-#include "libtransmission/macros.h" // TR_CONSTEXPR_VEC
 #include "libtransmission/shared-string.h"
 #include "libtransmission/types.h"
 #include "libtransmission/variant.h"
@@ -70,14 +69,14 @@ public:
         return std::size(trackers_);
     }
 
-    [[nodiscard]] TR_CONSTEXPR_VEC tracker_info const& at(size_t i) const
+    [[nodiscard]] constexpr tracker_info const& at(size_t i) const
     {
         return trackers_.at(i);
     }
 
     [[nodiscard]] tr_tracker_tier_t nextTier() const;
 
-    [[nodiscard]] TR_CONSTEXPR_VEC bool operator==(tr_announce_list const& that) const
+    [[nodiscard]] constexpr bool operator==(tr_announce_list const& that) const
     {
         return trackers_ == that.trackers_;
     }
@@ -95,7 +94,7 @@ public:
     bool remove(tr_tracker_id_t id);
     bool replace(tr_tracker_id_t id, std::string_view announce_url_sv);
 
-    TR_CONSTEXPR_VEC void clear()
+    constexpr void clear()
     {
         trackers_.clear();
     }

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -168,9 +168,9 @@ public:
         TR_ASSERT(!is_shutting_down_);
 
         if (auto const scrape_sv = request.scrape_url.sv();
-            tr_strv_starts_with(scrape_sv, "http://"sv) || tr_strv_starts_with(scrape_sv, "https://"sv)) {
+            scrape_sv.starts_with("http://"sv) || scrape_sv.starts_with("https://"sv)) {
             tr_tracker_http_scrape(session, request, std::move(on_response));
-        } else if (tr_strv_starts_with(scrape_sv, "udp://"sv)) {
+        } else if (scrape_sv.starts_with("udp://"sv)) {
             announcer_udp_.scrape(request, std::move(on_response));
         } else {
             tr_logAddError(fmt::format(fmt::runtime(_("Unsupported URL: '{url}'")), fmt::arg("url", scrape_sv)));
@@ -182,9 +182,9 @@ public:
         TR_ASSERT(!is_shutting_down_ || request.event == TR_ANNOUNCE_EVENT_STOPPED);
 
         if (auto const announce_sv = request.announce_url.sv();
-            tr_strv_starts_with(announce_sv, "http://"sv) || tr_strv_starts_with(announce_sv, "https://"sv)) {
+            announce_sv.starts_with("http://"sv) || announce_sv.starts_with("https://"sv)) {
             tr_tracker_http_announce(session, request, std::move(on_response));
-        } else if (tr_strv_starts_with(announce_sv, "udp://"sv)) {
+        } else if (announce_sv.starts_with("udp://"sv)) {
             announcer_udp_.announce(request, std::move(on_response));
         } else {
             tr_logAddWarn(fmt::format(fmt::runtime(_("Unsupported URL: '{url}'")), fmt::arg("url", announce_sv)));

--- a/libtransmission/bitfield.h
+++ b/libtransmission/bitfield.h
@@ -131,7 +131,7 @@ public:
     tr_bitfield& operator|=(tr_bitfield const& that);
 
 private:
-    [[nodiscard]] TR_CONSTEXPR_VEC size_t count_flags() const noexcept
+    [[nodiscard]] constexpr size_t count_flags() const noexcept
     {
         auto ret = size_t{};
         for (auto const flag : flags_) {

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -493,7 +493,7 @@ std::vector<Blocklists::Blocklist> Blocklists::load_folder(std::string_view cons
 {
     // check for files that need to be updated
     for (auto const& src_file : getFilenamesInDir(folder)) {
-        if (tr_strv_ends_with(src_file, BinFileSuffix)) {
+        if (src_file.ends_with(BinFileSuffix)) {
             continue;
         }
 
@@ -511,7 +511,7 @@ std::vector<Blocklists::Blocklist> Blocklists::load_folder(std::string_view cons
 
     auto ret = std::vector<Blocklist>{};
     for (auto const& bin_file : getFilenamesInDir(folder)) {
-        if (tr_strv_ends_with(bin_file, BinFileSuffix)) {
+        if (bin_file.ends_with(BinFileSuffix)) {
             ret.emplace_back(bin_file, is_enabled);
         }
     }

--- a/libtransmission/blocklist.cc
+++ b/libtransmission/blocklist.cc
@@ -236,7 +236,7 @@ std::optional<std::vector<address_range_t>> parseFile(std::string_view filename)
         }
 
         // ignore comments
-        if (tr_strv_starts_with(line, "//"sv) || tr_strv_starts_with(line, "#"sv)) {
+        if (line.starts_with("//"sv) || line.starts_with("#"sv)) {
             continue;
         }
 

--- a/libtransmission/clients.cc
+++ b/libtransmission/clients.cc
@@ -627,7 +627,7 @@ void tr_clientForId(char* buf, size_t buflen, tr_peer_id_t peer_id)
     // both "-WT" and "-WT-" is formatted by the "-WT-" entry
     if (auto const it = std::ranges::find_if(
             Clients,
-            [key](Client const& client) { return tr_strv_starts_with(key, client.begins_with); });
+            [key](Client const& client) { return key.starts_with(client.begins_with); });
         it != Clients.end()) {
         it->formatter(buf, buflen, it->name, peer_id);
         return;

--- a/libtransmission/crypto-utils.cc
+++ b/libtransmission/crypto-utils.cc
@@ -69,7 +69,7 @@ bool tr_ssha1_test(std::string_view text)
 {
     using namespace ssha1_impl;
 
-    return tr_strv_starts_with(text, SaltedPrefix) && std::size(text) >= std::size(SaltedPrefix) + DigestStringSize;
+    return text.starts_with(SaltedPrefix) && std::size(text) >= std::size(SaltedPrefix) + DigestStringSize;
 }
 
 bool tr_ssha1_matches(std::string_view ssha1, std::string_view plaintext)

--- a/libtransmission/error.h
+++ b/libtransmission/error.h
@@ -9,14 +9,13 @@
 #include <string_view>
 
 #include "libtransmission/error-types.h"
-#include "libtransmission/macros.h"
 
 /** @brief Structure holding error information. */
 struct tr_error {
 public:
-    TR_CONSTEXPR_STR tr_error() = default;
+    constexpr tr_error() = default;
 
-    TR_CONSTEXPR_STR tr_error(tr_error_code_t code, std::string message)
+    constexpr tr_error(tr_error_code_t code, std::string message)
         : message_{ std::move(message) }
         , code_{ code }
     {
@@ -27,7 +26,7 @@ public:
         return code_;
     }
 
-    [[nodiscard]] TR_CONSTEXPR_STR auto message() const noexcept
+    [[nodiscard]] constexpr auto message() const noexcept
     {
         return std::string_view{ message_ };
     }
@@ -42,24 +41,24 @@ public:
         return has_value();
     }
 
-    TR_CONSTEXPR_STR void set(tr_error_code_t code, std::string&& message)
+    constexpr void set(tr_error_code_t code, std::string&& message)
     {
         code_ = code;
         message_ = std::move(message);
     }
 
-    TR_CONSTEXPR_STR void set(tr_error_code_t code, std::string_view message)
+    constexpr void set(tr_error_code_t code, std::string_view message)
     {
         code_ = code;
         message_.assign(message);
     }
 
-    TR_CONSTEXPR_STR void set(tr_error_code_t code, char const* const message)
+    constexpr void set(tr_error_code_t code, char const* const message)
     {
         set(code, std::string_view{ message != nullptr ? message : "" });
     }
 
-    TR_CONSTEXPR_STR void prefix_message(std::string_view prefix)
+    constexpr void prefix_message(std::string_view prefix)
     {
         message_.insert(std::begin(message_), std::begin(prefix), std::end(prefix));
     }

--- a/libtransmission/file-piece-map.h
+++ b/libtransmission/file-piece-map.h
@@ -16,7 +16,6 @@
 #include <vector>
 
 #include "libtransmission/bitfield.h"
-#include "libtransmission/macros.h" // TR_CONSTEXPR_VEC
 #include "libtransmission/types.h"
 
 struct tr_block_info;
@@ -43,7 +42,7 @@ public:
     explicit tr_file_piece_map(tr_torrent_metainfo const& tm);
     tr_file_piece_map(tr_block_info const& block_info, std::span<uint64_t const> file_sizes);
 
-    [[nodiscard]] TR_CONSTEXPR_VEC piece_span_t piece_span_for_file(tr_file_index_t const file) const noexcept
+    [[nodiscard]] constexpr piece_span_t piece_span_for_file(tr_file_index_t const file) const noexcept
     {
         return file_pieces_[file];
     }
@@ -57,7 +56,7 @@ public:
         return std::size(file_pieces_);
     }
 
-    [[nodiscard]] TR_CONSTEXPR_VEC auto byte_span_for_file(tr_file_index_t const file) const noexcept
+    [[nodiscard]] constexpr auto byte_span_for_file(tr_file_index_t const file) const noexcept
     {
         auto const& span = file_bytes_[file];
         return tr_byte_span_t{ .begin = span.begin, .end = span.end };
@@ -82,7 +81,7 @@ private:
 class tr_file_priorities
 {
 public:
-    TR_CONSTEXPR_VEC explicit tr_file_priorities(tr_file_piece_map const* fpm) noexcept
+    constexpr explicit tr_file_priorities(tr_file_piece_map const* fpm) noexcept
         : fpm_{ fpm }
     {
     }

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -41,6 +41,7 @@ namespace
 {
 inline constexpr auto MaxQueueLength = 10000U;
 
+// TODO(c++20): switch to std::chrono::zoned_time, GCC 13.1, clang 19 (or clang 21 with std::format), fmt 11.2
 template<typename T>
 inline constexpr bool HasTmGmtoffV = requires(T t) { t.tm_gmtoff; };
 

--- a/libtransmission/macros.h
+++ b/libtransmission/macros.h
@@ -5,12 +5,6 @@
 
 #pragma once
 
-#if __cpp_lib_constexpr_vector >= 201907L
-#define TR_CONSTEXPR_VEC constexpr
-#else
-#define TR_CONSTEXPR_VEC
-#endif
-
 #if __cpp_lib_constexpr_string >= 201907L
 #define TR_CONSTEXPR_STR constexpr
 #else

--- a/libtransmission/macros.h
+++ b/libtransmission/macros.h
@@ -5,12 +5,6 @@
 
 #pragma once
 
-#if __cpp_lib_constexpr_string >= 201907L
-#define TR_CONSTEXPR_STR constexpr
-#else
-#define TR_CONSTEXPR_STR
-#endif
-
 #if __cplusplus >= 202302L // _MSVC_LANG value for C++23 not available yet
 #define TR_CONSTEXPR23 constexpr
 #else

--- a/libtransmission/magnet-metainfo.cc
+++ b/libtransmission/magnet-metainfo.cc
@@ -211,7 +211,7 @@ bool tr_magnet_metainfo::parseMagnet(std::string_view magnet_link, tr_error* err
     for (auto const& [key, value] : parsed->query_entries()) {
         if (key == "dn"sv) {
             this->set_name(tr_urlPercentDecode(value));
-        } else if (key == "tr"sv || tr_strv_starts_with(key, "tr."sv)) {
+        } else if (key == "tr"sv || key.starts_with("tr."sv)) {
             // some magnet links have tracker notation like this:
             // tr.1=http://sometracker/announce&tr.2=http://someothertracker/announce
             // The dot-number notation differs from BEP 9, which specifies:
@@ -225,14 +225,13 @@ bool tr_magnet_metainfo::parseMagnet(std::string_view magnet_link, tr_error* err
             if (tr_urlIsValid(url_sv)) {
                 this->webseed_urls_.emplace_back(url_sv);
             }
-        } else if (static auto constexpr ValPrefix = "urn:btih:"sv; key == "xt"sv && tr_strv_starts_with(value, ValPrefix)) {
+        } else if (static auto constexpr ValPrefix = "urn:btih:"sv; key == "xt"sv && value.starts_with(ValPrefix)) {
             // v1 info-hash
             if (auto const hash = parseHash(value.substr(std::size(ValPrefix))); hash) {
                 this->info_hash_ = *hash;
                 got_hash = true;
             }
-        } else if (
-            static auto constexpr ValPrefix2 = "urn:btmh:1220"sv; key == "xt"sv && tr_strv_starts_with(value, ValPrefix2)) {
+        } else if (static auto constexpr ValPrefix2 = "urn:btmh:1220"sv; key == "xt"sv && value.starts_with(ValPrefix2)) {
             // v2 info-hash
             // The 1220 tag identifies the hash as sha256, removing tag before sending to parseHash2
             if (auto const hash = parseHash2(value.substr(std::size(ValPrefix2))); hash) {

--- a/libtransmission/magnet-metainfo.h
+++ b/libtransmission/magnet-metainfo.h
@@ -12,7 +12,6 @@
 
 #include "libtransmission/announce-list.h"
 #include "libtransmission/digest.h" // tr_sha1_digest_t, tr_sha1_string, ...
-#include "libtransmission/macros.h" // TR_CONSTEXPR_VEC
 
 struct tr_error;
 
@@ -40,7 +39,7 @@ public:
         return std::size(webseed_urls_);
     }
 
-    [[nodiscard]] TR_CONSTEXPR_VEC auto const& webseed(size_t i) const
+    [[nodiscard]] constexpr auto const& webseed(size_t i) const
     {
         return webseed_urls_.at(i);
     }

--- a/libtransmission/makemeta.h
+++ b/libtransmission/makemeta.h
@@ -20,7 +20,6 @@
 #include "libtransmission/error.h"
 #include "libtransmission/file.h"
 #include "libtransmission/torrent-files.h"
-#include "libtransmission/macros.h" // TR_CONSTEXPR_VEC
 #include "libtransmission/types.h"
 
 class tr_metainfo_builder
@@ -144,7 +143,7 @@ public:
         return files_.file_count();
     }
 
-    [[nodiscard]] TR_CONSTEXPR_VEC auto file_size(tr_file_index_t i) const noexcept
+    [[nodiscard]] constexpr auto file_size(tr_file_index_t i) const noexcept
     {
         return files_.file_size(i);
     }
@@ -159,7 +158,7 @@ public:
         return tr_sys_path_basename(top_);
     }
 
-    [[nodiscard]] TR_CONSTEXPR_VEC auto const& path(tr_file_index_t i) const noexcept
+    [[nodiscard]] constexpr auto const& path(tr_file_index_t i) const noexcept
     {
         return files_.path(i);
     }

--- a/libtransmission/peer-mgr-wishlist.cc
+++ b/libtransmission/peer-mgr-wishlist.cc
@@ -15,12 +15,11 @@
 #include "libtransmission/crypto-utils.h" // for tr_salt_shaker
 #include "libtransmission/peer-mgr-wishlist.h"
 #include "libtransmission/tr-assert.h"
-#include "libtransmission/macros.h" // TR_CONSTEXPR_VEC
 #include "libtransmission/types.h"
 
 namespace
 {
-[[nodiscard]] TR_CONSTEXPR_VEC std::vector<tr_block_span_t> make_spans(small::vector<tr_block_index_t> const& blocks)
+[[nodiscard]] constexpr std::vector<tr_block_span_t> make_spans(small::vector<tr_block_index_t> const& blocks)
 {
     if (std::empty(blocks)) {
         return {};

--- a/libtransmission/peer-mgr-wishlist.h
+++ b/libtransmission/peer-mgr-wishlist.h
@@ -135,7 +135,7 @@ public:
         }
     }
 
-    TR_CONSTEXPR_VEC void on_got_choke(tr_bitfield const& requests)
+    constexpr void on_got_choke(tr_bitfield const& requests)
     {
         reset_blocks_bitfield(requests);
     }
@@ -158,7 +158,7 @@ public:
         reset_block(block);
     }
 
-    TR_CONSTEXPR_VEC void on_peer_disconnect(tr_bitfield const& have, tr_bitfield const& requests)
+    constexpr void on_peer_disconnect(tr_bitfield const& have, tr_bitfield const& requests)
     {
         dec_replication_bitfield(have);
         reset_blocks_bitfield(requests);
@@ -282,7 +282,7 @@ private:
         }
     }
 
-    TR_CONSTEXPR_VEC void reset_blocks_bitfield(tr_bitfield const& requests)
+    constexpr void reset_blocks_bitfield(tr_bitfield const& requests)
     {
         for (auto& candidate : candidates_) {
             auto const [begin, end] = candidate.block_span;

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -210,7 +210,7 @@ void send_simple_response(struct evhttp_request* req, int code, char const* text
     });
 
     for (auto const& [suffix, mime_type] : Types) {
-        if (tr_strv_ends_with(path, suffix)) {
+        if (path.ends_with(suffix)) {
             return mime_type;
         }
     }
@@ -916,7 +916,7 @@ void tr_rpc_server::load(Settings&& settings)
 {
     settings_ = std::move(settings);
 
-    if (std::string& path = settings_.url; !tr_strv_ends_with(path, '/')) {
+    if (std::string& path = settings_.url; !path.ends_with('/')) {
         path = fmt::format("{:s}/", path);
     }
 

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -91,7 +91,7 @@ public:
 
     [[nodiscard]] bool from_string(std::string_view src)
     {
-        if (!tr_strv_starts_with(src, TrUnixSocketPrefix)) {
+        if (!src.starts_with(TrUnixSocketPrefix)) {
             return false;
         }
 
@@ -467,7 +467,7 @@ bool is_authorized(tr_rpc_server const* server, char const* auth_header)
 
     auto constexpr Prefix = "Basic "sv;
     auto auth = std::string_view{ auth_header != nullptr ? auth_header : "" };
-    if (!tr_strv_starts_with(auth, Prefix)) {
+    if (!auth.starts_with(Prefix)) {
         return false;
     }
 
@@ -553,10 +553,10 @@ void handle_request(struct evhttp_request* req, void* arg)
 
     auto const uri = std::string_view{ evhttp_request_get_uri(req) };
 
-    if (!tr_strv_starts_with(uri, base_path) || uri == deprecated_web_path) {
+    if (!uri.starts_with(base_path) || uri == deprecated_web_path) {
         evhttp_add_header(output_headers, "Location", web_base_path.c_str());
         send_simple_response(req, HTTP_MOVEPERM, nullptr);
-    } else if (tr_strv_starts_with(uri, web_base_path)) {
+    } else if (uri.starts_with(web_base_path)) {
         handle_web_client(req, server);
     } else if (!isHostnameAllowed(server, req)) {
         static auto constexpr Body =

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1389,7 +1389,7 @@ void onPortTested(tr_web::FetchResponse const& web_response)
         return;
     }
 
-    auto const port_is_open = tr_strv_starts_with(body, '1');
+    auto const port_is_open = body.starts_with('1');
     data->args_out.try_emplace(TR_KEY_port_is_open, port_is_open);
     tr_rpc_idle_done(data, Error::SUCCESS, {});
 }

--- a/libtransmission/session.cc
+++ b/libtransmission/session.cc
@@ -1393,7 +1393,7 @@ auto get_remaining_files(std::string_view folder, std::vector<std::string>& queu
 
     // Read .torrent first if somehow a .magnet of the same hash exists
     // Example of possible cause: https://github.com/transmission/transmission/issues/5007
-    std::ranges::stable_partition(ret, [](std::string_view name) { return tr_strv_ends_with(name, ".torrent"sv); });
+    std::ranges::stable_partition(ret, [](std::string_view name) { return name.ends_with(".torrent"sv); });
 
     return ret;
 }
@@ -1404,12 +1404,12 @@ void session_load_torrents(tr_session* session, tr_torrent_builder* builder, std
     auto const& folder = session->torrentDir();
 
     auto load_func = [&folder, &n_torrents, builder, buf = std::vector<char>{}](std::string_view name) mutable {
-        if (tr_strv_ends_with(name, ".torrent"sv)) {
+        if (name.ends_with(".torrent"sv)) {
             auto const path = tr_pathbuf{ folder, '/', name };
             if (builder->set_metainfo_from_file(path.sv()) && tr_torrentNew(builder, nullptr) != nullptr) {
                 ++n_torrents;
             }
-        } else if (tr_strv_ends_with(name, ".magnet"sv)) {
+        } else if (name.ends_with(".magnet"sv)) {
             auto const path = tr_pathbuf{ folder, '/', name };
             if (tr_file_read(path, buf) &&
                 builder->set_metainfo_from_magnet_link(std::string_view{ std::data(buf), std::size(buf) }, nullptr) &&

--- a/libtransmission/string-utils.h
+++ b/libtransmission/string-utils.h
@@ -49,26 +49,6 @@ template <typename T> [[nodiscard]] constexpr bool tr_strv_contains(std::string_
 }
 
 // c++20 (P0457R2), GCC 9.1, clang 6
-[[nodiscard]] constexpr bool tr_strv_starts_with(std::string_view sv, char key)
-{
-    return !std::empty(sv) && sv.front() == key;
-}
-
-// c++20 (P0457R2), GCC 9.1, clang 6
-[[nodiscard]] constexpr bool tr_strv_starts_with(std::string_view sv, std::string_view key)
-{
-    return std::size(key) <= std::size(sv) && sv.substr(0, std::size(key)) == key;
-}
-
-// c++20 (P0457R2), GCC 9.1, clang 6
-[[nodiscard]] constexpr bool tr_strv_starts_with(
-    std::wstring_view sv,
-    std::wstring_view key) // c++20 (P0457R2), GCC 9.1, clang 6
-{
-    return std::size(key) <= std::size(sv) && sv.substr(0, std::size(key)) == key;
-}
-
-// c++20 (P0457R2), GCC 9.1, clang 6
 [[nodiscard]] constexpr bool tr_strv_ends_with(std::string_view sv, std::string_view key)
 {
     return std::size(key) <= std::size(sv) && sv.substr(std::size(sv) - std::size(key)) == key;

--- a/libtransmission/string-utils.h
+++ b/libtransmission/string-utils.h
@@ -48,18 +48,6 @@ template <typename T> [[nodiscard]] constexpr bool tr_strv_contains(std::string_
     return sv.find(key) != std::string_view::npos;
 }
 
-// c++20 (P0457R2), GCC 9.1, clang 6
-[[nodiscard]] constexpr bool tr_strv_ends_with(std::string_view sv, std::string_view key)
-{
-    return std::size(key) <= std::size(sv) && sv.substr(std::size(sv) - std::size(key)) == key;
-}
-
-// c++20 (P0457R2), GCC 9.1, clang 6
-[[nodiscard]] constexpr bool tr_strv_ends_with(std::string_view sv, char key)
-{
-    return !std::empty(sv) && sv.back() == key;
-}
-
 template <typename... Args> constexpr std::string_view tr_strv_sep(std::string_view* sv, Args&&... args)
 {
     auto pos = sv->find_first_of(std::forward<Args>(args)...);

--- a/libtransmission/subprocess-win32.cc
+++ b/libtransmission/subprocess-win32.cc
@@ -197,7 +197,7 @@ auto get_app_type(char const* app)
 {
     auto const lower = tr_strlower(app);
 
-    if (tr_strv_ends_with(lower, ".cmd") || tr_strv_ends_with(lower, ".bat")) {
+    if (lower.ends_with(".cmd") || lower.ends_with(".bat")) {
         return tr_app_type::BATCH;
     }
 

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -417,7 +417,7 @@ void append_sanitized_component(std::string_view in, std::string& out, bool os_s
     in = tr_strv_strip(in);
 
     // remove trailing periods
-    while (tr_strv_ends_with(in, '.')) {
+    while (in.ends_with('.')) {
         in.remove_suffix(1);
     }
 #endif

--- a/libtransmission/torrent-files.cc
+++ b/libtransmission/torrent-files.cc
@@ -65,7 +65,7 @@ bool is_junk_file(std::string_view filename)
 
 #ifdef __APPLE__
     // check for resource forks. <http://web.archive.org/web/20101010051608/http://support.apple.com/kb/TA20578>
-    if (tr_strv_starts_with(base, "._"sv)) {
+    if (base.starts_with("._"sv)) {
         return true;
     }
 #endif
@@ -349,9 +349,7 @@ namespace
         "LPT1."sv, "LPT2."sv, "LPT3."sv, "LPT4."sv, "LPT5."sv, "LPT6."sv, "LPT7."sv, "LPT8."sv, "LPT9."sv,
         // clang-format on
     });
-    return std::ranges::any_of(ReservedPrefixes, [in_upper_sv](auto const& prefix) {
-        return tr_strv_starts_with(in_upper_sv, prefix);
-    });
+    return std::ranges::any_of(ReservedPrefixes, [in_upper_sv](auto const& prefix) { return in_upper_sv.starts_with(prefix); });
 }
 
 [[nodiscard]] bool is_reserved_file(std::string_view in, bool os_specific) noexcept

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include "libtransmission/file.h"
-#include "libtransmission/macros.h"
 #include "libtransmission/types.h"
 
 struct tr_error;
@@ -188,7 +187,7 @@ public:
 private:
     struct file_t {
     public:
-        TR_CONSTEXPR_STR void set_path(std::string_view subpath)
+        constexpr void set_path(std::string_view subpath)
         {
             if (path_ != subpath) {
                 path_ = subpath;
@@ -196,7 +195,7 @@ private:
             }
         }
 
-        TR_CONSTEXPR_STR file_t(std::string_view path, uint64_t size)
+        constexpr file_t(std::string_view path, uint64_t size)
             : path_{ path }
             , size_{ size }
         {

--- a/libtransmission/torrent-files.h
+++ b/libtransmission/torrent-files.h
@@ -38,7 +38,7 @@ public:
         return std::size(files_);
     }
 
-    [[nodiscard]] TR_CONSTEXPR_VEC uint64_t file_size(tr_file_index_t file_index) const
+    [[nodiscard]] constexpr uint64_t file_size(tr_file_index_t file_index) const
     {
         return files_.at(file_index).size_;
     }
@@ -48,7 +48,7 @@ public:
         return total_size_;
     }
 
-    [[nodiscard]] TR_CONSTEXPR_VEC std::string const& path(tr_file_index_t file_index) const
+    [[nodiscard]] constexpr std::string const& path(tr_file_index_t file_index) const
     {
         return files_.at(file_index).path_;
     }
@@ -69,17 +69,17 @@ public:
         }
     }
 
-    TR_CONSTEXPR_VEC void reserve(size_t n_files)
+    constexpr void reserve(size_t n_files)
     {
         files_.reserve(n_files);
     }
 
-    TR_CONSTEXPR_VEC void shrink_to_fit()
+    constexpr void shrink_to_fit()
     {
         files_.shrink_to_fit();
     }
 
-    TR_CONSTEXPR_VEC void clear() noexcept
+    constexpr void clear() noexcept
     {
         files_.clear();
         total_size_ = uint64_t{};
@@ -98,7 +98,7 @@ public:
         return ret;
     }
 
-    TR_CONSTEXPR_VEC tr_file_index_t add(std::string_view path, uint64_t file_size)
+    constexpr tr_file_index_t add(std::string_view path, uint64_t file_size)
     {
         auto const ret = static_cast<tr_file_index_t>(std::size(files_));
         files_.emplace_back(path, file_size);

--- a/libtransmission/torrent-magnet.h
+++ b/libtransmission/torrent-magnet.h
@@ -20,8 +20,6 @@
 
 #include <small/vector.hpp>
 
-#include "libtransmission/macros.h"
-
 // defined by BEP #9
 inline constexpr auto MetadataPieceSize = 1024 * 16;
 
@@ -48,7 +46,7 @@ public:
         return metadata_;
     }
 
-    [[nodiscard]] TR_CONSTEXPR_STR std::string_view log_name() const noexcept
+    [[nodiscard]] constexpr std::string_view log_name() const noexcept
     {
         return log_name_;
     }

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -44,11 +44,11 @@ public:
     {
         return files().file_count();
     }
-    [[nodiscard]] TR_CONSTEXPR_VEC auto file_size(tr_file_index_t i) const
+    [[nodiscard]] constexpr auto file_size(tr_file_index_t i) const
     {
         return files().file_size(i);
     }
-    [[nodiscard]] TR_CONSTEXPR_VEC auto const& file_subpath(tr_file_index_t i) const
+    [[nodiscard]] constexpr auto const& file_subpath(tr_file_index_t i) const
     {
         return files().path(i);
     }
@@ -130,7 +130,7 @@ public:
         return is_private_;
     }
 
-    [[nodiscard]] TR_CONSTEXPR_VEC tr_sha1_digest_t const& piece_hash(tr_piece_index_t piece) const noexcept
+    [[nodiscard]] constexpr tr_sha1_digest_t const& piece_hash(tr_piece_index_t piece) const noexcept
     {
         return pieces_[piece];
     }

--- a/libtransmission/torrent-queue.h
+++ b/libtransmission/torrent-queue.h
@@ -42,7 +42,7 @@ public:
     [[nodiscard]] size_t get_pos(tr_torrent_id_t id) const noexcept;
     [[nodiscard]] std::vector<tr_torrent_id_t> set_pos(tr_torrent_id_t id, size_t new_pos);
 
-    [[nodiscard]] TR_CONSTEXPR_VEC auto size() const noexcept
+    [[nodiscard]] constexpr auto size() const noexcept
     {
         return queue_.size();
     }

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2359,7 +2359,7 @@ auto renamePath(tr_torrent const* tor, std::string_view oldpath, std::string_vie
 
     if (tr_sys_path_exists(src)) {
         auto const parent = tr_sys_path_dirname(src);
-        auto const tgt = tr_strv_ends_with(src, tr_torrent_files::PartialFileSuffix) ?
+        auto const tgt = src.ends_with(tr_torrent_files::PartialFileSuffix) ?
             tr_pathbuf{ parent, '/', newname, tr_torrent_files::PartialFileSuffix } :
             tr_pathbuf{ parent, '/', newname };
 

--- a/libtransmission/torrent.cc
+++ b/libtransmission/torrent.cc
@@ -2320,7 +2320,7 @@ bool renameArgsAreValid(tr_torrent const* tor, std::string_view oldpath, std::st
 
     for (tr_file_index_t i = 0; i < n_files; ++i) {
         auto const& name = tor->file_subpath(i);
-        if (newpath == name || tr_strv_starts_with(name, newpath_as_dir)) {
+        if (newpath == name || name.starts_with(newpath_as_dir)) {
             return false;
         }
     }
@@ -2336,7 +2336,7 @@ auto renameFindAffectedFiles(tr_torrent const* tor, std::string_view oldpath)
 
     for (tr_file_index_t i = 0; i < n_files; ++i) {
         auto const& name = tor->file_subpath(i);
-        if (name == oldpath || tr_strv_starts_with(name, oldpath_as_dir)) {
+        if (name == oldpath || name.starts_with(oldpath_as_dir)) {
             indices.push_back(i);
         }
     }

--- a/libtransmission/torrent.h
+++ b/libtransmission/torrent.h
@@ -483,12 +483,12 @@ struct tr_torrent {
         subdirectory. */
     [[nodiscard]] bool is_folder() const;
 
-    [[nodiscard]] TR_CONSTEXPR_VEC auto const& file_subpath(tr_file_index_t i) const
+    [[nodiscard]] constexpr auto const& file_subpath(tr_file_index_t i) const
     {
         return metainfo_.file_subpath(i);
     }
 
-    [[nodiscard]] TR_CONSTEXPR_VEC auto file_size(tr_file_index_t i) const
+    [[nodiscard]] constexpr auto file_size(tr_file_index_t i) const
     {
         return metainfo_.file_size(i);
     }
@@ -520,7 +520,7 @@ struct tr_torrent {
         return metainfo_.webseed_count();
     }
 
-    [[nodiscard]] TR_CONSTEXPR_VEC auto const& webseed(size_t i) const
+    [[nodiscard]] constexpr auto const& webseed(size_t i) const
     {
         return metainfo_.webseed(i);
     }
@@ -1260,7 +1260,7 @@ private:
     // must be called after the torrent's announce list changes.
     void on_announce_list_changed();
 
-    [[nodiscard]] TR_CONSTEXPR_VEC tr_byte_span_t byte_span_for_file(tr_file_index_t file) const
+    [[nodiscard]] constexpr tr_byte_span_t byte_span_for_file(tr_file_index_t file) const
     {
         return fpm_.byte_span_for_file(file);
     }

--- a/libtransmission/tr-lpd.cc
+++ b/libtransmission/tr-lpd.cc
@@ -135,14 +135,14 @@ std::optional<ParsedAnnounce> parseAnnounceMsg(std::string_view announce)
     if (auto const pos = announce.find(key); pos != std::string_view::npos) {
         // parse `${major}.${minor}`
         auto walk = announce.substr(pos + std::size(key));
-        if (auto const major = tr_num_parse<int>(walk, &walk); major && tr_strv_starts_with(walk, '.')) {
+        if (auto const major = tr_num_parse<int>(walk, &walk); major && walk.starts_with('.')) {
             ret.major = *major;
         } else {
             return {};
         }
 
         walk.remove_prefix(1); // the '.' between major and minor
-        if (auto const minor = tr_num_parse<int>(walk, &walk); minor && tr_strv_starts_with(walk, CrLf)) {
+        if (auto const minor = tr_num_parse<int>(walk, &walk); minor && walk.starts_with(CrLf)) {
             ret.minor = *minor;
         } else {
             return {};
@@ -152,7 +152,7 @@ std::optional<ParsedAnnounce> parseAnnounceMsg(std::string_view announce)
     key = "Port: "sv;
     if (auto const pos = announce.find(key); pos != std::string_view::npos) {
         auto walk = announce.substr(pos + std::size(key));
-        if (auto const port = tr_num_parse<uint16_t>(walk, &walk); port && tr_strv_starts_with(walk, CrLf)) {
+        if (auto const port = tr_num_parse<uint16_t>(walk, &walk); port && walk.starts_with(CrLf)) {
             ret.port = tr_port::from_host(*port);
         } else {
             return {};

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -38,8 +38,6 @@
 
 #include <fmt/format.h>
 
-#include <fast_float/fast_float.h>
-
 #include "libtransmission/mime-types.h"
 #include "libtransmission/string-utils.h"
 #include "libtransmission/types.h"
@@ -376,7 +374,7 @@ template<std::floating_point T>
     auto const* const begin_ch = std::data(str);
     auto const* const end_ch = begin_ch + std::size(str);
     auto val = T{};
-    auto const result = fast_float::from_chars(begin_ch, end_ch, val);
+    auto const result = std::from_chars(begin_ch, end_ch, val);
     if (result.ec != std::errc{}) {
         return std::nullopt;
     }

--- a/libtransmission/utils.cc
+++ b/libtransmission/utils.cc
@@ -38,6 +38,8 @@
 
 #include <fmt/format.h>
 
+#include <fast_float/fast_float.h>
+
 #include "libtransmission/mime-types.h"
 #include "libtransmission/string-utils.h"
 #include "libtransmission/types.h"
@@ -374,7 +376,8 @@ template<std::floating_point T>
     auto const* const begin_ch = std::data(str);
     auto const* const end_ch = begin_ch + std::size(str);
     auto val = T{};
-    auto const result = std::from_chars(begin_ch, end_ch, val);
+    // TODO(c++17): switch to std::from_chars, GCC 11, clang 20, macOS 26
+    auto const result = fast_float::from_chars(begin_ch, end_ch, val);
     if (result.ec != std::errc{}) {
         return std::nullopt;
     }

--- a/libtransmission/variant-benc.cc
+++ b/libtransmission/variant-benc.cc
@@ -53,7 +53,7 @@ std::optional<int64_t> ParseInt(std::string_view* benc)
 
     // find the beginning delimiter
     auto walk = *benc;
-    if (std::size(walk) < 3 || !tr_strv_starts_with(walk, Prefix)) {
+    if (std::size(walk) < 3 || !walk.starts_with(Prefix)) {
         return {};
     }
 
@@ -71,7 +71,7 @@ std::optional<int64_t> ParseInt(std::string_view* benc)
 
     // parse the string and make sure the next char is `Suffix`
     auto value = tr_num_parse<int64_t>(walk, &walk);
-    if (!value || !tr_strv_starts_with(walk, Suffix)) {
+    if (!value || !walk.starts_with(Suffix)) {
         return {};
     }
 

--- a/libtransmission/web-utils.cc
+++ b/libtransmission/web-utils.cc
@@ -274,7 +274,7 @@ std::string_view getSiteName(std::string_view host)
 // strings that are wrapped in square brackets (e.g. inet_pton())
 std::string_view getHostWoBrackets(std::string_view host)
 {
-    if (tr_strv_starts_with(host, '[')) {
+    if (host.starts_with('[')) {
         host.remove_prefix(1);
         host.remove_suffix(1);
     }
@@ -292,7 +292,7 @@ std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url)
     // So many magnet links are malformed, e.g. not escaping text
     // in the display name, that we're better off handling magnets
     // as a special case before even scanning for invalid chars.
-    if (auto constexpr MagnetStart = "magnet:?"sv; tr_strv_starts_with(url, MagnetStart)) {
+    if (auto constexpr MagnetStart = "magnet:?"sv; url.starts_with(MagnetStart)) {
         parsed.scheme = "magnet"sv;
         parsed.query = url.substr(std::size(MagnetStart));
         return parsed;
@@ -312,7 +312,7 @@ std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url)
     // The authority component is preceded by a double slash ("//") and is
     // terminated by the next slash ("/"), question mark ("?"), or number
     // sign ("#") character, or by the end of the URI.
-    if (auto key = "//"sv; tr_strv_starts_with(url, key)) {
+    if (auto key = "//"sv; url.starts_with(key)) {
         url.remove_prefix(std::size(key));
         auto pos = url.find_first_of("/?#");
         parsed.authority = url.substr(0, pos);
@@ -323,7 +323,7 @@ std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url)
         // within square brackets ("[" and "]").  This is the only place where
         // square bracket characters are allowed in the URI syntax.
         auto remain = parsed.authority;
-        if (tr_strv_starts_with(remain, '[')) {
+        if (remain.starts_with('[')) {
             pos = remain.find(']');
             if (pos == std::string_view::npos) {
                 return std::nullopt;
@@ -348,7 +348,7 @@ std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url)
                 return std::nullopt;
             }
             parsed.port = *port;
-        } else if (tr_strv_starts_with(remain, ':')) {
+        } else if (remain.starts_with(':')) {
             remain.remove_prefix(1);
             auto const port = tr_num_parse<uint16_t>(remain);
             if (!port || *port == 0U) {
@@ -375,7 +375,7 @@ std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url)
     url = pos == std::string_view::npos ? ""sv : url.substr(pos);
 
     // query
-    if (tr_strv_starts_with(url, '?')) {
+    if (url.starts_with('?')) {
         url.remove_prefix(1);
         pos = url.find('#');
         parsed.query = url.substr(0, pos);
@@ -383,7 +383,7 @@ std::optional<tr_url_parsed_t> tr_urlParse(std::string_view url)
     }
 
     // fragment
-    if (tr_strv_starts_with(url, '#')) {
+    if (url.starts_with('#')) {
         parsed.fragment = url.substr(1);
     }
 

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -124,7 +124,7 @@ CURLcode ssl_context_func(CURL* /*curl*/, void* ssl_ctx, void* /*user_data*/)
     }
 
     curl_version_info_data const* const curl_ver = curl_version_info(CURLVERSION_NOW);
-    if (curl_ver->age >= 0 && tr_strv_starts_with(curl_ver->ssl_version, "Schannel"sv)) {
+    if (curl_ver->age >= 0 && std::string_view{ curl_ver->ssl_version }.starts_with("Schannel"sv)) {
         return CURLE_OK;
     }
 

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -452,7 +452,7 @@ void tr_webseed_task::on_partial_data_fetched(tr_web::FetchResponse const& web_r
     ret.reserve(std::size(url) + std::size(name) + Slack);
     ret += url;
 
-    if (tr_strv_ends_with(url, "/"sv) && !std::empty(name)) {
+    if (url.ends_with("/"sv) && !std::empty(name)) {
         tr_urlPercentEncode(ret, name, false);
     }
 

--- a/qt/DetailsDialog.cc
+++ b/qt/DetailsDialog.cc
@@ -6,6 +6,7 @@
 #include "DetailsDialog.h"
 
 #include <algorithm>
+#include <bit>
 #include <cassert>
 #include <ctime>
 #include <map>
@@ -228,8 +229,7 @@ private:
                 QByteArray tmp(16, '\0');
 
                 for (int i = 0; i < 16; ++i) {
-                    // NOLINTNEXTLINE(bugprone-narrowing-conversions): TODO(c++20): use std::bit_cast after gcc 11.1
-                    tmp[i] = ipv6_address[i];
+                    tmp[i] = std::bit_cast<char>(ipv6_address[i]);
                 }
 
                 collated = QStringLiteral("2-") + QString::fromUtf8(tmp.toHex());

--- a/tests/libtransmission-app/converter-tests.cc
+++ b/tests/libtransmission-app/converter-tests.cc
@@ -26,20 +26,12 @@ using tr::serializer::to_variant;
 
 namespace
 {
-constexpr int64_t days_from_civil(int year, unsigned month, unsigned day)
+constexpr std::chrono::sys_seconds make_sys_seconds(int year, unsigned month, unsigned day, int hour, int minute, int second)
 {
-    year -= month <= 2;
-    auto const era = (year >= 0 ? year : year - 399) / 400;
-    auto const yoe = static_cast<unsigned>(year - era * 400);
-    auto const doy = (153 * (month + (month > 2 ? -3 : 9)) + 2) / 5 + day - 1;
-    auto const doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
-    return static_cast<int64_t>(era) * 146097 + static_cast<int64_t>(doe) - 719468;
-}
-
-constexpr std::chrono::sys_seconds make_sys_seconds(int year, int month, int day, int hour, int minute, int second)
-{
-    return std::chrono::sys_seconds{ std::chrono::seconds{ days_from_civil(year, month, day) * 86400 } } +
-        std::chrono::hours{ hour } + std::chrono::minutes{ minute } + std::chrono::seconds{ second };
+    return std::chrono::sys_days{
+        std::chrono::year_month_day{ std::chrono::year{ year }, std::chrono::month{ month }, std::chrono::day{ day } }
+    } + std::chrono::hours{ hour } +
+        std::chrono::minutes{ minute } + std::chrono::seconds{ second };
 }
 
 void expect_sys_seconds_eq(std::optional<std::chrono::sys_seconds> const& actual, std::chrono::sys_seconds expected)

--- a/tests/libtransmission/string-utils-test.cc
+++ b/tests/libtransmission/string-utils-test.cc
@@ -34,22 +34,6 @@ TEST_F(UtilsTest, trStrvContains)
     EXPECT_TRUE(tr_strv_contains(""sv, ""sv));
 }
 
-TEST_F(UtilsTest, trStrvEndsWith)
-{
-    EXPECT_FALSE(tr_strv_ends_with(""sv, "string"sv));
-    EXPECT_FALSE(tr_strv_ends_with("this is a string"sv, "alphabet"sv));
-    EXPECT_FALSE(tr_strv_ends_with("this is a string"sv, "strin"sv));
-    EXPECT_FALSE(tr_strv_ends_with("this is a string"sv, "this is"sv));
-    EXPECT_FALSE(tr_strv_ends_with("this is a string"sv, "this"sv));
-    EXPECT_FALSE(tr_strv_ends_with("tring"sv, "string"sv));
-    EXPECT_TRUE(tr_strv_ends_with(""sv, ""sv));
-    EXPECT_TRUE(tr_strv_ends_with("this is a string"sv, " string"sv));
-    EXPECT_TRUE(tr_strv_ends_with("this is a string"sv, ""sv));
-    EXPECT_TRUE(tr_strv_ends_with("this is a string"sv, "a string"sv));
-    EXPECT_TRUE(tr_strv_ends_with("this is a string"sv, "g"sv));
-    EXPECT_TRUE(tr_strv_ends_with("this is a string"sv, "string"sv));
-}
-
 TEST_F(UtilsTest, trStrvSep)
 {
     static auto constexpr CommaCh = ',';

--- a/tests/libtransmission/string-utils-test.cc
+++ b/tests/libtransmission/string-utils-test.cc
@@ -34,21 +34,6 @@ TEST_F(UtilsTest, trStrvContains)
     EXPECT_TRUE(tr_strv_contains(""sv, ""sv));
 }
 
-TEST_F(UtilsTest, trStrvStartsWith)
-{
-    EXPECT_FALSE(tr_strv_starts_with(""sv, "this is a string"sv));
-    EXPECT_FALSE(tr_strv_starts_with("this is a strin"sv, "this is a string"sv));
-    EXPECT_FALSE(tr_strv_starts_with("this is a strin"sv, "this is a string"sv));
-    EXPECT_FALSE(tr_strv_starts_with("this is a string"sv, " his is a string"sv));
-    EXPECT_FALSE(tr_strv_starts_with("this is a string"sv, "his is a string"sv));
-    EXPECT_FALSE(tr_strv_starts_with("this is a string"sv, "string"sv));
-    EXPECT_TRUE(tr_strv_starts_with(""sv, ""sv));
-    EXPECT_TRUE(tr_strv_starts_with("this is a string"sv, ""sv));
-    EXPECT_TRUE(tr_strv_starts_with("this is a string"sv, "this "sv));
-    EXPECT_TRUE(tr_strv_starts_with("this is a string"sv, "this is"sv));
-    EXPECT_TRUE(tr_strv_starts_with("this is a string"sv, "this"sv));
-}
-
 TEST_F(UtilsTest, trStrvEndsWith)
 {
     EXPECT_FALSE(tr_strv_ends_with(""sv, "string"sv));

--- a/tests/libtransmission/subprocess-test.cc
+++ b/tests/libtransmission/subprocess-test.cc
@@ -98,7 +98,7 @@ TEST_P(SubprocessTest, SpawnAsyncMissingExec)
 TEST_P(SubprocessTest, SpawnAsyncArgs)
 {
     auto const result_path = buildSandboxPath("result.txt");
-    bool const allow_batch_metachars = TR_IF_WIN32(false, true) || !tr_strv_ends_with(tr_strlower(self_path_), ".cmd"sv);
+    bool const allow_batch_metachars = TR_IF_WIN32(!tr_strlower(self_path_).ends_with(".cmd"sv), true);
 
     auto const test_arg1 = std::string{ "arg1 " };
     auto const test_arg2 = std::string{ " arg2" };

--- a/utils/remote.cc
+++ b/utils/remote.cc
@@ -423,7 +423,7 @@ bool parseNumberSection(std::string_view str, number_range& range)
         return true;
     }
 
-    if (!tr_strv_starts_with(str, Delimiter)) {
+    if (!str.starts_with(Delimiter)) {
         return false;
     }
 
@@ -3213,10 +3213,10 @@ void get_host_and_port_and_rpc_url(
     }
 
     auto const sv = std::string_view{ argv[1] };
-    if (tr_strv_starts_with(sv, "http://")) /* user passed in http rpc url */
+    if (sv.starts_with("http://")) /* user passed in http rpc url */
     {
         rpcurl = fmt::format("{:s}/{:s}", sv.substr(7), TrHttpServerRpcRelativePath);
-    } else if (tr_strv_starts_with(sv, "https://")) /* user passed in https rpc url */
+    } else if (sv.starts_with("https://")) /* user passed in https rpc url */
     {
         config.use_ssl = true;
         rpcurl = fmt::format("{:s}/{:s}", sv.substr(8), TrHttpServerRpcRelativePath);
@@ -3231,7 +3231,7 @@ void get_host_and_port_and_rpc_url(
             host = sv.substr(0, last_colon);
         }
     } else {
-        auto const is_unbracketed_ipv6 = !tr_strv_starts_with(sv, '[') && last_colon != std::string_view::npos;
+        auto const is_unbracketed_ipv6 = !sv.starts_with('[') && last_colon != std::string_view::npos;
         host = is_unbracketed_ipv6 ? fmt::format("[{:s}]", sv) : sv;
     }
 


### PR DESCRIPTION
## Description

As Debian 11 goes EOL, the oldest GCC our CI covers is 12, so drop all the compatibility code for GCC 11 and below.
~Most notably, we don't need the fast_float library anymore!~

Notes: Require GCC 12 or above.

P.S. Jumping the gun here because I can't wait to drop some baggage.
~P.P.S. We're still alive! https://github.com/transmission/transmission/issues/6742#issuecomment-2020156031~

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
