### PR TITLE
macOS. Migrate deprecated allowedFileTypes to UTType.

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -958,9 +958,11 @@ static auto getSettingsFromNSUserDefaults(NSUserDefaults* defaults)
     didReceiveResponse:(nonnull NSURLResponse*)response
      completionHandler:(nonnull void (^)(NSURLSessionResponseDisposition))completionHandler
 {
-    UTType* contentType = [UTType typeWithMIMEType:response.MIMEType];
+    NSString* mimeType = response.MIMEType;
+    UTType* contentType = mimeType.length > 0 ? [UTType typeWithMIMEType:mimeType] : nil;
     NSString* suggestedName = response.suggestedFilename;
-    UTType* fileType = [UTType typeWithFilenameExtension:suggestedName.pathExtension];
+    NSString* suggestedExtension = suggestedName.pathExtension;
+    UTType* fileType = suggestedExtension.length > 0 ? [UTType typeWithFilenameExtension:suggestedExtension] : nil;
     UTType* torrentType = UTType.torrent;
 
     BOOL isTorrent = [contentType conformsToType:torrentType] || [fileType conformsToType:torrentType];
@@ -986,7 +988,11 @@ static auto getSettingsFromNSUserDefaults(NSUserDefaults* defaults)
         if (mainWindow) {
             [alert beginSheetModalForWindow:mainWindow completionHandler:nil];
         } else {
-            [NSApp activateIgnoringOtherApps:YES];
+            if (@available(macOS 14.0, *)) {
+                [NSApp activate];
+            } else {
+                [NSApp activateIgnoringOtherApps:YES];
+            }
             [alert runModal];
         }
     });

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -62,6 +62,7 @@
 #import "ExpandedPathToIconTransformer.h"
 #import "PowerManager.h"
 #import "Utils.h"
+#import "DefaultAppHelper.h"
 
 typedef NSString* ToolbarItemIdentifier NS_TYPED_EXTENSIBLE_ENUM;
 
@@ -1284,7 +1285,7 @@ static auto getSettingsFromNSUserDefaults(NSUserDefaults* defaults)
     panel.canChooseFiles = YES;
     panel.canChooseDirectories = NO;
 
-    panel.allowedFileTypes = @[ @"org.bittorrent.torrent", @"torrent" ];
+    panel.allowedContentTypes = @[ UTType.torrent ];
 
     [panel beginSheetModalForWindow:self.fWindow completionHandler:^(NSInteger result) {
         if (result == NSModalResponseOK) {
@@ -1875,7 +1876,7 @@ static auto getSettingsFromNSUserDefaults(NSUserDefaults* defaults)
 
     if (!torrent.magnet && [NSFileManager.defaultManager fileExistsAtPath:torrent.torrentLocation]) {
         NSSavePanel* panel = [NSSavePanel savePanel];
-        panel.allowedFileTypes = @[ @"org.bittorrent.torrent", @"torrent" ];
+        panel.allowedContentTypes = @[ UTType.torrent ];
         panel.extensionHidden = NO;
 
         panel.nameFieldStringValue = torrent.name;
@@ -3131,8 +3132,8 @@ static auto getSettingsFromNSUserDefaults(NSUserDefaults* defaults)
 
         NSString* fullFile = [path stringByAppendingPathComponent:file];
 
-        if (!([[NSWorkspace.sharedWorkspace typeOfFile:fullFile error:NULL] isEqualToString:@"org.bittorrent.torrent"] ||
-              [fullFile.pathExtension caseInsensitiveCompare:@"torrent"] == NSOrderedSame)) {
+        auto fileURL = [NSURL fileURLWithPath:fullFile];
+        if (!(fileURL.isTorrentFile)) {
             continue;
         }
 
@@ -3369,8 +3370,7 @@ static auto getSettingsFromNSUserDefaults(NSUserDefaults* defaults)
         NSArray<NSURL*>* files = [pasteboard readObjectsForClasses:@[ NSURL.class ]
                                                            options:@{ NSPasteboardURLReadingFileURLsOnlyKey : @YES }];
         for (NSURL* fileToParse in files) {
-            if ([[NSWorkspace.sharedWorkspace typeOfFile:fileToParse.path error:NULL] isEqualToString:@"org.bittorrent.torrent"] ||
-                [fileToParse.pathExtension caseInsensitiveCompare:@"torrent"] == NSOrderedSame) {
+            if (fileToParse.isTorrentFile) {
                 torrent = YES;
                 auto metainfo = tr_torrent_metainfo{};
                 if (metainfo.parse_torrent_file(fileToParse.path.UTF8String)) {
@@ -3431,8 +3431,7 @@ static auto getSettingsFromNSUserDefaults(NSUserDefaults* defaults)
                                                            options:@{ NSPasteboardURLReadingFileURLsOnlyKey : @YES }];
         NSMutableArray<NSString*>* filesToOpen = [NSMutableArray arrayWithCapacity:files.count];
         for (NSURL* file in files) {
-            if ([[NSWorkspace.sharedWorkspace typeOfFile:file.path error:NULL] isEqualToString:@"org.bittorrent.torrent"] ||
-                [file.pathExtension caseInsensitiveCompare:@"torrent"] == NSOrderedSame) {
+            if (file.isTorrentFile) {
                 torrent = YES;
                 auto metainfo = tr_torrent_metainfo{};
                 if (metainfo.parse_torrent_file(file.path.UTF8String)) {

--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -958,11 +958,18 @@ static auto getSettingsFromNSUserDefaults(NSUserDefaults* defaults)
     didReceiveResponse:(nonnull NSURLResponse*)response
      completionHandler:(nonnull void (^)(NSURLSessionResponseDisposition))completionHandler
 {
+    UTType* contentType = [UTType typeWithMIMEType:response.MIMEType];
     NSString* suggestedName = response.suggestedFilename;
-    if ([suggestedName.pathExtension caseInsensitiveCompare:@"torrent"] == NSOrderedSame) {
+    UTType* fileType = [UTType typeWithFilenameExtension:suggestedName.pathExtension];
+    UTType* torrentType = UTType.torrent;
+
+    BOOL isTorrent = [contentType conformsToType:torrentType] || [fileType conformsToType:torrentType];
+
+    if (isTorrent) {
         completionHandler(NSURLSessionResponseBecomeDownload);
         return;
     }
+
     completionHandler(NSURLSessionResponseCancel);
 
     NSString* message = [NSString
@@ -974,7 +981,14 @@ static auto getSettingsFromNSUserDefaults(NSUserDefaults* defaults)
         [alert addButtonWithTitle:NSLocalizedString(@"OK", "Download not a torrent -> button")];
         alert.messageText = NSLocalizedString(@"Torrent download failed", "Download not a torrent -> title");
         alert.informativeText = message;
-        [alert runModal];
+
+        NSWindow* mainWindow = NSApp.mainWindow ?: NSApp.keyWindow;
+        if (mainWindow) {
+            [alert beginSheetModalForWindow:mainWindow completionHandler:nil];
+        } else {
+            [NSApp activateIgnoringOtherApps:YES];
+            [alert runModal];
+        }
     });
 }
 

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -18,6 +18,7 @@
 #import "CreatorWindowController.h"
 #import "Controller.h"
 #import "NSStringAdditions.h"
+#import "DefaultAppHelper.h"
 
 typedef NS_ENUM(NSUInteger, TrackerSegmentTag) {
     TrackerSegmentTagAdd = 0,
@@ -163,8 +164,9 @@ static NSMutableSet* creatorWindowControllerSet;
 
     auto const is_folder = self.fBuilder->file_count() > 1 || tr_strv_contains(self.fBuilder->path(0), '/');
 
-    NSImage* icon = [NSWorkspace.sharedWorkspace
-        iconForFileType:is_folder ? NSFileTypeForHFSTypeCode(kGenericFolderIcon) : self.fPath.pathExtension];
+    auto fileType = [UTType contentTypeForFilenameExtension:self.fPath.pathExtension isFolder:is_folder];
+
+    NSImage* icon = [NSWorkspace.sharedWorkspace iconForContentType:fileType];
     icon.size = self.fIconView.frame.size;
     self.fIconView.image = icon;
 
@@ -261,7 +263,7 @@ static NSMutableSet* creatorWindowControllerSet;
     panel.prompt = NSLocalizedString(@"Select", "Create torrent -> location sheet -> button");
     panel.message = NSLocalizedString(@"Select the name and location for the torrent file.", "Create torrent -> location sheet -> message");
 
-    panel.allowedFileTypes = @[ @"org.bittorrent.torrent", @"torrent" ];
+    panel.allowedContentTypes = @[ UTType.torrent ];
     panel.canSelectHiddenExtension = YES;
 
     panel.directoryURL = self.fLocation.URLByDeletingLastPathComponent;

--- a/macosx/CreatorWindowController.mm
+++ b/macosx/CreatorWindowController.mm
@@ -167,6 +167,7 @@ static NSMutableSet* creatorWindowControllerSet;
     auto fileType = [UTType contentTypeForFilenameExtension:self.fPath.pathExtension isFolder:is_folder];
 
     NSImage* icon = [NSWorkspace.sharedWorkspace iconForContentType:fileType];
+    icon = [icon copy];
     icon.size = self.fIconView.frame.size;
     self.fIconView.image = icon;
 

--- a/macosx/DefaultAppHelper.h
+++ b/macosx/DefaultAppHelper.h
@@ -3,6 +3,18 @@
 // License text can be found in the licenses/ folder.
 
 #import <Foundation/Foundation.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UTType (Torrent)
+@property(class, readonly, strong, nonnull) UTType* torrent;
++ (UTType*)contentTypeForFilenameExtension:(NSString*)fileExtension isFolder:(BOOL)isFolder;
+@end
+
+@interface NSURL (Torrent)
+@property(nonatomic, readonly) BOOL isTorrentFile;
+@end
 
 @interface DefaultAppHelper : NSObject
 
@@ -13,3 +25,5 @@
 - (void)setDefaultForMagnetURLs:(void (^_Nullable)())completionHandler;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/macosx/DefaultAppHelper.mm
+++ b/macosx/DefaultAppHelper.mm
@@ -45,21 +45,13 @@ static NSString* const kTorrentFileType = @"org.bittorrent.torrent";
     if ([self getResourceValue:&contentType forKey:NSURLContentTypeKey error:NULL] && contentType) {
         return [contentType conformsToType:UTType.torrent];
     }
-    return NO;
+
+    // LaunchServices resolves .torrent to another declared type when a different
+    // client owns it, and to a dynamic UTI when nothing is registered yet,
+    // so the extension stays authoritative.
+    return [self.pathExtension caseInsensitiveCompare:@"torrent"] == NSOrderedSame;
 }
 @end
-
-UTType* GetTorrentFileType(void)
-{
-    static UTType* result = nil;
-
-    static dispatch_once_t once;
-    dispatch_once(&once, ^{
-        result = [UTType exportedTypeWithIdentifier:kTorrentFileType conformingToType:UTTypeData];
-    });
-
-    return result;
-}
 
 @interface DefaultAppHelper ()
 

--- a/macosx/DefaultAppHelper.mm
+++ b/macosx/DefaultAppHelper.mm
@@ -10,6 +10,45 @@
 static NSString* const kMagnetURLScheme = @"magnet";
 static NSString* const kTorrentFileType = @"org.bittorrent.torrent";
 
+@implementation UTType (Torrent)
++ (UTType*)torrent
+{
+    static UTType* result = nil;
+
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        result = [UTType exportedTypeWithIdentifier:kTorrentFileType conformingToType:UTTypeData];
+    });
+
+    return result;
+}
+
++ (UTType*)contentTypeForFilenameExtension:(NSString*)fileExtension isFolder:(BOOL)isFolder
+{
+    if (isFolder) {
+        return UTTypeFolder;
+    }
+
+    UTType* fileType = nil;
+    if (fileExtension.length > 0) {
+        fileType = [UTType typeWithFilenameExtension:fileExtension];
+    }
+
+    return fileType ?: UTTypeData;
+}
+@end
+
+@implementation NSURL (Torrent)
+- (BOOL)isTorrentFile
+{
+    UTType* contentType = nil;
+    if ([self getResourceValue:&contentType forKey:NSURLContentTypeKey error:NULL] && contentType) {
+        return [contentType conformsToType:UTType.torrent];
+    }
+    return NO;
+}
+@end
+
 UTType* GetTorrentFileType(void)
 {
     static UTType* result = nil;
@@ -40,7 +79,7 @@ UTType* GetTorrentFileType(void)
 
 - (BOOL)isDefaultForTorrentFiles
 {
-    UTType* fileType = GetTorrentFileType();
+    auto fileType = UTType.torrent;
     NSURL* appUrl = [NSWorkspace.sharedWorkspace URLForApplicationToOpenContentType:fileType];
     if (!appUrl) {
         return NO;
@@ -57,7 +96,7 @@ UTType* GetTorrentFileType(void)
 
 - (void)setDefaultForTorrentFiles:(void (^_Nullable)())completionHandler
 {
-    UTType* fileType = GetTorrentFileType();
+    auto fileType = UTType.torrent;
     NSURL* appUrl = [NSWorkspace.sharedWorkspace URLForApplicationWithBundleIdentifier:self.bundleIdentifier];
     [NSWorkspace.sharedWorkspace setDefaultApplicationAtURL:appUrl toOpenContentType:fileType completionHandler:^(NSError* error) {
         if (error) {

--- a/macosx/DragOverlayWindow.mm
+++ b/macosx/DragOverlayWindow.mm
@@ -7,6 +7,7 @@
 #import "NSStringAdditions.h"
 
 #include <libtransmission/torrent-metainfo.h>
+#import "DefaultAppHelper.h"
 
 @interface DragOverlayWindow ()
 
@@ -58,8 +59,8 @@
     NSUInteger fileCount = 0;
 
     for (NSString* file in files) {
-        if ([[NSWorkspace.sharedWorkspace typeOfFile:file error:NULL] isEqualToString:@"org.bittorrent.torrent"] ||
-            [file.pathExtension caseInsensitiveCompare:@"torrent"] == NSOrderedSame) {
+        auto fileURL = [NSURL fileURLWithPath:file];
+        if (fileURL.isTorrentFile) {
             auto metainfo = tr_torrent_metainfo{};
             if (metainfo.parse_torrent_file(file.UTF8String)) {
                 ++count;
@@ -98,8 +99,8 @@
 
     NSImage* icon;
     if (count == 1) {
-        icon = [NSWorkspace.sharedWorkspace
-            iconForFileType:fileCount <= 1 ? name.pathExtension : NSFileTypeForHFSTypeCode(kGenericFolderIcon)];
+        auto fileType = [UTType contentTypeForFilenameExtension:name.pathExtension isFolder:fileCount <= 1];
+        icon = [NSWorkspace.sharedWorkspace iconForContentType:fileType];
     } else {
         name = [NSString localizedStringWithFormat:NSLocalizedString(@"%lu Torrent Files", "Drag overlay -> torrents"), count];
         secondString = [secondString stringByAppendingString:@" total"];

--- a/macosx/DragOverlayWindow.mm
+++ b/macosx/DragOverlayWindow.mm
@@ -99,7 +99,7 @@
 
     NSImage* icon;
     if (count == 1) {
-        auto fileType = [UTType contentTypeForFilenameExtension:name.pathExtension isFolder:fileCount <= 1];
+        auto fileType = [UTType contentTypeForFilenameExtension:name.pathExtension isFolder:fileCount > 1];
         icon = [NSWorkspace.sharedWorkspace iconForContentType:fileType];
     } else {
         name = [NSString localizedStringWithFormat:NSLocalizedString(@"%lu Torrent Files", "Drag overlay -> torrents"), count];

--- a/macosx/ExpandedPathToIconTransformer.mm
+++ b/macosx/ExpandedPathToIconTransformer.mm
@@ -9,6 +9,7 @@
 #endif
 
 #import "ExpandedPathToIconTransformer.h"
+#import "DefaultAppHelper.h"
 
 @implementation ExpandedPathToIconTransformer
 
@@ -29,13 +30,10 @@
     }
 
     NSString* path = [value stringByExpandingTildeInPath];
-    NSImage* icon;
     //show a folder icon if the folder doesn't exist
-    if ([path.pathExtension isEqualToString:@""] && ![NSFileManager.defaultManager fileExistsAtPath:path]) {
-        icon = [NSWorkspace.sharedWorkspace iconForFileType:NSFileTypeForHFSTypeCode(kGenericFolderIcon)];
-    } else {
-        icon = [NSWorkspace.sharedWorkspace iconForFile:path];
-    }
+    auto isFolder = [path.pathExtension isEqualToString:@""] && ![NSFileManager.defaultManager fileExistsAtPath:path];
+    auto contentType = [UTType contentTypeForFilenameExtension:path isFolder:isFolder];
+    NSImage* icon = [NSWorkspace.sharedWorkspace iconForContentType:contentType];
 
     icon.size = NSMakeSize(16.0, 16.0);
 

--- a/macosx/ExpandedPathToIconTransformer.mm
+++ b/macosx/ExpandedPathToIconTransformer.mm
@@ -30,11 +30,17 @@
     }
 
     NSString* path = [value stringByExpandingTildeInPath];
-    //show a folder icon if the folder doesn't exist
-    auto isFolder = [path.pathExtension isEqualToString:@""] && ![NSFileManager.defaultManager fileExistsAtPath:path];
-    auto contentType = [UTType contentTypeForFilenameExtension:path isFolder:isFolder];
-    NSImage* icon = [NSWorkspace.sharedWorkspace iconForContentType:contentType];
+    NSImage* icon;
+    if ([NSFileManager.defaultManager fileExistsAtPath:path]) {
+        icon = [NSWorkspace.sharedWorkspace iconForFile:path];
+    } else {
+        //show a folder icon if the path has no extension
+        auto isFolder = path.pathExtension.length == 0;
+        auto contentType = [UTType contentTypeForFilenameExtension:path.pathExtension isFolder:isFolder];
+        icon = [NSWorkspace.sharedWorkspace iconForContentType:contentType];
+    }
 
+    icon = [icon copy];
     icon.size = NSMakeSize(16.0, 16.0);
 
     return icon;

--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -2,6 +2,8 @@
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+
 #include <libtransmission/log.h>
 #include <libtransmission/file.h>
 #include <libtransmission/string-utils.h>
@@ -433,7 +435,7 @@ static NSUInteger const kMaxQueueLength = 10000U;
 - (void)writeToFile:(id)sender
 {
     NSSavePanel* panel = [NSSavePanel savePanel];
-    panel.allowedContentTypes = @[ UTTypeText ];
+    panel.allowedContentTypes = @[ UTTypePlainText ];
     panel.canSelectHiddenExtension = YES;
 
     panel.nameFieldStringValue = NSLocalizedString(@"untitled", "Save log panel -> default file name");

--- a/macosx/MessageWindowController.mm
+++ b/macosx/MessageWindowController.mm
@@ -433,7 +433,7 @@ static NSUInteger const kMaxQueueLength = 10000U;
 - (void)writeToFile:(id)sender
 {
     NSSavePanel* panel = [NSSavePanel savePanel];
-    panel.allowedFileTypes = @[ @"txt" ];
+    panel.allowedContentTypes = @[ UTTypeText ];
     panel.canSelectHiddenExtension = YES;
 
     panel.nameFieldStringValue = NSLocalizedString(@"untitled", "Save log panel -> default file name");

--- a/macosx/Torrent.mm
+++ b/macosx/Torrent.mm
@@ -20,6 +20,7 @@
 #import "NSStringAdditions.h"
 #import "TrackerNode.h"
 #import "Utils.h"
+#import "DefaultAppHelper.h"
 
 using tr::Values::Speed;
 
@@ -618,8 +619,8 @@ static tr_torrent_rename_done_func makeRenameDoneCallback(NSDictionary* contextI
     }
 
     if (!self.fIcon) {
-        self.fIcon = self.folder ? [NSImage imageNamed:NSImageNameFolder] :
-                                   [NSWorkspace.sharedWorkspace iconForFileType:self.name.pathExtension];
+        auto contentType = [UTType contentTypeForFilenameExtension:self.name.pathExtension isFolder:self.folder];
+        self.fIcon = [NSWorkspace.sharedWorkspace iconForContentType:contentType];
     }
     return self.fIcon;
 }


### PR DESCRIPTION
## Description

This PR migrates the macOS-specific file type handling from the deprecated `allowedFileTypes` and `typeOfFile` APIs to the modern `UTType` and `allowedContentTypes` infrastructure introduced in macOS 11+.

## Changes
- Replaced `allowedFileTypes` array strings with `UTType.torrent` and `UTTypeText` in panels.
- Refactored file type detection in `Controller`, `DragOverlayWindow`, and `ExpandedPathToIconTransformer` to leverage the new helper properties.
- Extended `UTType` and `NSURL` via categories in `DefaultAppHelper` to provide robust, uniform torrent file classification.

## Motivation and Context
The older `allowedFileTypes` methods are deprecated by Apple. Moving to `UTType` ensures forward compatibility with newer macOS versions, eliminates hardcoded uniform type identifier strings across multiple files, and improves type-safety.

## How Has This Been Tested?
- Verified that opening and saving `.torrent` files works via dialog sheets.
- Verified that drag-and-drop actions properly identify torrent files and directories.