### PR TITLE
Move error badge rendering from table view to torrent cell.

### DIFF
--- a/macosx/SmallTorrentCell.mm
+++ b/macosx/SmallTorrentCell.mm
@@ -151,6 +151,11 @@ static CGFloat const kButtonsSpacing = 3.0;
     ]];
 }
 
+- (void)setAnyErrorOrWarning:(BOOL)errorOrWarning
+{
+    // nothing to do. we use iconView for error status.
+}
+
 // show fControlButton and fRevealButton
 - (void)mouseEntered:(NSEvent*)event
 {

--- a/macosx/TorrentCell.h
+++ b/macosx/TorrentCell.h
@@ -32,4 +32,6 @@
 - (void)configurePriorities;
 - (void)setupConstraints;
 
+- (void)setAnyErrorOrWarning:(BOOL)errorOrWarning;
+
 @end

--- a/macosx/TorrentCell.mm
+++ b/macosx/TorrentCell.mm
@@ -35,6 +35,13 @@ static CGFloat const kButtonSize = 14.0;
 static CGFloat const kButtonsSpacing = 3.0;
 static CGFloat const kRevealButtonTrailingOffset = -8.0; // inverted for constraints.
 
+// Error status
+static CGFloat const kErrorImageSize = 20.0;
+
+@interface TorrentCell ()
+@property(nonatomic, readonly) NSImageView* errorImageView;
+@end
+
 @implementation TorrentCell
 
 - (instancetype)initWithFrame:(NSRect)frameRect
@@ -307,6 +314,28 @@ static CGFloat const kRevealButtonTrailingOffset = -8.0; // inverted for constra
 
     NSColor* priorityColor = backgroundStyle == NSBackgroundStyleEmphasized ? NSColor.whiteColor : NSColor.labelColor;
     self.fTorrentPriorityView.contentTintColor = priorityColor;
+}
+
+- (void)setAnyErrorOrWarning:(BOOL)errorOrWarning
+{
+    if (errorOrWarning) {
+        if (_errorImageView == nil) {
+            _errorImageView = [[NSImageView alloc] init];
+            _errorImageView.imageScaling = NSImageScaleProportionallyDown;
+            _errorImageView.image = [NSImage imageNamed:NSImageNameCaution];
+            [self.fIconView addSubview:_errorImageView];
+            _errorImageView.translatesAutoresizingMaskIntoConstraints = NO;
+
+            [NSLayoutConstraint activateConstraints:@[
+                [_errorImageView.leadingAnchor constraintEqualToAnchor:self.fIconView.centerXAnchor],
+                [_errorImageView.topAnchor constraintEqualToAnchor:self.fIconView.centerYAnchor],
+                [_errorImageView.widthAnchor constraintEqualToConstant:kErrorImageSize],
+                [_errorImageView.heightAnchor constraintEqualToConstant:kErrorImageSize],
+            ]];
+        }
+    }
+
+    _errorImageView.hidden = !errorOrWarning;
 }
 
 @end

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -245,28 +245,8 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
             torrentCell.fTorrentProgressField.stringValue = torrent.progressString;
 
             // set torrent icon and error badge
-            NSImage* fileImage = torrent.icon;
-            if (error) {
-                NSRect frame = torrentCell.fIconView.frame;
-                NSImage* resultImage = [[NSImage alloc] initWithSize:frame.size];
-                [resultImage lockFocus];
-
-                // draw fileImage
-                [fileImage drawAtPoint:NSZeroPoint fromRect:NSZeroRect operation:NSCompositingOperationSourceOver fraction:1.0];
-
-                // overlay error badge
-                NSImage* errorImage = [NSImage imageNamed:NSImageNameCaution];
-                NSRect const errorRect = NSMakeRect(frame.origin.x, 0, kErrorImageSize, kErrorImageSize);
-                [errorImage drawInRect:errorRect fromRect:NSZeroRect operation:NSCompositingOperationSourceOver fraction:1.0
-                        respectFlipped:YES
-                                 hints:nil];
-
-                [resultImage unlockFocus];
-
-                torrentCell.fIconView.image = resultImage;
-            } else {
-                torrentCell.fIconView.image = fileImage;
-            }
+            [torrentCell setAnyErrorOrWarning:error];
+            torrentCell.fIconView.image = torrent.icon;
 
             // set torrent status
             NSString* status;


### PR DESCRIPTION
## Description
This PR refactors the error badge rendering logic for torrent rows in the macOS client. 

Previously, `TorrentTableView` manually drew the caution badge directly onto the torrent's icon image using focus-locking drawing operations. This approach has been replaced by delegating the error state management to the cells via a new method `-setAnyErrorOrWarning:`. 

`TorrentCell` now manages an internal `NSImageView` (`_errorImageView`) overlayed using modern Auto Layout constraints. `SmallTorrentCell` implements a stub for this method since it handles error status representation via its main icon view.

## Changes
- **TorrentCell.h / .mm**: Added `-setAnyErrorOrWarning:` method and implemented dynamic initialization and layout constraints for `_errorImageView`.
- **SmallTorrentCell.mm**: Implemented an empty stub for `-setAnyErrorOrWarning:` to conform to the shared interface.
- **TorrentTableView.mm**: Simplified the row configuration by removing legacy image-drawing code and replacing it with the new cell method call.

## Type of Change
- [x] Refactoring (non-breaking change which improves code structure)

## Verification
- Verified that the error badge (`NSImageNameCaution`) appears correctly positioned over the torrent icon when a torrent encounters an error.
- Verified that the badge disappears when the error state is cleared.
- Checked that `SmallTorrentCell` does not crash or layout incorrectly during state updates.