### PR TITLE
gitignore: ignore local LSP and compiler cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ compile_commands.json
 
 # CMake user presets
 CMakeUserPresets.json
+
+# Cache
+.cache


### PR DESCRIPTION
### Description

This PR enables `CMAKE_EXPORT_COMPILE_COMMANDS` to generate `compile_commands.json`. This is required for language servers like `clangd` and `clang-tidy` to work properly in editors like Sublime Text.

It also adds the `.cache` directory to `.gitignore` to prevent tracking local LSP/compiler cache files.

### Changes

- Set `CMAKE_EXPORT_COMPILE_COMMANDS` to `ON` in `CMakeLists.txt`.
- Added `.cache` to `.gitignore`.
