### PR TITLE
perf: use strongly-typed TRGroup model in GroupsController

### DIFF
--- a/macosx/GroupsController.h
+++ b/macosx/GroupsController.h
@@ -15,32 +15,32 @@
 - (NSInteger)rowValueForIndex:(NSInteger)index;
 - (NSInteger)indexForRow:(NSInteger)row;
 
-- (NSString*)nameForIndex:(NSInteger)index;
+- (nullable NSString*)nameForIndex:(NSInteger)index;
 - (void)setName:(NSString*)name forIndex:(NSInteger)index;
 
-- (NSImage*)imageForIndex:(NSInteger)index;
+- (nonnull NSImage*)imageForIndex:(NSInteger)index;
 
-- (NSColor*)colorForIndex:(NSInteger)index;
-- (void)setColor:(NSColor*)color forIndex:(NSInteger)index;
+- (nullable NSColor*)colorForIndex:(NSInteger)index;
+- (void)setColor:(nullable NSColor*)color forIndex:(NSInteger)index;
 
 - (BOOL)usesCustomDownloadLocationForIndex:(NSInteger)index;
 - (void)setUsesCustomDownloadLocation:(BOOL)useCustomLocation forIndex:(NSInteger)index;
 
-- (NSString*)customDownloadLocationForIndex:(NSInteger)index;
-- (void)setCustomDownloadLocation:(NSString*)location forIndex:(NSInteger)index;
+- (nullable NSString*)customDownloadLocationForIndex:(NSInteger)index;
+- (void)setCustomDownloadLocation:(nullable NSString*)location forIndex:(NSInteger)index;
 
 - (BOOL)usesAutoAssignRulesForIndex:(NSInteger)index;
 - (void)setUsesAutoAssignRules:(BOOL)useAutoAssignRules forIndex:(NSInteger)index;
 
-- (NSPredicate*)autoAssignRulesForIndex:(NSInteger)index;
-- (void)setAutoAssignRules:(NSPredicate*)predicate forIndex:(NSInteger)index;
+- (nullable NSPredicate*)autoAssignRulesForIndex:(NSInteger)index;
+- (void)setAutoAssignRules:(nullable NSPredicate*)predicate forIndex:(NSInteger)index;
 
 - (void)addNewGroup;
 - (void)removeGroupWithRowIndex:(NSInteger)row;
 
 - (void)moveGroupAtRow:(NSInteger)oldRow toRow:(NSInteger)newRow;
 
-- (NSMenu*)groupMenuWithTarget:(id)target action:(SEL)action isSmall:(BOOL)small;
+- (nonnull NSMenu*)groupMenuWithTarget:(id)target action:(SEL)action isSmall:(BOOL)small;
 
 - (NSInteger)groupIndexForTorrent:(Torrent*)torrent;
 @end

--- a/macosx/GroupsController.h
+++ b/macosx/GroupsController.h
@@ -6,9 +6,11 @@
 
 @class Torrent;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GroupsController : NSObject
 
-@property(nonatomic, class, readonly) GroupsController* groups;
+@property(nonatomic, class, readonly, nonnull) GroupsController* groups;
 
 @property(nonatomic, readonly) NSInteger numberOfGroups;
 
@@ -16,7 +18,7 @@
 - (NSInteger)indexForRow:(NSInteger)row;
 
 - (nullable NSString*)nameForIndex:(NSInteger)index;
-- (void)setName:(NSString*)name forIndex:(NSInteger)index;
+- (void)setName:(nullable NSString*)name forIndex:(NSInteger)index;
 
 - (nonnull NSImage*)imageForIndex:(NSInteger)index;
 
@@ -40,7 +42,9 @@
 
 - (void)moveGroupAtRow:(NSInteger)oldRow toRow:(NSInteger)newRow;
 
-- (nonnull NSMenu*)groupMenuWithTarget:(id)target action:(SEL)action isSmall:(BOOL)small;
+- (nonnull NSMenu*)groupMenuWithTarget:(nullable id)target action:(nullable SEL)action isSmall:(BOOL)small;
 
 - (NSInteger)groupIndexForTorrent:(Torrent*)torrent;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/macosx/GroupsController.mm
+++ b/macosx/GroupsController.mm
@@ -4,7 +4,6 @@
 
 #import "GroupsController.h"
 #import "NSImageAdditions.h"
-#import "NSKeyedUnarchiverAdditions.h"
 #import "NSMutableArrayAdditions.h"
 
 static CGFloat const kIconWidth = 16.0;
@@ -86,10 +85,16 @@ static CGFloat const kIconWidthSmall = 12.0;
 /** Fast lookup map (Group ID -> Array Index) providing O(1) row queries. */
 @property(nonatomic, strong) NSMutableDictionary<NSNumber*, NSNumber*>* fIndexMap;
 
-- (NSImage*)imageForGroupNone;
-- (NSImage*)imageForGroup:(TRGroup*)group;
-- (BOOL)torrent:(Torrent*)torrent doesMatchRulesForGroupAtIndex:(NSInteger)index;
+- (nullable TRGroup*)groupForIndex:(NSInteger)index;
 - (void)rebuildIndexMap;
+
+- (void)saveGroups;
+- (void)saveGroupsAndNotify;
+
+- (BOOL)torrent:(Torrent*)torrent doesMatchRulesForGroup:(TRGroup*)group;
+
+- (nonnull NSImage*)imageForGroupNone;
+- (nonnull NSImage*)imageForGroup:(TRGroup*)group;
 
 @end
 
@@ -129,34 +134,39 @@ static CGFloat const kIconWidthSmall = 12.0;
                                                                                                    nil]
                                                                     fromData:data
                                                                        error:nil];
-            _fGroups = [[NSMutableArray alloc] init];
-            for (NSDictionary* dict in oldDicts) {
-                TRGroup* g = [[TRGroup alloc] initWithIndex:[dict[@"Index"] integerValue] name:dict[@"Name"] color:dict[@"Color"]];
-                g.usesCustomDownloadLocation = [dict[@"UsesCustomDownloadLocation"] boolValue];
-                g.customDownloadLocation = dict[@"CustomDownloadLocation"];
-                g.usesAutoGroupRules = [dict[@"UsesAutoGroupRules"] boolValue];
-                g.autoGroupRules = dict[@"AutoGroupRules"];
-                [_fGroups addObject:g];
+            if (oldDicts != nil) {
+                _fGroups = [[NSMutableArray alloc] init];
+                for (NSDictionary* dict in oldDicts) {
+                    TRGroup* g = [[TRGroup alloc] initWithIndex:[dict[@"Index"] integerValue] name:dict[@"Name"]
+                                                          color:dict[@"Color"]];
+                    g.usesCustomDownloadLocation = [dict[@"UsesCustomDownloadLocation"] boolValue];
+                    g.customDownloadLocation = dict[@"CustomDownloadLocation"];
+                    g.usesAutoGroupRules = [dict[@"UsesAutoGroupRules"] boolValue];
+                    g.autoGroupRules = dict[@"AutoGroupRules"];
+                    [_fGroups addObject:g];
+                }
+                [self saveGroups];
             }
-            [self saveGroups];
+
+            [NSUserDefaults.standardUserDefaults removeObjectForKey:@"GroupDicts"];
         }
 
         // 3. Fallback: Initialize with default color-coded groups if no saved data exists
         if (_fGroups == nil) {
             _fGroups = [[NSMutableArray alloc]
-                initWithObjects:[[TRGroup alloc] initWithIndex:0 name:NSLocalizedString(@"Red", @"Groups -> Name")
+                initWithObjects:[[TRGroup alloc] initWithIndex:0 name:NSLocalizedString(@"Red", "Groups -> Name")
                                                          color:NSColor.systemRedColor],
-                                [[TRGroup alloc] initWithIndex:1 name:NSLocalizedString(@"Orange", @"Groups -> Name")
+                                [[TRGroup alloc] initWithIndex:1 name:NSLocalizedString(@"Orange", "Groups -> Name")
                                                          color:NSColor.systemOrangeColor],
-                                [[TRGroup alloc] initWithIndex:2 name:NSLocalizedString(@"Yellow", @"Groups -> Name")
+                                [[TRGroup alloc] initWithIndex:2 name:NSLocalizedString(@"Yellow", "Groups -> Name")
                                                          color:NSColor.systemYellowColor],
-                                [[TRGroup alloc] initWithIndex:3 name:NSLocalizedString(@"Green", @"Groups -> Name")
+                                [[TRGroup alloc] initWithIndex:3 name:NSLocalizedString(@"Green", "Groups -> Name")
                                                          color:NSColor.systemGreenColor],
-                                [[TRGroup alloc] initWithIndex:4 name:NSLocalizedString(@"Blue", @"Groups -> Name")
+                                [[TRGroup alloc] initWithIndex:4 name:NSLocalizedString(@"Blue", "Groups -> Name")
                                                          color:NSColor.systemBlueColor],
-                                [[TRGroup alloc] initWithIndex:5 name:NSLocalizedString(@"Purple", @"Groups -> Name")
+                                [[TRGroup alloc] initWithIndex:5 name:NSLocalizedString(@"Purple", "Groups -> Name")
                                                          color:NSColor.systemPurpleColor],
-                                [[TRGroup alloc] initWithIndex:6 name:NSLocalizedString(@"Gray", @"Groups -> Name")
+                                [[TRGroup alloc] initWithIndex:6 name:NSLocalizedString(@"Gray", "Groups -> Name")
                                                          color:NSColor.systemGrayColor],
                                 nil];
             [self saveGroups];
@@ -188,6 +198,12 @@ static CGFloat const kIconWidthSmall = 12.0;
     }
 }
 
+- (void)saveGroupsAndNotify
+{
+    [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateGroups" object:self];
+    [self saveGroups];
+}
+
 #pragma mark - Data Accessors
 
 - (NSInteger)numberOfGroups
@@ -209,38 +225,45 @@ static CGFloat const kIconWidthSmall = 12.0;
     return self.fGroups[row].groupIndex;
 }
 
-- (NSString*)nameForIndex:(NSInteger)index
+- (nullable TRGroup*)groupForIndex:(NSInteger)index
 {
     NSInteger orderIndex = [self rowValueForIndex:index];
-    return orderIndex != -1 ? self.fGroups[orderIndex].name : nil;
+    return orderIndex != -1 ? self.fGroups[orderIndex] : nil;
+}
+
+- (NSString*)nameForIndex:(NSInteger)index
+{
+    return [self groupForIndex:index].name;
 }
 
 - (void)setName:(NSString*)name forIndex:(NSInteger)index
 {
-    NSInteger orderIndex = [self rowValueForIndex:index];
-    if (orderIndex != -1) {
-        self.fGroups[orderIndex].name = name;
-        [self saveGroups];
-        [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateGroups" object:self];
+    TRGroup* group = [self groupForIndex:index];
+
+    if (group == nil) {
+        return;
     }
+
+    group.name = name;
+    [self saveGroupsAndNotify];
 }
 
 - (NSColor*)colorForIndex:(NSInteger)index
 {
-    NSInteger orderIndex = [self rowValueForIndex:index];
-    return orderIndex != -1 ? self.fGroups[orderIndex].color : nil;
+    return [self groupForIndex:index].color;
 }
 
 - (void)setColor:(NSColor*)color forIndex:(NSInteger)index
 {
-    NSInteger orderIndex = [self rowValueForIndex:index];
-    if (orderIndex != -1) {
-        TRGroup* group = self.fGroups[orderIndex];
-        group.icon = nil; // Invalidate cached icon to force re-render with the new color
-        group.color = color;
-        [self saveGroups];
-        [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateGroups" object:self];
+    TRGroup* group = [self groupForIndex:index];
+
+    if (group == nil) {
+        return;
     }
+
+    group.icon = nil; // Invalidate cached icon to force re-render with the new color
+    group.color = color;
+    [self saveGroupsAndNotify];
 }
 
 #pragma mark - Download Location Management
@@ -249,69 +272,77 @@ static CGFloat const kIconWidthSmall = 12.0;
 {
     if (![self customDownloadLocationForIndex:index])
         return NO;
-    NSInteger orderIndex = [self rowValueForIndex:index];
-    return orderIndex != -1 ? self.fGroups[orderIndex].usesCustomDownloadLocation : NO;
+
+    return [self groupForIndex:index].usesCustomDownloadLocation;
 }
 
 - (void)setUsesCustomDownloadLocation:(BOOL)useCustomLocation forIndex:(NSInteger)index
 {
-    NSInteger orderIndex = [self rowValueForIndex:index];
-    if (orderIndex != -1) {
-        self.fGroups[orderIndex].usesCustomDownloadLocation = useCustomLocation;
-        [self saveGroups];
+    TRGroup* group = [self groupForIndex:index];
+
+    if (group == nil) {
+        return;
     }
+
+    group.usesCustomDownloadLocation = useCustomLocation;
+    [self saveGroups];
 }
 
 - (NSString*)customDownloadLocationForIndex:(NSInteger)index
 {
-    NSInteger orderIndex = [self rowValueForIndex:index];
-    return orderIndex != -1 ? self.fGroups[orderIndex].customDownloadLocation : nil;
+    return [self groupForIndex:index].customDownloadLocation;
 }
 
 - (void)setCustomDownloadLocation:(NSString*)location forIndex:(NSInteger)index
 {
-    NSInteger orderIndex = [self rowValueForIndex:index];
-    if (orderIndex != -1) {
-        self.fGroups[orderIndex].customDownloadLocation = location;
-        [self saveGroups];
+    TRGroup* group = [self groupForIndex:index];
+
+    if (group == nil) {
+        return;
     }
+
+    group.customDownloadLocation = location;
+    [self saveGroups];
 }
 
 #pragma mark - Smart Rules (NSPredicate Matching)
 
 - (BOOL)usesAutoAssignRulesForIndex:(NSInteger)index
 {
-    NSInteger orderIndex = [self rowValueForIndex:index];
-    return orderIndex != -1 ? self.fGroups[orderIndex].usesAutoGroupRules : NO;
+    return [self groupForIndex:index].usesAutoGroupRules;
 }
 
 - (void)setUsesAutoAssignRules:(BOOL)useAutoAssignRules forIndex:(NSInteger)index
 {
-    NSInteger orderIndex = [self rowValueForIndex:index];
-    if (orderIndex != -1) {
-        self.fGroups[orderIndex].usesAutoGroupRules = useAutoAssignRules;
-        [self saveGroups];
+    TRGroup* group = [self groupForIndex:index];
+
+    if (group == nil) {
+        return;
     }
+
+    group.usesAutoGroupRules = useAutoAssignRules;
+    [self saveGroups];
 }
 
 - (NSPredicate*)autoAssignRulesForIndex:(NSInteger)index
 {
-    NSInteger orderIndex = [self rowValueForIndex:index];
-    return orderIndex != -1 ? self.fGroups[orderIndex].autoGroupRules : nil;
+    return [self groupForIndex:index].autoGroupRules;
 }
 
 - (void)setAutoAssignRules:(NSPredicate*)predicate forIndex:(NSInteger)index
 {
-    NSInteger orderIndex = [self rowValueForIndex:index];
-    if (orderIndex != -1) {
-        TRGroup* group = self.fGroups[orderIndex];
-        if (predicate) {
-            group.autoGroupRules = predicate;
-            [self saveGroups];
-        } else {
-            group.autoGroupRules = nil;
-            [self setUsesAutoAssignRules:NO forIndex:index];
-        }
+    TRGroup* group = [self groupForIndex:index];
+
+    if (group == nil) {
+        return;
+    }
+
+    if (predicate != nil) {
+        group.autoGroupRules = predicate;
+        [self saveGroups];
+    } else {
+        group.autoGroupRules = nil;
+        [self setUsesAutoAssignRules:NO forIndex:index];
     }
 }
 
@@ -332,37 +363,41 @@ static CGFloat const kIconWidthSmall = 12.0;
     [self.fGroups addObject:newGroup];
 
     [self rebuildIndexMap];
-    [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateGroups" object:self];
-    [self saveGroups];
+
+    [self saveGroupsAndNotify];
 }
 
 - (void)removeGroupWithRowIndex:(NSInteger)row
 {
-    if (row < 0 || row >= self.fGroups.count)
+    if (row < 0 || row >= self.fGroups.count) {
         return;
+    }
 
     NSInteger index = self.fGroups[row].groupIndex;
     [self.fGroups removeObjectAtIndex:row];
     [self rebuildIndexMap];
 
     [NSNotificationCenter.defaultCenter postNotificationName:@"GroupValueRemoved" object:self
-
                                                     userInfo:@{ @"Index" : @(index) }];
+
     // Reset UI group filter if the currently filtered group was deleted
     if (index == [NSUserDefaults.standardUserDefaults integerForKey:@"FilterGroup"]) {
         [NSUserDefaults.standardUserDefaults setInteger:-2 forKey:@"FilterGroup"];
     }
-    [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateGroups" object:self];
-    [self saveGroups];
+
+    [self saveGroupsAndNotify];
 }
 
 - (void)moveGroupAtRow:(NSInteger)oldRow toRow:(NSInteger)newRow
 {
-    if (oldRow < 0 || oldRow >= self.fGroups.count || newRow < 0 || newRow >= self.fGroups.count)
+    if (oldRow < 0 || oldRow >= self.fGroups.count || newRow < 0 || newRow >= self.fGroups.count) {
         return;
+    }
+
     [self.fGroups moveObjectAtIndex:oldRow toIndex:newRow];
-    [self rebuildIndexMap]; // Critical: Map must be updated as table row positions shifted[self saveGroups];
-    [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateGroups" object:self];
+    [self rebuildIndexMap];
+
+    [self saveGroupsAndNotify];
 }
 
 #pragma mark - UI Menu & Torrent Matching
@@ -394,19 +429,20 @@ static CGFloat const kIconWidthSmall = 12.0;
 {
     // Evaluate smart-rules linearly to find the first matching category
     for (TRGroup* group in self.fGroups) {
-        if ([self torrent:torrent doesMatchRulesForGroupAtIndex:group.groupIndex]) {
+        if ([self torrent:torrent doesMatchRulesForGroup:group]) {
             return group.groupIndex;
         }
     }
     return -1;
 }
 
-- (BOOL)torrent:(Torrent*)torrent doesMatchRulesForGroupAtIndex:(NSInteger)index
+- (BOOL)torrent:(Torrent*)torrent doesMatchRulesForGroup:(TRGroup*)group
 {
-    if (![self usesAutoAssignRulesForIndex:index]) {
+    if (group.usesAutoGroupRules == NO) {
         return NO;
     }
-    NSPredicate* predicate = [self autoAssignRulesForIndex:index];
+
+    NSPredicate* predicate = group.autoGroupRules;
     [predicate allowEvaluation];
     BOOL eval = NO;
     @try {
@@ -420,7 +456,7 @@ static CGFloat const kIconWidthSmall = 12.0;
 
 #pragma mark - Icon Graphics Rendering
 
-- (NSImage*)imageForGroupNone
+- (nonnull NSImage*)imageForGroupNone
 {
     static NSImage* icon;
     if (icon)
@@ -437,19 +473,27 @@ static CGFloat const kIconWidthSmall = 12.0;
     return icon;
 }
 
-- (NSImage*)imageForGroup:(TRGroup*)group
+- (nonnull NSImage*)imageForGroup:(TRGroup*)group
 {
-    if (group.icon)
-        return group.icon; // Render the crisp round badge matching the group color and cache it inside the model instance
+    if (group.icon) {
+        return group.icon;
+    }
+
+    // Render the crisp round badge matching the group color and cache it inside the model instance
     NSImage* icon = [NSImage discIconWithColor:group.color insetFactor:0];
     group.icon = icon;
+
     return icon;
 }
 
-- (NSImage*)imageForIndex:(NSInteger)index
+- (nonnull NSImage*)imageForIndex:(NSInteger)index
 {
-    NSInteger orderIndex = [self rowValueForIndex:index];
-    TRGroup* group = orderIndex != -1 ? self.fGroups[orderIndex] : nil;
+    TRGroup* group = [self groupForIndex:index];
+
+    if (group == nil) {
+        return [self imageForGroupNone];
+    }
+
     return [self imageForGroup:group];
 }
 

--- a/macosx/GroupsController.mm
+++ b/macosx/GroupsController.mm
@@ -11,9 +11,85 @@ static CGFloat const kIconWidth = 16.0;
 static CGFloat const kBorderWidth = 1.25;
 static CGFloat const kIconWidthSmall = 12.0;
 
+@interface TRGroup : NSObject<NSSecureCoding>
+
+@property(nonatomic, assign) NSInteger groupIndex;
+@property(nonatomic, copy) NSString* name;
+@property(nonatomic, strong) NSColor* color;
+
+/** Runtime-only cache for the rendered group icon. Ignored during serialization. */
+@property(nonatomic, strong, nullable) NSImage* icon;
+
+@property(nonatomic, assign) BOOL usesCustomDownloadLocation;
+@property(nonatomic, copy, nullable) NSString* customDownloadLocation;
+
+@property(nonatomic, assign) BOOL usesAutoGroupRules;
+@property(nonatomic, strong, nullable) NSPredicate* autoGroupRules;
+
+- (instancetype)initWithIndex:(NSInteger)index name:(NSString*)name color:(NSColor*)color;
+
+@end
+
+@implementation TRGroup
+
++ (BOOL)supportsSecureCoding
+{
+    return YES;
+}
+
+- (instancetype)initWithIndex:(NSInteger)index name:(NSString*)name color:(NSColor*)color
+{
+    self = [super init];
+    if (self) {
+        _groupIndex = index;
+        _name = [name copy];
+        _color = color;
+    }
+    return self;
+}
+
+#pragma mark - NSSecureCoding
+
+- (void)encodeWithCoder:(NSCoder*)coder
+{
+    [coder encodeInteger:self.groupIndex forKey:@"Index"];
+    [coder encodeObject:self.name forKey:@"Name"];
+    [coder encodeObject:self.color forKey:@"Color"];
+    [coder encodeBool:self.usesCustomDownloadLocation forKey:@"UsesCustomDownloadLocation"];
+    [coder encodeObject:self.customDownloadLocation forKey:@"CustomDownloadLocation"];
+    [coder encodeBool:self.usesAutoGroupRules forKey:@"UsesAutoGroupRules"];
+    [coder encodeObject:self.autoGroupRules forKey:@"AutoGroupRules"];
+}
+
+- (instancetype)initWithCoder:(NSCoder*)coder
+{
+    self = [super init];
+    if (self) {
+        _groupIndex = [coder decodeIntegerForKey:@"Index"];
+        _name = [coder decodeObjectOfClass:NSString.class forKey:@"Name"] ?: @"";
+        _color = [coder decodeObjectOfClass:NSColor.class forKey:@"Color"] ?: NSColor.systemGrayColor;
+        _usesCustomDownloadLocation = [coder decodeBoolForKey:@"UsesCustomDownloadLocation"];
+        _customDownloadLocation = [coder decodeObjectOfClass:NSString.class forKey:@"CustomDownloadLocation"];
+        _usesAutoGroupRules = [coder decodeBoolForKey:@"UsesAutoGroupRules"];
+        _autoGroupRules = [coder decodeObjectOfClass:NSPredicate.class forKey:@"AutoGroupRules"];
+    }
+    return self;
+}
+
+@end
+
 @interface GroupsController ()
 
-@property(nonatomic, readonly) NSMutableArray<NSMutableDictionary*>* fGroups;
+/** Backing array storing strongly-typed TRGroup model objects. */
+@property(nonatomic, strong) NSMutableArray<TRGroup*>* fGroups;
+
+/** Fast lookup map (Group ID -> Array Index) providing O(1) row queries. */
+@property(nonatomic, strong) NSMutableDictionary<NSNumber*, NSNumber*>* fIndexMap;
+
+- (NSImage*)imageForGroupNone;
+- (NSImage*)imageForGroup:(TRGroup*)group;
+- (BOOL)torrent:(Torrent*)torrent doesMatchRulesForGroupAtIndex:(NSInteger)index;
+- (void)rebuildIndexMap;
 
 @end
 
@@ -26,344 +102,303 @@ static CGFloat const kIconWidthSmall = 12.0;
     dispatch_once(&onceToken, ^{
         fGroupsInstance = [[GroupsController alloc] init];
     });
-
     return fGroupsInstance;
 }
 
 - (instancetype)init
 {
     if ((self = [super init])) {
+        _fIndexMap = [[NSMutableDictionary alloc] init];
         NSData* data;
-        if ((data = [NSUserDefaults.standardUserDefaults dataForKey:@"GroupDicts"])) {
-            _fGroups = [NSKeyedUnarchiver unarchivedObjectOfClasses:[NSSet setWithObjects:NSMutableArray.class,
-                                                                                          NSMutableDictionary.class,
-                                                                                          NSNumber.class,
-                                                                                          NSColor.class,
-                                                                                          NSString.class,
-                                                                                          NSPredicate.class,
-                                                                                          nil]
-                                                           fromData:data
-                                                              error:nil];
-        } else if ((data = [NSUserDefaults.standardUserDefaults dataForKey:@"Groups"])) //handle old groups
-        {
-            _fGroups = [NSKeyedUnarchiver deprecatedUnarchiveObjectWithData:data];
-            [NSUserDefaults.standardUserDefaults removeObjectForKey:@"Groups"];
+
+        // 1. Try to load modern strongly-typed TRGroup objects
+        if ((data = [NSUserDefaults.standardUserDefaults dataForKey:@"GroupObjects"])) {
+            _fGroups = [NSKeyedUnarchiver
+                unarchivedObjectOfClasses:[NSSet setWithObjects:NSMutableArray.class, TRGroup.class, NSColor.class, NSPredicate.class, nil]
+                                 fromData:data
+                                    error:nil];
+        }
+        // 2. Backward compatibility: Migrate old untyped dictionaries to TRGroup objects
+        else if ((data = [NSUserDefaults.standardUserDefaults dataForKey:@"GroupDicts"])) {
+            NSArray* oldDicts = [NSKeyedUnarchiver unarchivedObjectOfClasses:[NSSet setWithObjects:NSArray.class,
+                                                                                                   NSDictionary.class,
+                                                                                                   NSNumber.class,
+                                                                                                   NSColor.class,
+                                                                                                   NSString.class,
+                                                                                                   NSPredicate.class,
+                                                                                                   nil]
+                                                                    fromData:data
+                                                                       error:nil];
+            _fGroups = [[NSMutableArray alloc] init];
+            for (NSDictionary* dict in oldDicts) {
+                TRGroup* g = [[TRGroup alloc] initWithIndex:[dict[@"Index"] integerValue] name:dict[@"Name"] color:dict[@"Color"]];
+                g.usesCustomDownloadLocation = [dict[@"UsesCustomDownloadLocation"] boolValue];
+                g.customDownloadLocation = dict[@"CustomDownloadLocation"];
+                g.usesAutoGroupRules = [dict[@"UsesAutoGroupRules"] boolValue];
+                g.autoGroupRules = dict[@"AutoGroupRules"];
+                [_fGroups addObject:g];
+            }
             [self saveGroups];
         }
+
+        // 3. Fallback: Initialize with default color-coded groups if no saved data exists
         if (_fGroups == nil) {
-            //default groups
-            NSMutableDictionary* red = [NSMutableDictionary
-                dictionaryWithObjectsAndKeys:NSColor.systemRedColor, @"Color", NSLocalizedString(@"Red", "Groups -> Name"), @"Name", @0, @"Index", nil];
-
-            NSMutableDictionary* orange = [NSMutableDictionary
-                dictionaryWithObjectsAndKeys:NSColor.systemOrangeColor, @"Color", NSLocalizedString(@"Orange", "Groups -> Name"), @"Name", @1, @"Index", nil];
-
-            NSMutableDictionary* yellow = [NSMutableDictionary
-                dictionaryWithObjectsAndKeys:NSColor.systemYellowColor, @"Color", NSLocalizedString(@"Yellow", "Groups -> Name"), @"Name", @2, @"Index", nil];
-
-            NSMutableDictionary* green = [NSMutableDictionary
-                dictionaryWithObjectsAndKeys:NSColor.systemGreenColor, @"Color", NSLocalizedString(@"Green", "Groups -> Name"), @"Name", @3, @"Index", nil];
-
-            NSMutableDictionary* blue = [NSMutableDictionary
-                dictionaryWithObjectsAndKeys:NSColor.systemBlueColor, @"Color", NSLocalizedString(@"Blue", "Groups -> Name"), @"Name", @4, @"Index", nil];
-
-            NSMutableDictionary* purple = [NSMutableDictionary
-                dictionaryWithObjectsAndKeys:NSColor.systemPurpleColor, @"Color", NSLocalizedString(@"Purple", "Groups -> Name"), @"Name", @5, @"Index", nil];
-
-            NSMutableDictionary* gray = [NSMutableDictionary
-                dictionaryWithObjectsAndKeys:NSColor.systemGrayColor, @"Color", NSLocalizedString(@"Gray", "Groups -> Name"), @"Name", @6, @"Index", nil];
-
-            _fGroups = [[NSMutableArray alloc] initWithObjects:red, orange, yellow, green, blue, purple, gray, nil];
-            [self saveGroups]; //make sure this is saved right away
+            _fGroups = [[NSMutableArray alloc]
+                initWithObjects:[[TRGroup alloc] initWithIndex:0 name:NSLocalizedString(@"Red", @"Groups -> Name")
+                                                         color:NSColor.systemRedColor],
+                                [[TRGroup alloc] initWithIndex:1 name:NSLocalizedString(@"Orange", @"Groups -> Name")
+                                                         color:NSColor.systemOrangeColor],
+                                [[TRGroup alloc] initWithIndex:2 name:NSLocalizedString(@"Yellow", @"Groups -> Name")
+                                                         color:NSColor.systemYellowColor],
+                                [[TRGroup alloc] initWithIndex:3 name:NSLocalizedString(@"Green", @"Groups -> Name")
+                                                         color:NSColor.systemGreenColor],
+                                [[TRGroup alloc] initWithIndex:4 name:NSLocalizedString(@"Blue", @"Groups -> Name")
+                                                         color:NSColor.systemBlueColor],
+                                [[TRGroup alloc] initWithIndex:5 name:NSLocalizedString(@"Purple", @"Groups -> Name")
+                                                         color:NSColor.systemPurpleColor],
+                                [[TRGroup alloc] initWithIndex:6 name:NSLocalizedString(@"Gray", @"Groups -> Name")
+                                                         color:NSColor.systemGrayColor],
+                                nil];
+            [self saveGroups];
         }
-    }
 
+        [self rebuildIndexMap];
+    }
     return self;
 }
+
+/** Rebuilds the O(1) hash map cache. Must be called whenever the array mutates or reorders. */
+- (void)rebuildIndexMap
+{
+    [self.fIndexMap removeAllObjects];
+    for (NSUInteger i = 0; i < self.fGroups.count; i++) {
+        self.fIndexMap[@(self.fGroups[i].groupIndex)] = @(i);
+    }
+}
+
+- (void)saveGroups
+{
+    NSError* error = nil;
+    // Runtime-only .icon property is naturally skipped since it's omitted in TRGroup's encodeWithCoder
+    NSData* data = [NSKeyedArchiver archivedDataWithRootObject:self.fGroups requiringSecureCoding:YES error:&error];
+    if (data && !error) {
+        [NSUserDefaults.standardUserDefaults setObject:data forKey:@"GroupObjects"];
+    } else {
+        NSLog(@"[GroupsController] Serialization failed: %@", error.localizedDescription);
+    }
+}
+
+#pragma mark - Data Accessors
 
 - (NSInteger)numberOfGroups
 {
     return self.fGroups.count;
 }
 
+/** Resolves table row index from a unique Group ID. Optimized to O(1) via hash map. */
 - (NSInteger)rowValueForIndex:(NSInteger)index
 {
-    if (index != -1) {
-        for (NSUInteger i = 0; i < self.fGroups.count; i++) {
-            if (index == [self.fGroups[i][@"Index"] integerValue]) {
-                return i;
-            }
-        }
-    }
-    return -1;
+    if (index == -1 || index == NSNotFound)
+        return -1;
+    NSNumber* row = self.fIndexMap[@(index)];
+    return row ? [row integerValue] : -1;
 }
 
 - (NSInteger)indexForRow:(NSInteger)row
 {
-    return [self.fGroups[row][@"Index"] integerValue];
+    return self.fGroups[row].groupIndex;
 }
 
 - (NSString*)nameForIndex:(NSInteger)index
 {
     NSInteger orderIndex = [self rowValueForIndex:index];
-    return orderIndex != -1 ? self.fGroups[orderIndex][@"Name"] : nil;
+    return orderIndex != -1 ? self.fGroups[orderIndex].name : nil;
 }
 
 - (void)setName:(NSString*)name forIndex:(NSInteger)index
 {
     NSInteger orderIndex = [self rowValueForIndex:index];
-    self.fGroups[orderIndex][@"Name"] = name;
-    [self saveGroups];
-
-    [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateGroups" object:self];
-}
-
-- (NSImage*)imageForIndex:(NSInteger)index
-{
-    NSInteger orderIndex = [self rowValueForIndex:index];
-    return orderIndex != -1 ? [self imageForGroup:self.fGroups[orderIndex]] : [self imageForGroupNone];
+    if (orderIndex != -1) {
+        self.fGroups[orderIndex].name = name;
+        [self saveGroups];
+        [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateGroups" object:self];
+    }
 }
 
 - (NSColor*)colorForIndex:(NSInteger)index
 {
     NSInteger orderIndex = [self rowValueForIndex:index];
-    return orderIndex != -1 ? self.fGroups[orderIndex][@"Color"] : nil;
+    return orderIndex != -1 ? self.fGroups[orderIndex].color : nil;
 }
 
 - (void)setColor:(NSColor*)color forIndex:(NSInteger)index
 {
-    NSMutableDictionary* dict = self.fGroups[[self rowValueForIndex:index]];
-    [dict removeObjectForKey:@"Icon"];
-
-    dict[@"Color"] = color;
-
-    [GroupsController.groups saveGroups];
-    [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateGroups" object:self];
+    NSInteger orderIndex = [self rowValueForIndex:index];
+    if (orderIndex != -1) {
+        TRGroup* group = self.fGroups[orderIndex];
+        group.icon = nil; // Invalidate cached icon to force re-render with the new color
+        group.color = color;
+        [self saveGroups];
+        [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateGroups" object:self];
+    }
 }
+
+#pragma mark - Download Location Management
 
 - (BOOL)usesCustomDownloadLocationForIndex:(NSInteger)index
 {
-    if (![self customDownloadLocationForIndex:index]) {
+    if (![self customDownloadLocationForIndex:index])
         return NO;
-    }
-
     NSInteger orderIndex = [self rowValueForIndex:index];
-    return [self.fGroups[orderIndex][@"UsesCustomDownloadLocation"] boolValue];
+    return orderIndex != -1 ? self.fGroups[orderIndex].usesCustomDownloadLocation : NO;
 }
 
 - (void)setUsesCustomDownloadLocation:(BOOL)useCustomLocation forIndex:(NSInteger)index
 {
-    NSMutableDictionary* dict = self.fGroups[[self rowValueForIndex:index]];
-
-    dict[@"UsesCustomDownloadLocation"] = @(useCustomLocation);
-
-    [GroupsController.groups saveGroups];
+    NSInteger orderIndex = [self rowValueForIndex:index];
+    if (orderIndex != -1) {
+        self.fGroups[orderIndex].usesCustomDownloadLocation = useCustomLocation;
+        [self saveGroups];
+    }
 }
 
 - (NSString*)customDownloadLocationForIndex:(NSInteger)index
 {
     NSInteger orderIndex = [self rowValueForIndex:index];
-    return orderIndex != -1 ? self.fGroups[orderIndex][@"CustomDownloadLocation"] : nil;
+    return orderIndex != -1 ? self.fGroups[orderIndex].customDownloadLocation : nil;
 }
 
 - (void)setCustomDownloadLocation:(NSString*)location forIndex:(NSInteger)index
 {
-    NSMutableDictionary* dict = self.fGroups[[self rowValueForIndex:index]];
-    dict[@"CustomDownloadLocation"] = location;
-
-    [GroupsController.groups saveGroups];
+    NSInteger orderIndex = [self rowValueForIndex:index];
+    if (orderIndex != -1) {
+        self.fGroups[orderIndex].customDownloadLocation = location;
+        [self saveGroups];
+    }
 }
+
+#pragma mark - Smart Rules (NSPredicate Matching)
 
 - (BOOL)usesAutoAssignRulesForIndex:(NSInteger)index
 {
     NSInteger orderIndex = [self rowValueForIndex:index];
-    if (orderIndex == -1) {
-        return NO;
-    }
-
-    NSNumber* assignRules = self.fGroups[orderIndex][@"UsesAutoGroupRules"];
-    return assignRules && assignRules.boolValue;
+    return orderIndex != -1 ? self.fGroups[orderIndex].usesAutoGroupRules : NO;
 }
 
 - (void)setUsesAutoAssignRules:(BOOL)useAutoAssignRules forIndex:(NSInteger)index
 {
-    NSMutableDictionary* dict = self.fGroups[[self rowValueForIndex:index]];
-
-    dict[@"UsesAutoGroupRules"] = @(useAutoAssignRules);
-
-    [GroupsController.groups saveGroups];
+    NSInteger orderIndex = [self rowValueForIndex:index];
+    if (orderIndex != -1) {
+        self.fGroups[orderIndex].usesAutoGroupRules = useAutoAssignRules;
+        [self saveGroups];
+    }
 }
 
 - (NSPredicate*)autoAssignRulesForIndex:(NSInteger)index
 {
     NSInteger orderIndex = [self rowValueForIndex:index];
-    if (orderIndex == -1) {
-        return nil;
-    }
-
-    return self.fGroups[orderIndex][@"AutoGroupRules"];
+    return orderIndex != -1 ? self.fGroups[orderIndex].autoGroupRules : nil;
 }
 
 - (void)setAutoAssignRules:(NSPredicate*)predicate forIndex:(NSInteger)index
 {
-    NSMutableDictionary* dict = self.fGroups[[self rowValueForIndex:index]];
-
-    if (predicate) {
-        dict[@"AutoGroupRules"] = predicate;
-        [GroupsController.groups saveGroups];
-    } else {
-        [dict removeObjectForKey:@"AutoGroupRules"];
-        [self setUsesAutoAssignRules:NO forIndex:index];
+    NSInteger orderIndex = [self rowValueForIndex:index];
+    if (orderIndex != -1) {
+        TRGroup* group = self.fGroups[orderIndex];
+        if (predicate) {
+            group.autoGroupRules = predicate;
+            [self saveGroups];
+        } else {
+            group.autoGroupRules = nil;
+            [self setUsesAutoAssignRules:NO forIndex:index];
+        }
     }
 }
 
+#pragma mark - Group Management Mutators
+
 - (void)addNewGroup
 {
-    //find the lowest index
+    // Find the lowest available unique Group ID index
     NSMutableIndexSet* candidates = [NSMutableIndexSet indexSetWithIndexesInRange:NSMakeRange(0, self.fGroups.count + 1)];
-    for (NSDictionary* dict in self.fGroups) {
-        [candidates removeIndex:[dict[@"Index"] integerValue]];
+    for (TRGroup* group in self.fGroups) {
+        [candidates removeIndex:group.groupIndex];
     }
 
     NSInteger const index = candidates.firstIndex;
+    NSColor* defaultBlue = [NSColor colorWithCalibratedRed:0.0 green:0.65 blue:1.0 alpha:1.0];
 
-    [self.fGroups addObject:[NSMutableDictionary dictionaryWithObjectsAndKeys:@(index),
-                                                                              @"Index",
-                                                                              [NSColor colorWithCalibratedRed:0.0 green:0.65
-                                                                                                         blue:1.0
-                                                                                                        alpha:1.0],
-                                                                              @"Color",
-                                                                              @"",
-                                                                              @"Name",
-                                                                              nil]];
+    TRGroup* newGroup = [[TRGroup alloc] initWithIndex:index name:@"" color:defaultBlue];
+    [self.fGroups addObject:newGroup];
 
+    [self rebuildIndexMap];
     [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateGroups" object:self];
     [self saveGroups];
 }
 
 - (void)removeGroupWithRowIndex:(NSInteger)row
 {
-    NSInteger index = [self.fGroups[row][@"Index"] integerValue];
+    if (row < 0 || row >= self.fGroups.count)
+        return;
+
+    NSInteger index = self.fGroups[row].groupIndex;
     [self.fGroups removeObjectAtIndex:row];
+    [self rebuildIndexMap];
 
     [NSNotificationCenter.defaultCenter postNotificationName:@"GroupValueRemoved" object:self
-                                                    userInfo:@{ @"Index" : @(index) }];
 
+                                                    userInfo:@{ @"Index" : @(index) }];
+    // Reset UI group filter if the currently filtered group was deleted
     if (index == [NSUserDefaults.standardUserDefaults integerForKey:@"FilterGroup"]) {
         [NSUserDefaults.standardUserDefaults setInteger:-2 forKey:@"FilterGroup"];
     }
-
     [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateGroups" object:self];
     [self saveGroups];
 }
 
 - (void)moveGroupAtRow:(NSInteger)oldRow toRow:(NSInteger)newRow
 {
+    if (oldRow < 0 || oldRow >= self.fGroups.count || newRow < 0 || newRow >= self.fGroups.count)
+        return;
     [self.fGroups moveObjectAtIndex:oldRow toIndex:newRow];
-
-    [self saveGroups];
+    [self rebuildIndexMap]; // Critical: Map must be updated as table row positions shifted[self saveGroups];
     [NSNotificationCenter.defaultCenter postNotificationName:@"UpdateGroups" object:self];
 }
+
+#pragma mark - UI Menu & Torrent Matching
 
 - (NSMenu*)groupMenuWithTarget:(id)target action:(SEL)action isSmall:(BOOL)small
 {
     NSMenu* menu = [[NSMenu alloc] initWithTitle:@""];
-
     void (^addItemWithTitleTagIcon)(NSString*, NSInteger, NSImage*) = ^void(NSString* title, NSInteger tag, NSImage* icon) {
         NSMenuItem* item = [[NSMenuItem alloc] initWithTitle:title action:action keyEquivalent:@""];
         item.target = target;
         item.tag = tag;
-
         if (small) {
-            icon = [icon copy];
-            icon.size = NSMakeSize(kIconWidthSmall, kIconWidthSmall);
-
-            item.image = icon;
+            NSImage* smallIcon = [icon copy];
+            smallIcon.size = NSMakeSize(kIconWidthSmall, kIconWidthSmall);
+            item.image = smallIcon;
         } else {
             item.image = icon;
         }
-
         [menu addItem:item];
-    };
-
-    addItemWithTitleTagIcon(NSLocalizedString(@"None", "Groups -> Menu"), -1, [self imageForGroupNone]);
-
-    for (NSMutableDictionary* dict in self.fGroups) {
-        addItemWithTitleTagIcon(dict[@"Name"], [dict[@"Index"] integerValue], [self imageForGroup:dict]);
+    }; // Add the default placeholder item "None" (-1)
+    addItemWithTitleTagIcon(NSLocalizedString(@"None", "Groups -> Menu"), -1, [self imageForGroupNone]); // Populate menu items using the clean object properties
+    for (TRGroup* group in self.fGroups) {
+        addItemWithTitleTagIcon(group.name, group.groupIndex, [self imageForGroup:group]);
     }
-
     return menu;
 }
 
 - (NSInteger)groupIndexForTorrent:(Torrent*)torrent
 {
-    for (NSDictionary* group in self.fGroups) {
-        NSInteger row = [group[@"Index"] integerValue];
-        if ([self torrent:torrent doesMatchRulesForGroupAtIndex:row]) {
-            return row;
+    // Evaluate smart-rules linearly to find the first matching category
+    for (TRGroup* group in self.fGroups) {
+        if ([self torrent:torrent doesMatchRulesForGroupAtIndex:group.groupIndex]) {
+            return group.groupIndex;
         }
     }
     return -1;
-}
-
-#pragma mark - Private
-
-- (void)saveGroups
-{
-    //don't archive the icon
-    NSMutableArray* groups = [NSMutableArray arrayWithCapacity:self.fGroups.count];
-    for (NSDictionary* dict in self.fGroups) {
-        NSMutableDictionary* tempDict = [dict mutableCopy];
-        [tempDict removeObjectForKey:@"Icon"];
-        [groups addObject:tempDict];
-    }
-
-    [NSUserDefaults.standardUserDefaults setObject:[NSKeyedArchiver archivedDataWithRootObject:groups requiringSecureCoding:YES
-                                                                                         error:nil]
-                                            forKey:@"GroupDicts"];
-}
-
-- (NSImage*)imageForGroupNone
-{
-    static NSImage* icon;
-    if (icon) {
-        return icon;
-    }
-
-    icon = [NSImage imageWithSize:NSMakeSize(kIconWidth, kIconWidth) flipped:NO drawingHandler:^BOOL(NSRect rect) {
-        //shape
-        rect = NSInsetRect(rect, kBorderWidth / 2, kBorderWidth / 2);
-        NSBezierPath* bp = [NSBezierPath bezierPathWithOvalInRect:rect];
-        bp.lineWidth = kBorderWidth;
-
-        //border
-        // code reference for dashed style
-        //CGFloat dashAndGapLength = M_PI * rect.size.width / 8;
-        //CGFloat pattern[2] = { dashAndGapLength * .5, dashAndGapLength * .5 };
-        //[bp setLineDash:pattern count:2 phase:0];
-
-        [NSColor.controlTextColor setStroke];
-        [bp stroke];
-
-        return YES;
-    }];
-    [icon setTemplate:YES];
-
-    return icon;
-}
-
-- (NSImage*)imageForGroup:(NSMutableDictionary*)dict
-{
-    NSImage* icon;
-    if ((icon = dict[@"Icon"])) {
-        return icon;
-    }
-
-    icon = [NSImage discIconWithColor:dict[@"Color"] insetFactor:0];
-
-    dict[@"Icon"] = icon;
-
-    return icon;
 }
 
 - (BOOL)torrent:(Torrent*)torrent doesMatchRulesForGroupAtIndex:(NSInteger)index
@@ -371,17 +406,51 @@ static CGFloat const kIconWidthSmall = 12.0;
     if (![self usesAutoAssignRulesForIndex:index]) {
         return NO;
     }
-
     NSPredicate* predicate = [self autoAssignRulesForIndex:index];
     [predicate allowEvaluation];
     BOOL eval = NO;
     @try {
         eval = [predicate evaluateWithObject:torrent];
     } @catch (NSException* exception) {
-        NSLog(@"Error when evaluating predicate (%@) - %@", predicate, exception);
+        NSLog(@"[GroupsController] Predicate evaluation failed (%@) - %@", predicate, exception);
     } @finally {
         return eval;
     }
+}
+
+#pragma mark - Icon Graphics Rendering
+
+- (NSImage*)imageForGroupNone
+{
+    static NSImage* icon;
+    if (icon)
+        return icon;
+    icon = [NSImage imageWithSize:NSMakeSize(kIconWidth, kIconWidth) flipped:NO drawingHandler:^BOOL(NSRect rect) {
+        rect = NSInsetRect(rect, kBorderWidth / 2, kBorderWidth / 2);
+        NSBezierPath* bp = [NSBezierPath bezierPathWithOvalInRect:rect];
+        bp.lineWidth = kBorderWidth;
+        [NSColor.controlTextColor setStroke];
+        [bp stroke];
+        return YES;
+    }];
+    [icon setTemplate:YES];
+    return icon;
+}
+
+- (NSImage*)imageForGroup:(TRGroup*)group
+{
+    if (group.icon)
+        return group.icon; // Render the crisp round badge matching the group color and cache it inside the model instance
+    NSImage* icon = [NSImage discIconWithColor:group.color insetFactor:0];
+    group.icon = icon;
+    return icon;
+}
+
+- (NSImage*)imageForIndex:(NSInteger)index
+{
+    NSInteger orderIndex = [self rowValueForIndex:index];
+    TRGroup* group = orderIndex != -1 ? self.fGroups[orderIndex] : nil;
+    return [self imageForGroup:group];
 }
 
 @end

--- a/macosx/GroupsController.mm
+++ b/macosx/GroupsController.mm
@@ -13,8 +13,8 @@ static CGFloat const kIconWidthSmall = 12.0;
 @interface TRGroup : NSObject<NSSecureCoding>
 
 @property(nonatomic, assign) NSInteger groupIndex;
-@property(nonatomic, copy) NSString* name;
-@property(nonatomic, strong) NSColor* color;
+@property(nonatomic, copy, null_resettable) NSString* name;
+@property(nonatomic, strong, null_resettable) NSColor* color;
 
 /** Runtime-only cache for the rendered group icon. Ignored during serialization. */
 @property(nonatomic, strong, nullable) NSImage* icon;
@@ -31,6 +31,16 @@ static CGFloat const kIconWidthSmall = 12.0;
 
 @implementation TRGroup
 
+- (void)setName:(nullable NSString*)name
+{
+    _name = name ? [name copy] : @"";
+}
+
+- (void)setColor:(nullable NSColor*)color
+{
+    _color = color ?: NSColor.systemGrayColor;
+}
+
 + (BOOL)supportsSecureCoding
 {
     return YES;
@@ -38,11 +48,10 @@ static CGFloat const kIconWidthSmall = 12.0;
 
 - (instancetype)initWithIndex:(NSInteger)index name:(nullable NSString*)name color:(nullable NSColor*)color
 {
-    self = [super init];
-    if (self) {
+    if ((self = [super init])) {
         _groupIndex = index;
-        _name = [name copy] ?: @"";
-        _color = color ?: NSColor.systemGrayColor;
+        self.name = name;
+        self.color = color;
     }
     return self;
 }
@@ -62,11 +71,11 @@ static CGFloat const kIconWidthSmall = 12.0;
 
 - (instancetype)initWithCoder:(NSCoder*)coder
 {
-    self = [super init];
-    if (self) {
-        _groupIndex = [coder decodeIntegerForKey:@"Index"];
-        _name = [coder decodeObjectOfClass:NSString.class forKey:@"Name"] ?: @"";
-        _color = [coder decodeObjectOfClass:NSColor.class forKey:@"Color"] ?: NSColor.systemGrayColor;
+    auto groupIndex = [coder decodeIntegerForKey:@"Index"];
+    auto name = (NSString*)[coder decodeObjectOfClass:NSString.class forKey:@"Name"];
+    auto color = (NSColor*)[coder decodeObjectOfClass:NSColor.class forKey:@"Color"];
+
+    if ((self = [self initWithIndex:groupIndex name:name color:color])) {
         _usesCustomDownloadLocation = [coder decodeBoolForKey:@"UsesCustomDownloadLocation"];
         _customDownloadLocation = [coder decodeObjectOfClass:NSString.class forKey:@"CustomDownloadLocation"];
         _usesAutoGroupRules = [coder decodeBoolForKey:@"UsesAutoGroupRules"];
@@ -244,7 +253,7 @@ static CGFloat const kIconWidthSmall = 12.0;
         return;
     }
 
-    group.name = name ?: @"";
+    group.name = name;
     [self saveGroupsAndNotify];
 }
 
@@ -262,7 +271,7 @@ static CGFloat const kIconWidthSmall = 12.0;
     }
 
     group.icon = nil; // Invalidate cached icon to force re-render with the new color
-    group.color = color ?: NSColor.systemGrayColor;
+    group.color = color;
     [self saveGroupsAndNotify];
 }
 
@@ -417,11 +426,15 @@ static CGFloat const kIconWidthSmall = 12.0;
             item.image = icon;
         }
         [menu addItem:item];
-    }; // Add the default placeholder item "None" (-1)
-    addItemWithTitleTagIcon(NSLocalizedString(@"None", "Groups -> Menu"), -1, [self imageForGroupNone]); // Populate menu items using the clean object properties
+    };
+
+    // Add the default placeholder item "None" (-1)
+    addItemWithTitleTagIcon(NSLocalizedString(@"None", "Groups -> Menu"), -1, [self imageForGroupNone]);
+
     for (TRGroup* group in self.fGroups) {
         addItemWithTitleTagIcon(group.name, group.groupIndex, [self imageForGroup:group]);
     }
+
     return menu;
 }
 

--- a/macosx/GroupsController.mm
+++ b/macosx/GroupsController.mm
@@ -25,7 +25,7 @@ static CGFloat const kIconWidthSmall = 12.0;
 @property(nonatomic, assign) BOOL usesAutoGroupRules;
 @property(nonatomic, strong, nullable) NSPredicate* autoGroupRules;
 
-- (instancetype)initWithIndex:(NSInteger)index name:(NSString*)name color:(NSColor*)color;
+- (instancetype)initWithIndex:(NSInteger)index name:(nullable NSString*)name color:(nullable NSColor*)color;
 
 @end
 
@@ -36,13 +36,13 @@ static CGFloat const kIconWidthSmall = 12.0;
     return YES;
 }
 
-- (instancetype)initWithIndex:(NSInteger)index name:(NSString*)name color:(NSColor*)color
+- (instancetype)initWithIndex:(NSInteger)index name:(nullable NSString*)name color:(nullable NSColor*)color
 {
     self = [super init];
     if (self) {
         _groupIndex = index;
-        _name = [name copy];
-        _color = color;
+        _name = [name copy] ?: @"";
+        _color = color ?: NSColor.systemGrayColor;
     }
     return self;
 }
@@ -236,7 +236,7 @@ static CGFloat const kIconWidthSmall = 12.0;
     return [self groupForIndex:index].name;
 }
 
-- (void)setName:(NSString*)name forIndex:(NSInteger)index
+- (void)setName:(nullable NSString*)name forIndex:(NSInteger)index
 {
     TRGroup* group = [self groupForIndex:index];
 
@@ -244,7 +244,7 @@ static CGFloat const kIconWidthSmall = 12.0;
         return;
     }
 
-    group.name = name;
+    group.name = name ?: @"";
     [self saveGroupsAndNotify];
 }
 
@@ -253,7 +253,7 @@ static CGFloat const kIconWidthSmall = 12.0;
     return [self groupForIndex:index].color;
 }
 
-- (void)setColor:(NSColor*)color forIndex:(NSInteger)index
+- (void)setColor:(nullable NSColor*)color forIndex:(NSInteger)index
 {
     TRGroup* group = [self groupForIndex:index];
 
@@ -262,7 +262,7 @@ static CGFloat const kIconWidthSmall = 12.0;
     }
 
     group.icon = nil; // Invalidate cached icon to force re-render with the new color
-    group.color = color;
+    group.color = color ?: NSColor.systemGrayColor;
     [self saveGroupsAndNotify];
 }
 

--- a/macosx/GroupsController.mm
+++ b/macosx/GroupsController.mm
@@ -134,15 +134,21 @@ static CGFloat const kIconWidthSmall = 12.0;
         }
         // 2. Backward compatibility: Migrate old untyped dictionaries to TRGroup objects
         else if ((data = [NSUserDefaults.standardUserDefaults dataForKey:@"GroupDicts"])) {
-            NSArray* oldDicts = [NSKeyedUnarchiver unarchivedObjectOfClasses:[NSSet setWithObjects:NSArray.class,
-                                                                                                   NSDictionary.class,
+            NSError* error;
+            NSArray* oldDicts = [NSKeyedUnarchiver unarchivedObjectOfClasses:[NSSet setWithObjects:NSMutableArray.class,
+                                                                                                   NSMutableDictionary.class,
                                                                                                    NSNumber.class,
                                                                                                    NSColor.class,
                                                                                                    NSString.class,
                                                                                                    NSPredicate.class,
                                                                                                    nil]
                                                                     fromData:data
-                                                                       error:nil];
+                                                                       error:&error];
+
+            if (error != nil) {
+                NSLog(@"Got error in groups decoding: %@", error);
+            }
+
             if (oldDicts != nil) {
                 _fGroups = [[NSMutableArray alloc] init];
                 for (NSDictionary* dict in oldDicts) {
@@ -155,9 +161,8 @@ static CGFloat const kIconWidthSmall = 12.0;
                     [_fGroups addObject:g];
                 }
                 [self saveGroups];
+                [NSUserDefaults.standardUserDefaults removeObjectForKey:@"GroupDicts"];
             }
-
-            [NSUserDefaults.standardUserDefaults removeObjectForKey:@"GroupDicts"];
         }
 
         // 3. Fallback: Initialize with default color-coded groups if no saved data exists


### PR DESCRIPTION
### Description
This PR refactors the legacy macOS group management logic by moving away from raw, untyped `NSMutableDictionary` stores toward a robust, strongly-typed `TRGroup` model. 

### Key Changes
* **Type Safety:** Added the `TRGroup` class implementing `NSSecureCoding`, replacing brittle string-keyed dictionaries with compiler-verified properties.
* **Backward Compatibility:** Implemented a seamless migration path in `init` that reads old legacy `GroupDicts` from `NSUserDefaults`, transforms them into `TRGroup` objects, and saves them in the modern format.
* **Performance Optimization:** Introduced `fIndexMap` (`NSMutableDictionary<NSNumber*, NSNumber*>`) to cache Group ID -> Array Index relationships, dropping the time complexity of row index resolution from $O(N)$ linear scans to $O(1)$ lookups.
* **Code Cleanup:** Offloaded icon cache management directly into a runtime-only property inside the model, removing boilerplate dictionary modifications.
