### PR TITLE
ci: remove the "new" label on approval for PRs from forks

### DIFF
--- a/.github/workflows/pr-new-label-approved.yml
+++ b/.github/workflows/pr-new-label-approved.yml
@@ -36,16 +36,23 @@ jobs:
             const { head_sha } = context.payload.workflow_run;
 
             // The triggering run carries no PR number: `workflow_run`
-            // populates `pull_requests` only for same-repo branches.
-            const { data: associated } =
-              await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                owner,
-                repo,
-                commit_sha: head_sha,
-              });
-            const pr = associated.find((pr) => pr.head.sha === head_sha);
+            // populates `pull_requests` only for same-repo branches. Nor can
+            // the head SHA be looked up: a fork PR's head commit is not an
+            // object in this repository, so it has no commit-to-PR
+            // association. The open PR list is the one place a fork's head
+            // SHA is visible from here.
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const pr = prs.find((pr) => pr.head.sha === head_sha);
             if (!pr) {
-              core.setFailed(`No pull request has ${head_sha} as its head.`);
+              // Merged, closed, or pushed to between the approval and this
+              // run. The label only marks open PRs awaiting review, so there
+              // is nothing to do.
+              core.warning(`No open pull request has ${head_sha} as its head.`);
               return;
             }
 


### PR DESCRIPTION
Fixes #246

`GET /repos/{owner}/{repo}/commits/{sha}/pulls` returns nothing for the
head commit of an open pull request from a fork: the commit is not an
object in the base repository, so there is no commit-to-PR association to
find. The label removal therefore failed for every fork PR, and only for
fork PRs — all eight failed runs of the workflow were fork PRs, and every
same-repo approval succeeded.

Spot-checking the endpoint against currently open PRs:

| PR | from a fork? | results |
| --- | --- | --- |
| #279, #275 | no | 1 |
| #278, #276, #268 | yes | 0 |

The open PR list does report a fork's `head.sha`, so scan that instead.
A PR that is no longer open is now a warning rather than a failure: it
was merged, closed, or pushed to between the approval and this run, and
the label only marks open PRs awaiting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)