### PR TITLE
refactor: remove redundant makeKeyWindow calls on mouse down.

### DIFF
--- a/macosx/Controller.mm
+++ b/macosx/Controller.mm
@@ -653,8 +653,6 @@ static auto getSettingsFromNSUserDefaults(NSUserDefaults* defaults)
 
     [nc addObserver:self selector:@selector(updateForExpandCollapse) name:@"OutlineExpandCollapse" object:nil];
 
-    [nc addObserver:self.fWindow selector:@selector(makeKeyWindow) name:@"MakeWindowKey" object:nil];
-
     [nc addObserver:self selector:@selector(fullUpdateUI) name:@"UpdateTorrentsState" object:nil];
 
     [nc addObserver:self selector:@selector(applyFilter) name:@"ApplyFilter" object:nil];

--- a/macosx/FileOutlineView.mm
+++ b/macosx/FileOutlineView.mm
@@ -2,11 +2,8 @@
 // It may be used under the MIT (SPDX: MIT) license.
 // License text can be found in the licenses/ folder.
 
-#import "InfoWindowController.h"
-#import "FileListNode.h"
 #import "BaseFileNameCellView.h"
 #import "FileOutlineView.h"
-#import "Torrent.h"
 
 @interface FileOutlineView ()
 

--- a/macosx/FileOutlineView.mm
+++ b/macosx/FileOutlineView.mm
@@ -22,12 +22,6 @@
     self.indentationPerLevel = 14.0;
 }
 
-- (void)mouseDown:(NSEvent*)event
-{
-    [self.window makeKeyWindow];
-    [super mouseDown:event];
-}
-
 - (NSMenu*)menuForEvent:(NSEvent*)event
 {
     NSInteger const row = [self rowAtPoint:[self convertPoint:event.locationInWindow fromView:nil]];

--- a/macosx/InfoTrackersViewController.mm
+++ b/macosx/InfoTrackersViewController.mm
@@ -281,8 +281,6 @@ typedef NS_ENUM(NSInteger, TrackerSegmentTag) {
 
 - (void)addTrackers
 {
-    [self.view.window makeKeyWindow];
-
     NSAssert1(self.fTorrents.count == 1, @"Attempting to add tracker with %ld transfers selected", self.fTorrents.count);
 
     [self.fTrackers addObject:@{ @"Tier" : @-1 }];

--- a/macosx/InfoWindowController.mm
+++ b/macosx/InfoWindowController.mm
@@ -89,7 +89,9 @@ typedef NS_ENUM(NSUInteger, TabTag) {
     windowRect.size.height = windowHeight;
     [window setFrame:windowRect display:NO];
 
-    // Let inspector gain keyboard focus when clicked on non-interactive areas
+    // Any click makes the inspector the key window.
+    // Table views return NO from needsPanelToBecomeKey.
+    // Without this, the file, tracker and web seedlists would not focus it.
     window.becomesKeyOnlyIfNeeded = NO;
 
     //disable green maximise window button

--- a/macosx/InfoWindowController.mm
+++ b/macosx/InfoWindowController.mm
@@ -91,7 +91,7 @@ typedef NS_ENUM(NSUInteger, TabTag) {
 
     // Any click makes the inspector the key window.
     // Table views return NO from needsPanelToBecomeKey.
-    // Without this, the file, tracker and web seedlists would not focus it.
+    // Without this, the file, tracker and web seed lists would not focus it.
     window.becomesKeyOnlyIfNeeded = NO;
 
     //disable green maximise window button

--- a/macosx/TrackerTableView.mm
+++ b/macosx/TrackerTableView.mm
@@ -8,12 +8,6 @@
 
 @implementation TrackerTableView
 
-- (void)mouseDown:(NSEvent*)event
-{
-    [self.window makeKeyWindow];
-    [super mouseDown:event];
-}
-
 - (void)copy:(id)sender
 {
     NSMutableArray* addresses = [NSMutableArray arrayWithCapacity:self.trackers.count];

--- a/macosx/WebSeedTableView.mm
+++ b/macosx/WebSeedTableView.mm
@@ -6,12 +6,6 @@
 
 @implementation WebSeedTableView
 
-- (void)mouseDown:(NSEvent*)event
-{
-    [self.window makeKeyWindow];
-    [super mouseDown:event];
-}
-
 - (void)copy:(id)sender
 {
     NSIndexSet* indexes = self.selectedRowIndexes;


### PR DESCRIPTION
## Description
This PR removes the redundant `mouseDown:` method overrides from `FileOutlineView`, `TrackerTableView`, and `WebSeedTableView`. 

Previously, these classes explicitly called `[self.window makeKeyWindow]` before passing the event to `[super mouseDown:]`. This explicit activation is unnecessary because AppKit inherently handles window focusing and text/element selection correctly during mouse-down events on these standard controls. 

Removing these overrides cleans up unnecessary boilerplate code and prevents potential side effects related to window ordering and focus management.

## Changes
- **`macosx/FileOutlineView.mm`**: Removed custom `mouseDown:` implementation.
- **`macosx/TrackerTableView.mm`**: Removed custom `mouseDown:` implementation.
- **`macosx/WebSeedTableView.mm`**: Removed custom `mouseDown:` implementation.

## Testing Done
- [x] Verified that clicking on the elements inside File Outline, Tracker Table, and Web Seed Table still correctly focuses the main window.
- [x] Verified that standard mouse interaction (selection, context menus) functions normally.
