### PR TITLE
perf: move TorrentCell priority updates out of drawRect

### DIFF
--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -266,20 +266,26 @@ static CGFloat const kRevealButtonTrailingOffset = -8.0; // inverted for constra
         // draw progress bar
         NSRect barRect = self.fTorrentProgressBarView.frame;
         [ProgressBarView.sharedInstance drawBarInRect:barRect forTableView:self.fTorrentTableView withTorrent:torrent];
-
-        // set priority icon
-        if (torrent.priority != TR_PRI_NORMAL) {
-            NSImage* priorityImage = [NSImage imageNamed:(torrent.priority == TR_PRI_HIGH ? @"PriorityHighTemplate" : @"PriorityLowTemplate")];
-
-            self.fTorrentPriorityView.image = priorityImage;
-
-            [self.fStackView setVisibilityPriority:NSStackViewVisibilityPriorityMustHold forView:self.fTorrentPriorityView];
-        } else {
-            [self.fStackView setVisibilityPriority:NSStackViewVisibilityPriorityNotVisible forView:self.fTorrentPriorityView];
-        }
     }
 
     [super drawRect:dirtyRect];
+}
+
+- (void)setObjectValue:(id)objectValue {
+    [super setObjectValue:objectValue];
+    [self setTorrentPriority:[(Torrent*)objectValue priority]];
+}
+
+- (void)setTorrentPriority:(tr_priority_t)priority {    
+    if (priority != TR_PRI_NORMAL) {
+        NSImage* priorityImage = [NSImage imageNamed:(priority == TR_PRI_HIGH ? @"PriorityHighTemplate" : @"PriorityLowTemplate")];
+
+        self.fTorrentPriorityView.image = priorityImage;
+
+        [self.fStackView setVisibilityPriority:NSStackViewVisibilityPriorityMustHold forView:self.fTorrentPriorityView];
+    } else {
+        [self.fStackView setVisibilityPriority:NSStackViewVisibilityPriorityNotVisible forView:self.fTorrentPriorityView];
+    }
 }
 
 // otherwise progress bar is inverted

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -279,15 +279,20 @@ static CGFloat const kRevealButtonTrailingOffset = -8.0; // inverted for constra
 
 - (void)setTorrentPriority:(tr_priority_t)priority
 {
-    if (priority != TR_PRI_NORMAL) {
-        NSImage* priorityImage = [NSImage imageNamed:(priority == TR_PRI_HIGH ? @"PriorityHighTemplate" : @"PriorityLowTemplate")];
+    BOOL const hasPriority = priority != TR_PRI_NORMAL;
 
-        self.fTorrentPriorityView.image = priorityImage;
+    NSImage* const image = hasPriority ?
+        [NSImage imageNamed:(priority == TR_PRI_HIGH ? @"PriorityHighTemplate" : @"PriorityLowTemplate")] :
+        nil;
 
-        [self.fStackView setVisibilityPriority:NSStackViewVisibilityPriorityMustHold forView:self.fTorrentPriorityView];
-    } else {
-        [self.fStackView setVisibilityPriority:NSStackViewVisibilityPriorityNotVisible forView:self.fTorrentPriorityView];
+    NSStackViewVisibilityPriority const visibility = hasPriority ? NSStackViewVisibilityPriorityMustHold : NSStackViewVisibilityPriorityNotVisible;
+
+    if (self.fTorrentPriorityView.image == image && [self.fStackView visibilityPriorityForView:self.fTorrentPriorityView] == visibility) {
+        return;
     }
+
+    self.fTorrentPriorityView.image = image;
+    [self.fStackView setVisibilityPriority:visibility forView:self.fTorrentPriorityView];
 }
 
 // otherwise progress bar is inverted

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -271,12 +271,14 @@ static CGFloat const kRevealButtonTrailingOffset = -8.0; // inverted for constra
     [super drawRect:dirtyRect];
 }
 
-- (void)setObjectValue:(id)objectValue {
+- (void)setObjectValue:(id)objectValue
+{
     [super setObjectValue:objectValue];
     [self setTorrentPriority:[(Torrent*)objectValue priority]];
 }
 
-- (void)setTorrentPriority:(tr_priority_t)priority {    
+- (void)setTorrentPriority:(tr_priority_t)priority
+{
     if (priority != TR_PRI_NORMAL) {
         NSImage* priorityImage = [NSImage imageNamed:(priority == TR_PRI_HIGH ? @"PriorityHighTemplate" : @"PriorityLowTemplate")];
 


### PR DESCRIPTION
### Description
Optimized `TorrentCell` by moving the torrent priority UI logic out of the `drawRect:` method.

### Changes
- Removed priority icon state management and image loading from `drawRect:`.
- Added `setObjectValue:` override to capture data updates.
- Introduced `setTorrentPriority:` helper method to update the priority icon and stack view visibility only when the data changes.

### Impact
Improves UI rendering performance and avoids unnecessary stack view layout passes during cell redraws.

Notes: Improved UI code to use less CPU.