### PR TITLE
fix: clang-tidy & test regressions introduced by Qt / GTK interop

### DIFF
--- a/tests/interop/busy-test.sh
+++ b/tests/interop/busy-test.sh
@@ -38,22 +38,27 @@ rpc_port=$((20000 + (RANDOM % 20000)))
 "$DAEMON_BIN" -f -g "$config_dir" --port "$rpc_port" --no-portmap > "$workdir/daemon.log" 2>&1 &
 daemon_pid=$!
 
-# A session takes the config dir lock before it creates the directories it
-# resumes from, so waiting for one of those is waiting for the lock. Asking
-# for the lock here would answer nothing. It is an open-file-description lock,
-# which a separate open in this shell does not contend with.
-held=0
+# settings.json is proof the daemon owns the dir: only a session that owns one
+# saves settings there. Asking for the lock here would answer nothing. It is an
+# open-file-description lock, which a separate open in this shell does not
+# contend with.
+#
+# The launch reads settings.json too. Without one it opens the connection dialog
+# and waits for a user instead of starting the session that finds the dir held.
+# bandwidth-groups.json is the rest of that same save, so waiting for it leaves
+# no startup write to land between the snapshot below and the comparison after.
+ready=0
 for _ in $(seq 1 300); do
-    if [ -d "$config_dir/resume" ]; then
-        held=1
+    if [ -f "$config_dir/settings.json" ] && [ -f "$config_dir/bandwidth-groups.json" ]; then
+        ready=1
         break
     fi
     kill -0 "$daemon_pid" 2> /dev/null || break
     sleep 0.1
 done
 
-if [ "$held" -ne 1 ]; then
-    echo "FAIL: the daemon never took '$config_dir'"
+if [ "$ready" -ne 1 ]; then
+    echo "FAIL: the daemon never settled on '$config_dir'"
     sed -n '1,10p' "$workdir/daemon.log"
     exit 1
 fi

--- a/tests/libtransmission-app/CMakeLists.txt
+++ b/tests/libtransmission-app/CMakeLists.txt
@@ -17,8 +17,8 @@ set_property(
 	TARGET libtransmission-app-test
 	PROPERTY FOLDER "tests")
 
-# interop-test and dbus-peer-record-test use the heavier sandbox fixture from
-# tests/libtransmission/, which reaches libtransmission internals.
+# These tests reach libtransmission internals: the heavier sandbox fixture from
+# tests/libtransmission/, and headers such as net.h that guard on this macro.
 target_compile_definitions(libtransmission-app-test
 	PRIVATE
 		-DLIBTRANSMISSION_TEST_ASSETS_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../libtransmission/assets"

--- a/tests/libtransmission-app/rpc-client-test.cc
+++ b/tests/libtransmission-app/rpc-client-test.cc
@@ -3,8 +3,6 @@
 // or any future license endorsed by Mnemosaic LLC.
 // License text can be found in the licenses/ folder.
 
-#define __TRANSMISSION__ // for libtransmission/net.h
-
 #include <atomic>
 #include <chrono>
 #include <condition_variable>

--- a/tests/libtransmission/completion-test.cc
+++ b/tests/libtransmission/completion-test.cc
@@ -342,7 +342,7 @@ TEST_F(CompletionTest, createPieceBitfield)
     // and test that the new bitfield matches
     auto const pieces_raw_bitfield = completion.create_piece_bitfield();
     tr_bitfield pieces{ size_t{ block_info.piece_count() } };
-    pieces.set_raw(pieces_raw_bitfield);
+    ASSERT_TRUE(pieces.set_raw(pieces_raw_bitfield));
     for (uint64_t i = 0; i < block_info.piece_count(); ++i) {
         EXPECT_EQ(completion.has_piece(i), pieces.test(i));
     }


### PR DESCRIPTION
## Description

Fix clang-tidy warnings and a new test flake introduced by https://github.com/retransmission/retransmission/pull/248.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
