### PR TITLE
fix: multiple threads using same memory unguarded in `tr_metainfo_builder`

### DIFF
--- a/gtk/MakeDialog.cc
+++ b/gtk/MakeDialog.cc
@@ -71,7 +71,7 @@ public:
         BaseObjectType* cast_item,
         Glib::RefPtr<Gtk::Builder> const& builder,
         tr_metainfo_builder& metainfo_builder,
-        std::future<tr_error> future,
+        std::future<tr_metainfo_builder::Checksums> future,
         std::string_view target,
         Glib::RefPtr<Session> const& core);
     MakeProgressDialog(MakeProgressDialog&&) = delete;
@@ -83,7 +83,7 @@ public:
     static std::unique_ptr<MakeProgressDialog> create(
         std::string_view target,
         tr_metainfo_builder& metainfo_builder,
-        std::future<tr_error> future,
+        std::future<tr_metainfo_builder::Checksums> future,
         Glib::RefPtr<Session> const& core);
 
     [[nodiscard]] bool success() const
@@ -99,7 +99,7 @@ private:
 
 private:
     tr_metainfo_builder& builder_;
-    std::future<tr_error> future_;
+    std::future<tr_metainfo_builder::Checksums> future_;
     std::string const target_;
     Glib::RefPtr<Session> const core_;
     bool success_ = false;
@@ -193,9 +193,11 @@ bool MakeProgressDialog::onProgressDialogRefresh()
     if (!is_done) {
         str = fmt::format(fmt::runtime(_("Creating '{path}'")), fmt::arg("path", base));
     } else {
-        auto error = future_.get();
+        auto checksums = future_.get();
+        auto error = std::move(checksums.error);
 
         if (!error) {
+            builder_.set_piece_hashes(std::move(checksums.piece_hashes));
             builder_.save(target_, &error);
         }
 
@@ -274,7 +276,7 @@ MakeProgressDialog::MakeProgressDialog(
     BaseObjectType* cast_item,
     Glib::RefPtr<Gtk::Builder> const& builder,
     tr_metainfo_builder& metainfo_builder,
-    std::future<tr_error> future,
+    std::future<tr_metainfo_builder::Checksums> future,
     std::string_view target,
     Glib::RefPtr<Session> const& core)
     : Gtk::Dialog(cast_item)
@@ -296,7 +298,7 @@ MakeProgressDialog::MakeProgressDialog(
 std::unique_ptr<MakeProgressDialog> MakeProgressDialog::create(
     std::string_view target,
     tr_metainfo_builder& metainfo_builder,
-    std::future<tr_error> future,
+    std::future<tr_metainfo_builder::Checksums> future,
     Glib::RefPtr<Session> const& core)
 {
     auto const builder = Gtk::Builder::create_from_resource(gtr_get_full_resource_path("MakeProgressDialog.ui"));

--- a/libtransmission/makemeta.cc
+++ b/libtransmission/makemeta.cc
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <ctime> // time()
 #include <iterator>
+#include <memory> // std::shared_ptr
 #include <set>
 #include <string>
 #include <string_view>
@@ -139,72 +140,75 @@ bool tr_metainfo_builder::set_piece_size(uint32_t piece_size) noexcept
     return true;
 }
 
-bool tr_metainfo_builder::blocking_make_checksums(tr_error* error)
+// Args are taken by value so the worker owns them:
+// it can keep running after the builder that launched it is gone.
+// NOLINTBEGIN(performance-unnecessary-value-param)
+tr_metainfo_builder::Checksums tr_metainfo_builder::blocking_make_checksums(
+    std::string const parent_dir,
+    tr_torrent_files const files,
+    tr_block_info const block_info,
+    std::shared_ptr<ChecksumsState> const state)
+// NOLINTEND(performance-unnecessary-value-param)
 {
-    checksum_piece_ = 0;
-    cancel_ = false;
+    auto result = Checksums{};
 
-    if (total_size() == 0U) {
-        if (error != nullptr) {
-            error->set(ENOENT, "zero-length torrents are not allowed"sv);
-        }
-
-        return false;
+    if (files.total_size() == 0U) {
+        result.error.set(ENOENT, "zero-length torrents are not allowed"sv);
+        return result;
     }
 
-    auto hashes = std::vector<std::byte>(std::size(tr_sha1_digest_t{}) * piece_count());
+    auto hashes = std::vector<std::byte>(std::size(tr_sha1_digest_t{}) * block_info.piece_count());
     auto* walk = std::data(hashes);
     auto sha = tr_sha1{};
 
     auto file_index = tr_file_index_t{ 0U };
     auto piece_index = tr_piece_index_t{ 0U };
-    auto total_remain = total_size();
+    auto total_remain = files.total_size();
     auto off = uint64_t{ 0U };
 
-    auto buf = std::vector<char>(piece_size());
+    auto buf = std::vector<char>(block_info.piece_size());
 
-    auto const parent = tr_sys_path_dirname(top_);
     auto fd = tr_sys_file_open(
-        tr_pathbuf{ parent, '/', path(file_index) },
+        tr_pathbuf{ parent_dir, '/', files.path(file_index) },
         TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL,
         0,
-        error);
+        &result.error);
     if (fd == TR_BAD_SYS_FILE) {
-        return false;
+        return result;
     }
 
-    while (!cancel_ && (total_remain > 0U)) {
-        checksum_piece_ = piece_index;
+    while (!state->cancel && (total_remain > 0U)) {
+        state->current_piece = piece_index;
 
-        TR_ASSERT(piece_index < piece_count());
+        TR_ASSERT(piece_index < block_info.piece_count());
 
-        auto const piece_size = block_info_.piece_size(piece_index);
+        auto const piece_size = block_info.piece_size(piece_index);
         buf.resize(piece_size);
         auto* bufptr = std::data(buf);
 
         auto left_in_piece = piece_size;
         while (left_in_piece > 0U) {
-            auto const n_this_pass = std::min(file_size(file_index) - off, uint64_t{ left_in_piece });
+            auto const n_this_pass = std::min(files.file_size(file_index) - off, uint64_t{ left_in_piece });
             auto n_read = uint64_t{};
 
-            (void)tr_sys_file_read(fd, bufptr, n_this_pass, &n_read, error);
+            (void)tr_sys_file_read(fd, bufptr, n_this_pass, &n_read, &result.error);
             bufptr += n_read;
             off += n_read;
             left_in_piece -= n_read;
 
-            if (off == file_size(file_index)) {
+            if (off == files.file_size(file_index)) {
                 off = 0;
                 tr_sys_file_close(fd);
                 fd = TR_BAD_SYS_FILE;
 
-                if (++file_index < file_count()) {
+                if (++file_index < files.file_count()) {
                     fd = tr_sys_file_open(
-                        tr_pathbuf{ parent, '/', path(file_index) },
+                        tr_pathbuf{ parent_dir, '/', files.path(file_index) },
                         TR_SYS_FILE_READ | TR_SYS_FILE_SEQUENTIAL,
                         0,
-                        error);
+                        &result.error);
                     if (fd == TR_BAD_SYS_FILE) {
-                        return false;
+                        return result;
                     }
                 }
             }
@@ -221,28 +225,25 @@ bool tr_metainfo_builder::blocking_make_checksums(tr_error* error)
         ++piece_index;
     }
 
-    TR_ASSERT(cancel_ || size_t(walk - std::data(hashes)) == std::size(hashes));
-    TR_ASSERT(cancel_ || total_remain == 0U);
+    TR_ASSERT(state->cancel || size_t(walk - std::data(hashes)) == std::size(hashes));
+    TR_ASSERT(state->cancel || total_remain == 0U);
 
     if (fd != TR_BAD_SYS_FILE) {
         tr_sys_file_close(fd);
     }
 
-    if (cancel_) {
-        if (error != nullptr) {
-            error->set_from_errno(ECANCELED);
-        }
-
-        return false;
+    if (state->cancel) {
+        result.error.set_from_errno(ECANCELED);
+        return result;
     }
 
-    piece_hashes_ = std::move(hashes);
-    return true;
+    result.piece_hashes = std::move(hashes);
+    return result;
 }
 
 std::string tr_metainfo_builder::benc(tr_error* error) const
 {
-    TR_ASSERT_MSG(!std::empty(piece_hashes_), "did you forget to call makeChecksums() first?");
+    TR_ASSERT_MSG(!std::empty(piece_hashes_), "did you forget to call make_checksums() and set_piece_hashes() first?");
 
     auto const anonymize = this->anonymize();
     auto const& comment = this->comment();

--- a/libtransmission/makemeta.h
+++ b/libtransmission/makemeta.h
@@ -5,9 +5,11 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstddef> // std::byte
 #include <cstdint>
 #include <future>
+#include <memory> // std::shared_ptr
 #include <string>
 #include <string_view>
 #include <utility> // std::pair
@@ -33,31 +35,43 @@ public:
     tr_metainfo_builder& operator=(tr_metainfo_builder&&) = delete;
     tr_metainfo_builder& operator=(tr_metainfo_builder const&) = delete;
 
+    // The result of a `make_checksums()` run:
+    // on failure, `error` is set.
+    // on success, `error` is empty and `piece_hashes` has the piece checksums.
+    struct Checksums {
+        tr_error error;
+        std::vector<std::byte> piece_hashes;
+    };
+
     // Generate piece checksums asynchronously.
-    // - This must be done before calling `benc()` or `save()`.
     // - Runs in a worker thread because it can be time-consuming.
-    // - Can be cancelled with `cancelChecksums()` and polled with `checksumStatus()`
-    // - Resolves with a `tr_error` which is set on failure or empty on success.
-    [[nodiscard]] std::future<tr_error> make_checksums()
+    // - The worker owns copies of the builder's state, so the builder
+    //   may safely be destroyed while the worker is still running.
+    // - Can be cancelled with `cancel_checksums()` and polled with `checksum_status()`.
+    // - On success, pass the result to `set_piece_hashes()` before calling `benc()` or `save()`.
+    [[nodiscard]] std::future<Checksums> make_checksums()
     {
-        return std::async(std::launch::async, [this]() {
-            auto error = tr_error{};
-            blocking_make_checksums(&error);
-            return error;
-        });
+        checksums_state_ = std::make_shared<ChecksumsState>();
+        return std::async(
+            std::launch::async,
+            blocking_make_checksums,
+            std::string{ tr_sys_path_dirname(top_) },
+            files_,
+            block_info_,
+            checksums_state_);
     }
 
-    // Returns the status of a `makeChecksums()` call:
+    // Returns the status of a `make_checksums()` run:
     // The current piece being tested and the total number of pieces in the torrent.
-    [[nodiscard]] constexpr std::pair<tr_piece_index_t, tr_piece_index_t> checksum_status() const noexcept
+    [[nodiscard]] std::pair<tr_piece_index_t, tr_piece_index_t> checksum_status() const noexcept
     {
-        return std::make_pair(checksum_piece_, block_info_.piece_count());
+        return std::make_pair(checksums_state_->current_piece.load(), block_info_.piece_count());
     }
 
-    // Tell the `makeChecksums()` worker thread to cleanly exit ASAP.
-    constexpr void cancel_checksums() noexcept
+    // Tell the `make_checksums()` worker thread to cleanly exit ASAP.
+    void cancel_checksums() noexcept
     {
-        cancel_ = true;
+        checksums_state_->cancel = true;
     }
 
     // generate the metainfo
@@ -82,6 +96,13 @@ public:
     void set_comment(std::string_view comment)
     {
         comment_ = comment;
+    }
+
+    // Store the piece checksums from a successful `make_checksums()` run
+    // for `benc()` and `save()` to use.
+    void set_piece_hashes(std::vector<std::byte> piece_hashes)
+    {
+        piece_hashes_ = std::move(piece_hashes);
     }
 
     bool set_piece_size(uint32_t piece_size) noexcept;
@@ -186,7 +207,20 @@ public:
     }
 
 private:
-    bool blocking_make_checksums(tr_error* error = nullptr);
+    // Cancellation flag and progress shared between a `make_checksums()`
+    // worker and the builder that launched it. Shared ownership is what
+    // lets the worker outlive the builder: the worker holds the block and
+    // copies of everything else it reads.
+    struct ChecksumsState {
+        std::atomic<tr_piece_index_t> current_piece = 0;
+        std::atomic<bool> cancel = false;
+    };
+
+    [[nodiscard]] static Checksums blocking_make_checksums(
+        std::string parent_dir,
+        tr_torrent_files files,
+        tr_block_info block_info,
+        std::shared_ptr<ChecksumsState> state);
 
     std::string top_;
     tr_torrent_files files_;
@@ -198,9 +232,8 @@ private:
     std::string comment_;
     std::string source_;
 
-    tr_piece_index_t checksum_piece_ = 0;
+    std::shared_ptr<ChecksumsState> checksums_state_ = std::make_shared<ChecksumsState>();
 
     bool is_private_ = false;
     bool anonymize_ = false;
-    bool cancel_ = false;
 };

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -44,7 +44,7 @@ typedef NS_ENUM(NSUInteger, TrackerSegmentTag) {
 
 @property(nonatomic, readonly) std::shared_ptr<tr_metainfo_builder> fBuilder;
 @property(nonatomic, readonly) NSURL* fPath;
-@property(nonatomic) std::shared_future<tr_error> fFuture;
+@property(nonatomic) std::shared_future<tr_metainfo_builder::Checksums> fFuture;
 @property(nonatomic) NSURL* fLocation; // path to new torrent file
 @property(nonatomic) NSMutableArray<NSString*>* fTrackers;
 
@@ -624,8 +624,10 @@ static NSMutableSet* creatorWindowControllerSet;
     [self.fTimer invalidate];
     self.fTimer = nil;
 
-    auto error = self.fFuture.get();
+    auto checksums = self.fFuture.get();
+    auto error = std::move(checksums.error);
     if (!error) {
+        self.fBuilder->set_piece_hashes(std::move(checksums.piece_hashes));
         self.fBuilder->save(self.fLocation.path.UTF8String, &error);
     }
 

--- a/qt/MakeDialog.cc
+++ b/qt/MakeDialog.cc
@@ -41,7 +41,7 @@ public:
     MakeProgressDialog(
         Session& session,
         tr_metainfo_builder& builder,
-        std::future<tr_error> future,
+        std::future<tr_metainfo_builder::Checksums> future,
         QString outfile,
         QWidget* parent = nullptr);
 
@@ -52,7 +52,7 @@ private slots:
 private:
     Session& session_;
     tr_metainfo_builder& builder_;
-    std::future<tr_error> future_;
+    std::future<tr_metainfo_builder::Checksums> future_;
     QString const outfile_;
     Ui::MakeProgressDialog ui_ = {};
     QTimer timer_;
@@ -63,7 +63,7 @@ private:
 MakeProgressDialog::MakeProgressDialog(
     Session& session,
     tr_metainfo_builder& builder,
-    std::future<tr_error> future,
+    std::future<tr_metainfo_builder::Checksums> future,
     QString outfile,
     QWidget* parent)
     : BaseDialog{ parent }
@@ -125,9 +125,11 @@ void MakeProgressDialog::onProgress()
     if (!is_done) {
         str = tr("Creating \"%1\"").arg(base);
     } else {
-        auto error = future_.get();
+        auto checksums = future_.get();
+        auto error = std::move(checksums.error);
 
         if (!error) {
+            builder_.set_piece_hashes(std::move(checksums.piece_hashes));
             builder_.save(outfile_.toStdString(), &error);
         }
 

--- a/tests/libtransmission/makemeta-test.cc
+++ b/tests/libtransmission/makemeta-test.cc
@@ -63,8 +63,9 @@ protected:
 
     static auto testBuilder(tr_metainfo_builder& builder)
     {
-        auto error = builder.make_checksums().get();
-        EXPECT_FALSE(error) << error;
+        auto checksums = builder.make_checksums().get();
+        EXPECT_FALSE(checksums.error) << checksums.error;
+        builder.set_piece_hashes(std::move(checksums.piece_hashes));
 
         auto metainfo = tr_torrent_metainfo{};
         EXPECT_TRUE(metainfo.parse_benc(builder.benc()));
@@ -225,7 +226,9 @@ TEST_F(MakemetaTest, announceSingleTracker)
     builder.set_announce_list(std::move(trackers));
 
     // generate the torrent and parse it as a variant
-    EXPECT_FALSE(builder.make_checksums().get().has_value());
+    auto checksums = builder.make_checksums().get();
+    EXPECT_FALSE(checksums.error.has_value());
+    builder.set_piece_hashes(std::move(checksums.piece_hashes));
     auto top = tr_variant_serde::benc().parse(builder.benc());
     ASSERT_TRUE(top);
     auto* map = top->get_if<tr_variant::Map>();
@@ -253,7 +256,9 @@ TEST_F(MakemetaTest, announceMultiTracker)
     builder.set_announce_list(std::move(trackers));
 
     // generate the torrent and parse it as a variant
-    EXPECT_FALSE(builder.make_checksums().get().has_value());
+    auto checksums = builder.make_checksums().get();
+    EXPECT_FALSE(checksums.error.has_value());
+    builder.set_piece_hashes(std::move(checksums.piece_hashes));
     auto top = tr_variant_serde::benc().parse(builder.benc());
     ASSERT_TRUE(top);
     auto* map = top->get_if<tr_variant::Map>();

--- a/utils/create.cc
+++ b/utils/create.cc
@@ -260,10 +260,13 @@ int tr_main(int argc, char* argv[])
 
     fmt::print(" ");
 
-    if (auto error = future.get(); error) {
+    auto checksums = future.get();
+    if (auto const& error = checksums.error; error) {
         fmt::print("ERROR: {:s} {:d}\n", error.message(), error.code());
         return EXIT_FAILURE;
     }
+
+    builder.set_piece_hashes(std::move(checksums.piece_hashes));
 
     if (auto error = tr_error{}; !builder.save(options.outfile, &error)) {
         auto const errmsg = fmt::format(


### PR DESCRIPTION
This PR adds better thread safety to the worker that calculates piece hashes: instead of referencing the `tr_metainfo_builder` that's owned by another thread, all of the info it needs is passed in by value instead (it's all cheap to copy, too). The finished checksums are now returned from the worker thread by including them in the promise's result.

Also adds a small correctness cleanup to the `current_piece` and `cancel` fields: make them `std::atomic<>` instances to avoid UB.

Notes: Fixed a possible crash when quitting while a torrent was still being created.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
