### PR TITLE
perf: Optimize group ratio toggle

### DIFF
--- a/macosx/GroupCell.h
+++ b/macosx/GroupCell.h
@@ -7,12 +7,11 @@
 
 @interface GroupCell : NSTableCellView
 
-@property(nonatomic) NSImageView* fGroupIndicatorView;
-@property(nonatomic) NSTextField* fGroupTitleField;
+@property(nonatomic) NSImageView* indicatorView;
+@property(nonatomic) NSTextField* titleField;
 
-@property(nonatomic) NSImageView* fGroupDownloadView;
-@property(nonatomic) NSImageView* fGroupUploadAndRatioView;
-@property(nonatomic) NSTextField* fGroupDownloadField;
-@property(nonatomic) NSTextField* fGroupUploadAndRatioField;
+- (void)setDownloadSpeed:(CGFloat)downloadSpeed uploadSpeed:(CGFloat)uploadSpeed ratio:(CGFloat)ratio;
+- (void)setDisplayRatio:(BOOL)displayRatio;
+- (void)setTooltipForTorrentsCount:(NSUInteger)count;
 
 @end

--- a/macosx/GroupCell.mm
+++ b/macosx/GroupCell.mm
@@ -3,6 +3,14 @@
 // License text can be found in the licenses/ folder.
 
 #import "GroupCell.h"
+#import "NSStringAdditions.h"
+
+@interface GroupCell ()
+@property(nonatomic, readonly) NSStackView* stackView;
+@property(nonatomic, readonly) NSButton* downloadButton;
+@property(nonatomic, readonly) NSButton* uploadButton;
+@property(nonatomic, readonly) NSButton* ratioButton;
+@end
 
 @implementation GroupCell
 
@@ -20,90 +28,78 @@
 {
     auto indicatorView = [[NSImageView alloc] init];
     indicatorView.imageScaling = NSImageScaleProportionallyDown;
-    self.fGroupIndicatorView = indicatorView;
 
     auto titleField = [[NSTextField alloc] init];
+    titleField.editable = NO;
+    titleField.selectable = NO;
+    titleField.bordered = NO;
+    titleField.font = [NSFont boldSystemFontOfSize:NSFont.smallSystemFontSize];
+    titleField.drawsBackground = NO;
     titleField.textColor = NSColor.secondaryLabelColor;
     titleField.lineBreakMode = NSLineBreakByTruncatingMiddle;
-    self.fGroupTitleField = titleField;
     titleField.allowsExpansionToolTips = YES;
 
-    auto downloadView = [[NSImageView alloc] init];
-    downloadView.imageScaling = NSImageScaleProportionallyDown;
-    self.fGroupDownloadView = downloadView;
+    auto downloadButton = [NSButton buttonWithTitle:@"" image:[NSImage imageNamed:@"DownArrowGroupTemplate"] target:nil action:nil];
+    downloadButton.toolTip = NSLocalizedString(@"Download speed", "Torrent table -> group row -> tooltip");
 
-    auto downloadField = [[NSTextField alloc] init];
-    downloadField.textColor = NSColor.secondaryLabelColor;
-    downloadField.lineBreakMode = NSLineBreakByClipping;
-    self.fGroupDownloadField = downloadField;
+    auto uploadButton = [NSButton buttonWithTitle:@"" image:[NSImage imageNamed:@"UpArrowGroupTemplate"] target:nil action:nil];
+    uploadButton.toolTip = NSLocalizedString(@"Upload speed", "Torrent table -> group row -> tooltip");
+    uploadButton.image.accessibilityDescription = NSLocalizedString(@"UL", "Torrent -> status image");
 
-    auto uploadAndRatioView = [[NSImageView alloc] init];
-    uploadAndRatioView.imageScaling = NSImageScaleProportionallyDown;
-    self.fGroupUploadAndRatioView = uploadAndRatioView;
+    auto ratioButton = [NSButton buttonWithTitle:@"" image:[NSImage imageNamed:@"YingYangGroupTemplate"] target:nil action:nil];
+    ratioButton.toolTip = NSLocalizedString(@"Ratio", "Torrent table -> group row -> tooltip");
+    ratioButton.image.accessibilityDescription = NSLocalizedString(@"Ratio", "Torrent -> status image");
 
-    auto uploadAndRatioField = [[NSTextField alloc] init];
-    uploadAndRatioField.textColor = NSColor.secondaryLabelColor;
-    uploadAndRatioField.lineBreakMode = NSLineBreakByClipping;
-    self.fGroupUploadAndRatioField = uploadAndRatioField;
-
-    for (NSTextField* view in @[ titleField, downloadField, uploadAndRatioField ]) {
-        view.editable = NO;
-        view.selectable = NO;
-        view.bordered = NO;
-        view.font = [NSFont boldSystemFontOfSize:NSFont.smallSystemFontSize];
-        view.drawsBackground = NO;
+    for (NSButton* button in @[ downloadButton, uploadButton, ratioButton ]) {
+        button.imageScaling = NSImageScaleProportionallyDown;
+        button.imagePosition = NSImageLeft;
+        button.bordered = NO;
+        button.font = [NSFont boldSystemFontOfSize:NSFont.smallSystemFontSize];
+        button.contentTintColor = NSColor.secondaryLabelColor;
+        button.lineBreakMode = NSLineBreakByClipping;
     }
 
-    for (NSView* view in @[ indicatorView, titleField, downloadView, downloadField, uploadAndRatioView, uploadAndRatioField ]) {
+    auto stackView = [[NSStackView alloc] initWithFrame:NSZeroRect];
+
+    [stackView addArrangedSubview:downloadButton];
+    [stackView addArrangedSubview:uploadButton];
+    [stackView addArrangedSubview:ratioButton];
+
+    for (NSView* view in @[ indicatorView, titleField, stackView ]) {
         view.translatesAutoresizingMaskIntoConstraints = NO;
         [self addSubview:view];
     }
+
+    _indicatorView = indicatorView;
+    _titleField = titleField;
+    _downloadButton = downloadButton;
+    _uploadButton = uploadButton;
+    _ratioButton = ratioButton;
+    _stackView = stackView;
 }
 
 - (void)setupConstraints
 {
     [NSLayoutConstraint activateConstraints:@[
         // IndicatorView
-        [self.fGroupIndicatorView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:11],
-        [self.fGroupIndicatorView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-        [self.fGroupIndicatorView.widthAnchor constraintEqualToConstant:14],
-        [self.fGroupIndicatorView.heightAnchor constraintEqualToConstant:14],
+        [self.indicatorView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:11],
+        [self.indicatorView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [self.indicatorView.widthAnchor constraintEqualToConstant:14],
+        [self.indicatorView.heightAnchor constraintEqualToConstant:14],
 
         // TitleField
-        [self.fGroupTitleField.leadingAnchor constraintEqualToAnchor:self.fGroupIndicatorView.trailingAnchor constant:5],
-        [self.fGroupTitleField.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [self.titleField.leadingAnchor constraintEqualToAnchor:self.indicatorView.trailingAnchor constant:5],
+        [self.titleField.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
 
-        // DownloadView
-        [self.fGroupTitleField.trailingAnchor constraintEqualToAnchor:self.fGroupDownloadView.leadingAnchor],
-        [self.fGroupDownloadView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-        [self.fGroupDownloadView.widthAnchor constraintEqualToConstant:16],
-        [self.fGroupDownloadView.heightAnchor constraintEqualToConstant:16],
-
-        // DownloadField
-        [self.fGroupDownloadView.trailingAnchor constraintEqualToAnchor:self.fGroupDownloadField.leadingAnchor],
-        [self.fGroupDownloadField.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-        [self.fGroupDownloadField.widthAnchor constraintGreaterThanOrEqualToConstant:60],
-
-        // UploadAndRatioView
-        [self.fGroupUploadAndRatioView.leadingAnchor constraintEqualToAnchor:self.fGroupDownloadField.trailingAnchor constant:8],
-        [self.fGroupUploadAndRatioView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-        [self.fGroupUploadAndRatioView.widthAnchor constraintEqualToConstant:16],
-        [self.fGroupUploadAndRatioView.heightAnchor constraintEqualToConstant:16],
-
-        // UploadAndRatioField
-        [self.fGroupUploadAndRatioField.leadingAnchor constraintEqualToAnchor:self.fGroupUploadAndRatioView.trailingAnchor],
-        [self.fGroupUploadAndRatioField.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-5],
-        [self.fGroupUploadAndRatioField.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-        [self.fGroupUploadAndRatioField.widthAnchor constraintGreaterThanOrEqualToConstant:60],
+        // StackView
+        [self.stackView.leadingAnchor constraintGreaterThanOrEqualToAnchor:self.titleField.trailingAnchor],
+        [self.stackView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-5],
+        [self.stackView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+        [self.stackView.heightAnchor constraintEqualToConstant:16],
     ]];
 
-    [self.fGroupTitleField setContentCompressionResistancePriority:NSLayoutPriorityDefaultLow
-                                                    forOrientation:NSLayoutConstraintOrientationHorizontal];
-
-    [self.fGroupDownloadField setContentHuggingPriority:NSLayoutPriorityDefaultLow + 1
-                                         forOrientation:NSLayoutConstraintOrientationHorizontal];
-    [self.fGroupUploadAndRatioField setContentHuggingPriority:NSLayoutPriorityDefaultLow + 1
-                                               forOrientation:NSLayoutConstraintOrientationHorizontal];
+    [self.titleField setContentCompressionResistancePriority:NSLayoutPriorityDefaultLow
+                                              forOrientation:NSLayoutConstraintOrientationHorizontal];
 }
 
 - (void)setBackgroundStyle:(NSBackgroundStyle)backgroundStyle
@@ -111,7 +107,33 @@
     [super setBackgroundStyle:backgroundStyle];
 
     auto isEmphasized = backgroundStyle == NSBackgroundStyleEmphasized;
-    self.fGroupTitleField.textColor = isEmphasized ? NSColor.labelColor : NSColor.secondaryLabelColor;
+    self.titleField.textColor = isEmphasized ? NSColor.labelColor : NSColor.secondaryLabelColor;
+}
+
+- (void)setDownloadSpeed:(CGFloat)downloadSpeed uploadSpeed:(CGFloat)uploadSpeed ratio:(CGFloat)ratio
+{
+    _downloadButton.title = [NSString stringForSpeed:downloadSpeed];
+    _uploadButton.title = [NSString stringForSpeed:uploadSpeed];
+    _ratioButton.title = [NSString stringForRatio:ratio];
+}
+
+- (void)setDisplayRatio:(BOOL)displayRatio
+{
+    _downloadButton.hidden = displayRatio;
+    _uploadButton.hidden = displayRatio;
+    _ratioButton.hidden = !displayRatio;
+}
+
+- (void)setTooltipForTorrentsCount:(NSUInteger)count
+{
+    NSString* tooltipGroup;
+    if (count == 1) {
+        tooltipGroup = NSLocalizedString(@"1 transfer", "Torrent table -> group row -> tooltip");
+    } else {
+        tooltipGroup = NSLocalizedString(@"%lu transfers", "Torrent table -> group row -> tooltip");
+        tooltipGroup = [NSString localizedStringWithFormat:tooltipGroup, count];
+    }
+    self.toolTip = tooltipGroup;
 }
 
 @end

--- a/macosx/TorrentGroup.h
+++ b/macosx/TorrentGroup.h
@@ -6,6 +6,12 @@
 
 @class Torrent;
 
+@interface TorrentGroupData : NSObject
+@property(nonatomic, readonly) CGFloat ratio;
+@property(nonatomic, readonly) CGFloat uploadRate;
+@property(nonatomic, readonly) CGFloat downloadRate;
+@end
+
 @interface TorrentGroup : NSObject
 
 - (instancetype)initWithGroup:(NSInteger)group;
@@ -17,5 +23,7 @@
 @property(nonatomic, readonly) CGFloat ratio;
 @property(nonatomic, readonly) CGFloat uploadRate;
 @property(nonatomic, readonly) CGFloat downloadRate;
+
+@property(nonatomic, readonly) TorrentGroupData* aggregatedData;
 
 @end

--- a/macosx/TorrentGroup.mm
+++ b/macosx/TorrentGroup.mm
@@ -8,6 +8,23 @@
 #import "GroupsController.h"
 #import "Torrent.h"
 
+@interface TorrentGroupData ()
+- (instancetype)initWithRatio:(CGFloat)ratio uploadRate:(CGFloat)uploadRate downloadRate:(CGFloat)downloadRate;
+@end
+
+@implementation TorrentGroupData
+- (instancetype)initWithRatio:(CGFloat)ratio uploadRate:(CGFloat)uploadRate downloadRate:(CGFloat)downloadRate
+{
+    self = [super init];
+    if (self) {
+        _ratio = ratio;
+        _uploadRate = uploadRate;
+        _downloadRate = downloadRate;
+    }
+    return self;
+}
+@end
+
 @implementation TorrentGroup
 
 - (instancetype)initWithGroup:(NSInteger)group
@@ -58,6 +75,29 @@
     }
 
     return rate;
+}
+
+- (TorrentGroupData*)aggregatedData
+{
+    uint64_t uploaded = 0;
+    uint64_t total_size = 0;
+
+    CGFloat uploadRate = 0.0;
+
+    CGFloat downloadRate = 0.0;
+
+    for (Torrent* torrent in self.torrents) {
+        uploaded += torrent.uploadedTotal;
+        total_size += torrent.totalSizeSelected;
+
+        downloadRate += torrent.downloadRate;
+        uploadRate += torrent.uploadRate;
+    }
+
+    CGFloat ratio = tr_getRatio(uploaded, total_size);
+
+    auto result = [[TorrentGroupData alloc] initWithRatio:ratio uploadRate:uploadRate downloadRate:downloadRate];
+    return result;
 }
 
 @end

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -609,9 +609,25 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
 - (void)toggleGroupRowRatio
 {
-    BOOL displayGroupRowRatio = [self.fDefaults boolForKey:@"DisplayGroupRowRatio"];
-    [self.fDefaults setBool:!displayGroupRowRatio forKey:@"DisplayGroupRowRatio"];
-    [self reloadVisibleRows];
+    BOOL updatedDisplayGroupRowRatio = ![self.fDefaults boolForKey:@"DisplayGroupRowRatio"];
+    [self.fDefaults setBool:updatedDisplayGroupRowRatio forKey:@"DisplayGroupRowRatio"];
+
+    if (![self.fDefaults boolForKey:@"SortByGroup"]) {
+        return;
+    }
+
+    NSRange visibleRows = [self rowsInRect:self.visibleRect];
+
+    for (NSUInteger i = 0; i < visibleRows.length; ++i) {
+        NSUInteger row = visibleRows.location + i;
+
+        id item = [self itemAtRow:row];
+
+        if ([item isKindOfClass:[TorrentGroup class]]) {
+            GroupCell* groupCell = (GroupCell*)[self viewAtColumn:0 row:row makeIfNecessary:NO];
+            [groupCell setDisplayRatio:updatedDisplayGroupRowRatio];
+        }
+    }
 }
 
 - (IBAction)toggleControlForTorrent:(id)sender

--- a/macosx/TorrentTableView.mm
+++ b/macosx/TorrentTableView.mm
@@ -321,53 +321,20 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
         NSColor* groupColor = groupIndex != -1 ? [GroupsController.groups colorForIndex:groupIndex] :
                                                  [NSColor colorWithWhite:1.0 alpha:0];
-        groupCell.fGroupIndicatorView.image = [NSImage discIconWithColor:groupColor insetFactor:0];
+        groupCell.indicatorView.image = [NSImage discIconWithColor:groupColor insetFactor:0];
 
         NSString* groupName = groupIndex != -1 ? [GroupsController.groups nameForIndex:groupIndex] :
                                                  NSLocalizedString(@"No Group", "Group table row");
 
-        groupCell.fGroupTitleField.stringValue = groupName;
+        groupCell.titleField.stringValue = groupName;
 
-        groupCell.fGroupDownloadField.stringValue = [NSString stringForSpeed:group.downloadRate];
-        groupCell.fGroupDownloadView.image = [NSImage imageNamed:@"DownArrowGroupTemplate"];
-
-        NSString* tooltipDownload = NSLocalizedString(@"Download speed", "Torrent table -> group row -> tooltip");
-        groupCell.fGroupDownloadField.toolTip = tooltipDownload;
-        groupCell.fGroupDownloadView.toolTip = tooltipDownload;
+        auto aggregatedData = group.aggregatedData;
+        [groupCell setDownloadSpeed:aggregatedData.downloadRate uploadSpeed:aggregatedData.uploadRate ratio:aggregatedData.ratio];
 
         BOOL displayGroupRowRatio = [self.fDefaults boolForKey:@"DisplayGroupRowRatio"];
-        groupCell.fGroupDownloadField.hidden = displayGroupRowRatio;
-        groupCell.fGroupDownloadView.hidden = displayGroupRowRatio;
+        [groupCell setDisplayRatio:displayGroupRowRatio];
 
-        if (displayGroupRowRatio) {
-            groupCell.fGroupUploadAndRatioView.image = [NSImage imageNamed:@"YingYangGroupTemplate"];
-            groupCell.fGroupUploadAndRatioView.image.accessibilityDescription = NSLocalizedString(@"Ratio", "Torrent -> status image");
-
-            groupCell.fGroupUploadAndRatioField.stringValue = [NSString stringForRatio:group.ratio];
-
-            NSString* tooltipRatio = NSLocalizedString(@"Ratio", "Torrent table -> group row -> tooltip");
-            groupCell.fGroupUploadAndRatioField.toolTip = tooltipRatio;
-            groupCell.fGroupUploadAndRatioView.toolTip = tooltipRatio;
-        } else {
-            groupCell.fGroupUploadAndRatioView.image = [NSImage imageNamed:@"UpArrowGroupTemplate"];
-            groupCell.fGroupUploadAndRatioView.image.accessibilityDescription = NSLocalizedString(@"UL", "Torrent -> status image");
-
-            groupCell.fGroupUploadAndRatioField.stringValue = [NSString stringForSpeed:group.uploadRate];
-
-            NSString* tooltipUpload = NSLocalizedString(@"Upload speed", "Torrent table -> group row -> tooltip");
-            groupCell.fGroupUploadAndRatioField.toolTip = tooltipUpload;
-            groupCell.fGroupUploadAndRatioView.toolTip = tooltipUpload;
-        }
-
-        NSString* tooltipGroup;
-        NSUInteger count = group.torrents.count;
-        if (count == 1) {
-            tooltipGroup = NSLocalizedString(@"1 transfer", "Torrent table -> group row -> tooltip");
-        } else {
-            tooltipGroup = NSLocalizedString(@"%lu transfers", "Torrent table -> group row -> tooltip");
-            tooltipGroup = [NSString localizedStringWithFormat:tooltipGroup, count];
-        }
-        groupCell.toolTip = tooltipGroup;
+        [groupCell setTooltipForTorrentsCount:group.torrents.count];
 
         return groupCell;
     }
@@ -785,7 +752,7 @@ static NSTimeInterval const kToggleProgressSeconds = 0.175;
 
     //check if click is within the status/ratio rect
     GroupCell* groupCell = [self viewAtColumn:0 row:row makeIfNecessary:NO];
-    NSRect titleRect = groupCell.fGroupTitleField.frame;
+    NSRect titleRect = groupCell.titleField.frame;
     CGFloat maxX = NSMaxX(titleRect);
 
     return point.x > maxX;


### PR DESCRIPTION
## Description

This PR optimizes the `toggleGroupRowRatio` method in `TorrentTableView`. Instead of triggering a full `reloadVisibleRows` which refreshes all visible rows regardless of their type, the updated logic now targets only the visible `TorrentGroup` rows and updates their cells directly.

## Changes

- Replaced the heavy `[self reloadVisibleRows]` call with a selective loop over visible rows.
- Added a guard clause to return early if `SortByGroup` is disabled.
- Dynamically fetches and updates `GroupCell` instances using `setDisplayRatio:` for currently visible group items.

## Performance Impact

Reduces UI overhead when toggling the group row ratio, as non-group cells are no longer unnecessarily reloaded.
