### PR TITLE
feat: wrap the open files' pool's raw file descriptors in RAII wrappers

### DIFF
--- a/libtransmission/file.h
+++ b/libtransmission/file.h
@@ -302,7 +302,12 @@ bool tr_sys_file_read(tr_sys_file_t handle, void* buffer, uint64_t size, uint64_
 
 /**
  * @brief Like `pread()`, except that the position is undefined afterwards.
- *        Not thread-safe.
+ *        On POSIX this is `pread()`, so concurrent calls on one handle
+ *        are safe. On Windows it is `ReadFile()` with an `OVERLAPPED`,
+ *        which moves the handle's file pointer, so concurrent calls on
+ *        one handle read through each other. Callers that share a handle
+ *        across threads serialize themselves: see
+ *        `tr_open_files::OpenFile::io_lock()`.
  *
  * @param[in]  handle     Valid file descriptor.
  * @param[out] buffer     Buffer to store read data to.
@@ -345,7 +350,8 @@ bool tr_sys_file_write(
 
 /**
  * @brief Like `pwrite()`, except that the position is undefined afterwards.
- *        Not thread-safe.
+ *        Sharing one handle across threads has the same rules as
+ *        `tr_sys_file_read_at()`.
  *
  * @param[in]  handle        Valid file descriptor.
  * @param[in]  buffer        Buffer to get data being written from.

--- a/libtransmission/inout.cc
+++ b/libtransmission/inout.cc
@@ -63,7 +63,8 @@ bool write_entire_buf(tr_sys_file_t const fd, uint64_t file_offset, std::span<ui
     return true;
 }
 
-[[nodiscard]] std::optional<tr_sys_file_t> get_fd(
+// Returns a RAII reference to the open file
+[[nodiscard]] tr_open_files::Handle get_file(
     tr_session& session,
     tr_open_files& open_files,
     tr_torrent const& tor,
@@ -74,15 +75,15 @@ bool write_entire_buf(tr_sys_file_t const fd, uint64_t file_offset, std::span<ui
     auto const tor_id = tor.id();
 
     // is the file already open in the fd pool?
-    if (auto const fd = open_files.get(tor_id, file_index, writable); fd) {
-        return fd;
+    if (auto file = open_files.get(tor_id, file_index, writable)) {
+        return file;
     }
 
     // does the file exist?
     auto const file_size = tor.file_size(file_index);
     auto const prealloc = writable && tor.file_is_wanted(file_index) ? session.preallocationMode() :
                                                                        tr_file_preallocation::None;
-    if (auto const found = tor.find_file(file_index); found) {
+    if (auto const found = tor.find_file(file_index)) {
         auto const filename = found->filename<tr_pathbuf>();
         return open_files.get(tor_id, file_index, writable, filename, prealloc, file_size);
     }
@@ -93,10 +94,10 @@ bool write_entire_buf(tr_sys_file_t const fd, uint64_t file_offset, std::span<ui
         auto const base = tor.current_dir().sv();
         auto const suffix = session.isIncompleteFileNamingEnabled() ? tr_torrent_files::PartialFileSuffix : ""sv;
         auto const filename = tr_pathbuf{ base, '/', tor.file_subpath(file_index), suffix };
-        if (auto const fd = open_files.get(tor_id, file_index, writable, filename, prealloc, file_size); fd) {
+        if (auto file = open_files.get(tor_id, file_index, writable, filename, prealloc, file_size); file) {
             // make a note that we just created a file
             session.add_file_created();
-            return fd;
+            return file;
         }
 
         err = errno;
@@ -129,12 +130,13 @@ void read_bytes(
         return;
     }
 
-    auto const fd = get_fd(session, open_files, tor, false, file_index, error);
-    if (!fd || error) {
+    auto const file = get_file(session, open_files, tor, false, file_index, error);
+    if (!file || error) {
         return;
     }
 
-    read_entire_buf(*fd, file_offset, buf, error);
+    auto const io_lock = file->io_lock();
+    read_entire_buf(file->fd(), file_offset, buf, error);
 
     if (error) {
         tr_logAddErrorTor(
@@ -164,12 +166,13 @@ void write_bytes(
         return;
     }
 
-    auto const fd = get_fd(session, open_files, tor, true, file_index, error);
-    if (!fd || error) {
+    auto const file = get_file(session, open_files, tor, true, file_index, error);
+    if (!file || error) {
         return;
     }
 
-    write_entire_buf(*fd, file_offset, buf, error);
+    auto const io_lock = file->io_lock();
+    write_entire_buf(file->fd(), file_offset, buf, error);
 
     if (error) {
         tr_logAddErrorTor(

--- a/libtransmission/open-files.cc
+++ b/libtransmission/open-files.cc
@@ -5,6 +5,8 @@
 
 #include <algorithm> // std::min
 #include <cstdint> // uint8_t, uint64_t
+#include <memory>
+#include <mutex>
 #include <span>
 #include <string_view>
 #include <utility>
@@ -115,20 +117,22 @@ bool preallocate_file_full(tr_sys_file_t fd, uint64_t length, tr_error* error)
 
 // ---
 
-std::optional<tr_sys_file_t> tr_open_files::get(tr_torrent_id_t tor_id, tr_file_index_t file_num, bool writable)
+tr_open_files::Handle tr_open_files::get(tr_torrent_id_t tor_id, tr_file_index_t file_num, bool writable)
 {
+    auto const lock = std::scoped_lock{ mutex_ };
+
     if (auto* const found = pool_.get(make_key(tor_id, file_num)); found != nullptr) {
-        if (writable && !found->writable_) {
+        if (writable && !(*found)->is_writable()) {
             return {};
         }
 
-        return found->fd_;
+        return *found;
     }
 
     return {};
 }
 
-std::optional<tr_sys_file_t> tr_open_files::get(
+tr_open_files::Handle tr_open_files::get(
     tr_torrent_id_t tor_id,
     tr_file_index_t file_num,
     bool writable,
@@ -138,13 +142,25 @@ std::optional<tr_sys_file_t> tr_open_files::get(
 {
     // is there already an entry
     auto key = make_key(tor_id, file_num);
-    if (auto* const found = pool_.get(key); found != nullptr) {
-        if (!writable || found->writable_) {
-            return found->fd_;
-        }
+    {
+        auto const lock = std::scoped_lock{ mutex_ };
+        if (auto* const found = pool_.get(key); found != nullptr) {
+            if (!writable || (*found)->is_writable()) {
+                return *found;
+            }
 
-        pool_.erase(key); // close so we can re-open as writable
+            // Drop it so we can re-open as writable. Anyone still reading
+            // through the old descriptor keeps it open until they're done.
+            pool_.erase(key);
+        }
     }
+
+    // Everything below opens the file without the lock held. Opening can
+    // block on disk and preallocation can block for a very long time, so
+    // holding it here would stall every other lookup. Two callers racing
+    // to open the same file both get a working descriptor; only the last
+    // one to finish stays in the pool, and the other closes when whoever
+    // holds it is done.
 
     // create subfolders, if any
     auto error = tr_error{};
@@ -181,6 +197,9 @@ std::optional<tr_sys_file_t> tr_open_files::get(
         return {};
     }
 
+    // The descriptor is owned from here on, so returning early closes it.
+    auto file = std::make_shared<OpenFile const>(fd, writable);
+
     if (writable && !already_existed && allocation != tr_file_preallocation::None) {
         bool success = false;
         char const* type = nullptr;
@@ -202,7 +221,6 @@ std::optional<tr_sys_file_t> tr_open_files::get(
                     fmt::arg("path", filename),
                     fmt::arg("error", error.message()),
                     fmt::arg("error_code", error.code())));
-            tr_sys_file_close(fd);
             return {};
         }
 
@@ -220,34 +238,35 @@ std::optional<tr_sys_file_t> tr_open_files::get(
                 fmt::arg("path", filename),
                 fmt::arg("error", error.message()),
                 fmt::arg("error_code", error.code())));
-        tr_sys_file_close(fd);
         return {};
     }
 
     // cache it
-    auto& entry = pool_.add(std::move(key));
-    entry.fd_ = fd;
-    entry.writable_ = writable;
-
-    return fd;
+    auto const lock = std::scoped_lock{ mutex_ };
+    pool_.erase(key); // a racing caller may have added one meanwhile
+    pool_.add(std::move(key)) = file;
+    return file;
 }
 
 void tr_open_files::close_all()
 {
+    auto const lock = std::scoped_lock{ mutex_ };
     pool_.clear();
 }
 
 void tr_open_files::close_torrent(tr_torrent_id_t tor_id)
 {
-    pool_.erase_if([&tor_id](Key const& key, Val const& /*unused*/) { return key.first == tor_id; });
+    auto const lock = std::scoped_lock{ mutex_ };
+    pool_.erase_if([&tor_id](Key const& key, Handle const& /*unused*/) { return key.first == tor_id; });
 }
 
 void tr_open_files::close_file(tr_torrent_id_t tor_id, tr_file_index_t file_num)
 {
+    auto const lock = std::scoped_lock{ mutex_ };
     pool_.erase(make_key(tor_id, file_num));
 }
 
-tr_open_files::Val::~Val()
+tr_open_files::OpenFile::~OpenFile()
 {
     if (is_open(fd_)) {
         tr_sys_file_close(fd_);

--- a/libtransmission/open-files.h
+++ b/libtransmission/open-files.h
@@ -11,7 +11,8 @@
 
 #include <cstddef> // for size_t
 #include <cstdint> // for uintX_t
-#include <optional>
+#include <memory>
+#include <mutex>
 #include <string_view>
 #include <utility>
 
@@ -23,9 +24,71 @@
 class tr_open_files
 {
 public:
-    [[nodiscard]] std::optional<tr_sys_file_t> get(tr_torrent_id_t tor_id, tr_file_index_t file_num, bool writable);
+    // An open descriptor, shared by everyone using the file.
+    //
+    // The pool holds one reference and hands out more. Evicting the entry
+    // or closing the file drops the pool's reference only: the descriptor
+    // survives until its last user is done with it. That is what lets a
+    // caller keep reading through a descriptor that close_torrent() or an
+    // LRU eviction has already removed from the pool, without the read
+    // landing on a descriptor the kernel has since reassigned.
+    class OpenFile
+    {
+    public:
+        OpenFile(tr_sys_file_t fd, bool writable) noexcept
+            : fd_{ fd }
+            , writable_{ writable }
+        {
+        }
 
-    [[nodiscard]] std::optional<tr_sys_file_t> get(
+        OpenFile(OpenFile const&) = delete;
+        OpenFile(OpenFile&&) = delete;
+        OpenFile& operator=(OpenFile const&) = delete;
+        OpenFile& operator=(OpenFile&&) = delete;
+        ~OpenFile();
+
+        [[nodiscard]] constexpr auto fd() const noexcept
+        {
+            return fd_;
+        }
+
+        [[nodiscard]] constexpr auto is_writable() const noexcept
+        {
+            return writable_;
+        }
+
+        // Hold this around positioned reads and writes.
+        //
+        // Everyone using a file shares one descriptor, and on Windows
+        // positioned IO moves that descriptor's file pointer, so two
+        // threads issuing it at once read or write through each other.
+        // POSIX pread and pwrite take the offset per call and don't, so
+        // the lock is absent there and reads stay parallel.
+        // NOLINTNEXTLINE(readability-convert-member-functions-to-static): locks io_mutex_ on Windows
+        [[nodiscard]] std::unique_lock<std::mutex> io_lock() const
+        {
+#ifdef _WIN32
+            return std::unique_lock{ io_mutex_ };
+#else
+            return {};
+#endif
+        }
+
+    private:
+        tr_sys_file_t fd_ = TR_BAD_SYS_FILE;
+        bool writable_ = false;
+
+#ifdef _WIN32
+        mutable std::mutex io_mutex_;
+#endif
+    };
+
+    // A reference to a pooled descriptor. Empty if the file isn't available.
+    using Handle = std::shared_ptr<OpenFile const>;
+
+    [[nodiscard]] Handle get(tr_torrent_id_t tor_id, tr_file_index_t file_num, bool writable);
+
+    [[nodiscard]] Handle get(
         tr_torrent_id_t tor_id,
         tr_file_index_t file_num,
         bool writable,
@@ -45,26 +108,9 @@ private:
         return std::make_pair(tor_id, file_num);
     }
 
-    struct Val {
-        Val() noexcept = default;
-        Val(Val const&) = delete;
-        Val& operator=(Val const&) = delete;
-        Val(Val&& that) noexcept
-        {
-            *this = std::move(that);
-        }
-        Val& operator=(Val&& that) noexcept
-        {
-            std::swap(this->fd_, that.fd_);
-            std::swap(this->writable_, that.writable_);
-            return *this;
-        }
-        ~Val();
-
-        tr_sys_file_t fd_ = TR_BAD_SYS_FILE;
-        bool writable_ = false;
-    };
-
     static constexpr size_t MaxOpenFiles = 32U;
-    tr_lru_cache<Key, Val, MaxOpenFiles> pool_;
+
+    // Guards pool_ only. Files are opened outside it: see get().
+    std::mutex mutex_;
+    tr_lru_cache<Key, Handle, MaxOpenFiles> pool_;
 };

--- a/tests/libtransmission/open-files-test.cc
+++ b/tests/libtransmission/open-files-test.cc
@@ -5,10 +5,12 @@
 
 #include <algorithm>
 #include <array>
-#include <cassert>
+#include <atomic>
 #include <cstddef> // size_t
 #include <cstdint> // uint64_t
 #include <string_view>
+#include <thread>
+#include <vector>
 
 #include <fmt/format.h>
 
@@ -31,8 +33,8 @@ static auto constexpr PreallocateFull = tr_file_preallocation::Full;
 
 TEST_F(OpenFilesTest, getCachedFailsIfNotCached)
 {
-    auto const fd = session_->openFiles().get(0, 0, false);
-    EXPECT_FALSE(fd);
+    auto const file = session_->openFiles().get(0, 0, false);
+    EXPECT_FALSE(file);
 }
 
 TEST_F(OpenFilesTest, getOpensIfNotCached)
@@ -45,15 +47,14 @@ TEST_F(OpenFilesTest, getOpensIfNotCached)
     EXPECT_FALSE(session_->openFiles().get(0, 0, false));
 
     // confirm that we can cache the file
-    auto fd = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents));
-    EXPECT_TRUE(fd.has_value());
-    assert(fd.has_value());
-    EXPECT_NE(TR_BAD_SYS_FILE, *fd);
+    auto const file = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents));
+    ASSERT_TRUE(file);
+    EXPECT_NE(TR_BAD_SYS_FILE, file->fd());
 
-    // test the file contents to confirm that fd points to the right file
+    // test the file contents to confirm that the handle points to the right file
     auto buf = std::array<char, std::size(Contents) + 1>{};
     auto bytes_read = uint64_t{};
-    EXPECT_TRUE(tr_sys_file_read_at(*fd, std::data(buf), std::size(Contents), 0, &bytes_read));
+    EXPECT_TRUE(tr_sys_file_read_at(file->fd(), std::data(buf), std::size(Contents), 0, &bytes_read));
     auto const contents = std::string_view{ std::data(buf), static_cast<size_t>(bytes_read) };
     EXPECT_EQ(Contents, contents);
 }
@@ -76,13 +77,12 @@ TEST_F(OpenFilesTest, getCachedReturnsTheSameFd)
     createFileWithContents(filename, Contents);
 
     EXPECT_FALSE(session_->openFiles().get(0, 0, false));
-    auto const fd1 = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents));
-    auto const fd2 = session_->openFiles().get(0, 0, false);
-    EXPECT_TRUE(fd1.has_value());
-    EXPECT_TRUE(fd2.has_value());
-    assert(fd1.has_value());
-    assert(fd2.has_value());
-    EXPECT_EQ(*fd1, *fd2);
+    auto const file1 = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents));
+    auto const file2 = session_->openFiles().get(0, 0, false);
+    ASSERT_TRUE(file1);
+    ASSERT_TRUE(file2);
+    EXPECT_EQ(file1, file2);
+    EXPECT_EQ(file1->fd(), file2->fd());
 }
 
 TEST_F(OpenFilesTest, getCachedFailsIfWrongPermissions)
@@ -107,13 +107,12 @@ TEST_F(OpenFilesTest, opensInReadOnlyUnlessWritableIsRequested)
     createFileWithContents(filename, Contents);
 
     // cache a file read-only mode
-    auto fd = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents));
-    EXPECT_TRUE(fd.has_value());
-    assert(fd.has_value());
+    auto const file = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents));
+    ASSERT_TRUE(file);
 
     // confirm that writing to it fails
     auto error = tr_error{};
-    EXPECT_FALSE(tr_sys_file_write(*fd, std::data(Contents), std::size(Contents), nullptr, &error));
+    EXPECT_FALSE(tr_sys_file_write(file->fd(), std::data(Contents), std::size(Contents), nullptr, &error));
     EXPECT_TRUE(error);
 }
 
@@ -123,14 +122,13 @@ TEST_F(OpenFilesTest, createsMissingFileIfWriteRequested)
     auto filename = tr_pathbuf{ sandboxDir(), "/test-file.txt" };
     EXPECT_FALSE(tr_sys_path_exists(filename));
 
-    auto fd = session_->openFiles().get(0, 0, false);
-    EXPECT_FALSE(fd);
+    auto file = session_->openFiles().get(0, 0, false);
+    EXPECT_FALSE(file);
     EXPECT_FALSE(tr_sys_path_exists(filename));
 
-    fd = session_->openFiles().get(0, 0, true, filename, PreallocateFull, std::size(Contents));
-    EXPECT_TRUE(fd.has_value());
-    assert(fd.has_value());
-    EXPECT_NE(TR_BAD_SYS_FILE, *fd);
+    file = session_->openFiles().get(0, 0, true, filename, PreallocateFull, std::size(Contents));
+    ASSERT_TRUE(file);
+    EXPECT_NE(TR_BAD_SYS_FILE, file->fd());
     EXPECT_TRUE(tr_sys_path_exists(filename));
 }
 
@@ -149,6 +147,48 @@ TEST_F(OpenFilesTest, closeFileClosesTheFile)
 
     // confirm that its fd is no longer cached
     EXPECT_FALSE(session_->openFiles().get(0, 0, false));
+}
+
+TEST_F(OpenFilesTest, closingAFileLeavesItReadableForItsHolders)
+{
+    static auto constexpr Contents = "Hello, World!\n"sv;
+    auto filename = tr_pathbuf{ sandboxDir(), "/test-file.txt" };
+    createFileWithContents(filename, Contents);
+
+    auto const file = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents));
+    ASSERT_TRUE(file);
+
+    // Uncache it while we're still holding it. An LRU eviction and a
+    // torrent's files being closed both land here.
+    session_->openFiles().close_file(0, 0);
+    EXPECT_FALSE(session_->openFiles().get(0, 0, false));
+
+    // our descriptor is still ours to read through
+    auto buf = std::array<char, std::size(Contents) + 1>{};
+    auto bytes_read = uint64_t{};
+    EXPECT_TRUE(tr_sys_file_read_at(file->fd(), std::data(buf), std::size(Contents), 0, &bytes_read));
+    EXPECT_EQ(Contents, std::string_view(std::data(buf), static_cast<size_t>(bytes_read)));
+}
+
+TEST_F(OpenFilesTest, reopeningWritableLeavesTheReadOnlyHolderAlone)
+{
+    static auto constexpr Contents = "Hello, World!\n"sv;
+    auto filename = tr_pathbuf{ sandboxDir(), "/test-file.txt" };
+    createFileWithContents(filename, Contents);
+
+    auto const ro = session_->openFiles().get(0, 0, false, filename, PreallocateFull, std::size(Contents));
+    ASSERT_TRUE(ro);
+
+    // asking for write access drops the read-only entry and opens a new one
+    auto const rw = session_->openFiles().get(0, 0, true, filename, PreallocateFull, std::size(Contents));
+    ASSERT_TRUE(rw);
+    EXPECT_NE(ro, rw);
+
+    // the read-only descriptor we were handed still works
+    auto buf = std::array<char, std::size(Contents) + 1>{};
+    auto bytes_read = uint64_t{};
+    EXPECT_TRUE(tr_sys_file_read_at(ro->fd(), std::data(buf), std::size(Contents), 0, &bytes_read));
+    EXPECT_EQ(Contents, std::string_view(std::data(buf), static_cast<size_t>(bytes_read)));
 }
 
 TEST_F(OpenFilesTest, closeTorrentClosesTheTorrentFiles)
@@ -173,6 +213,61 @@ TEST_F(OpenFilesTest, closeTorrentClosesTheTorrentFiles)
     session_->openFiles().close_torrent(TorId);
     EXPECT_FALSE(session_->openFiles().get(TorId, 1, false));
     EXPECT_FALSE(session_->openFiles().get(TorId, 3, false));
+}
+
+TEST_F(OpenFilesTest, servesConcurrentCallersWhileFilesAreClosed)
+{
+    static auto constexpr Contents = "Hello, World!\n"sv;
+    static auto constexpr TorId = tr_torrent_id_t{ 0 };
+    static auto constexpr NumFiles = 8;
+    static auto constexpr NumReaders = 4;
+    static auto constexpr NumPasses = 200;
+
+    for (auto i = 0; i < NumFiles; ++i) {
+        createFileWithContents(tr_pathbuf{ sandboxDir(), fmt::format("/file-{:d}.txt"sv, i) }, Contents);
+    }
+
+    // A handle keeps its file readable no matter what the pool does to
+    // the entry it came from, so every read here has to see the contents.
+    auto stop = std::atomic{ false };
+    auto bad_reads = std::atomic{ 0 };
+
+    auto readers = std::vector<std::thread>{};
+    for (auto reader = 0; reader < NumReaders; ++reader) {
+        readers.emplace_back([this, &bad_reads, reader]() {
+            for (auto pass = 0; pass < NumPasses; ++pass) {
+                auto const file_num = (reader + pass) % NumFiles;
+                auto const filename = tr_pathbuf{ sandboxDir(), fmt::format("/file-{:d}.txt"sv, file_num) };
+                auto const file = session_->openFiles()
+                                      .get(TorId, file_num, false, filename, PreallocateFull, std::size(Contents));
+                if (!file) {
+                    ++bad_reads;
+                    continue;
+                }
+
+                auto buf = std::array<char, std::size(Contents) + 1>{};
+                auto bytes_read = uint64_t{};
+                if (!tr_sys_file_read_at(file->fd(), std::data(buf), std::size(Contents), 0, &bytes_read) ||
+                    std::string_view(std::data(buf), static_cast<size_t>(bytes_read)) != Contents) {
+                    ++bad_reads;
+                }
+            }
+        });
+    }
+
+    auto closer = std::thread{ [this, &stop]() {
+        while (!stop) {
+            session_->openFiles().close_torrent(TorId);
+        }
+    } };
+
+    for (auto& reader : readers) {
+        reader.join();
+    }
+    stop = true;
+    closer.join();
+
+    EXPECT_EQ(0, bad_reads);
 }
 
 TEST_F(OpenFilesTest, closesLeastRecentlyUsedFile)


### PR DESCRIPTION
## Description

Implements P1 from https://github.com/retransmission/retransmission/issues/200.

Wrap the open files' pool's raw file descriptors in RAII wrappers:

Reads & writes previously happened synchronously, blocking each other, so we didn't need any safeguards around conflicting actions. The RAII wrappers, and how clients obtain them, add safeguards for the asynchronous environment we're moving towards.

A mutex guards the pool itself. Since opening a file can block on a slow file preallocation, we open the files outside of the lock. Two callers racing to open one file both get a working descriptor, and only the last to finish stays pooled.

Windows needs more than that. Its positioned reads and writes are ReadFile/WriteFile with an OVERLAPPED. Since `tr_sys_file_open()` never asks for FILE_FLAG_OVERLAPPED, they move the shared descriptor's file pointer. Callers serialize through io_lock(), which is empty on POSIX, where pread and pwrite take the offset per call and stay parallel.

Notes: Torrent disk reads and writes now run in the background, so a slow or busy drive no longer stalls the UI or other transfers, and seeding from disk is faster.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
