### PR TITLE
fix: limit curl connection lifetime to 24 hours

### DIFF
--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -437,6 +437,7 @@ public:
     static auto constexpr MaxHostConnections = long{ 16 };
     static auto constexpr MaxTotalConnections = long{ 96 };
     static auto constexpr MaxCachedConnections = MaxTotalConnections;
+    static auto constexpr MaxlifetimeConn = long{ 24 * 60 * 60 }; // default since curl 8.17.0, disabled by default before
 
     bool const curl_verbose = tr_env_key_exists("TR_CURL_VERBOSE");
     bool const curl_ssl_verify = !tr_env_key_exists("TR_CURL_SSL_NO_VERIFY");
@@ -580,6 +581,9 @@ public:
         (void)curl_easy_setopt(e, CURLOPT_AUTOREFERER, 1L);
         (void)curl_easy_setopt(e, CURLOPT_ACCEPT_ENCODING, "");
         (void)curl_easy_setopt(e, CURLOPT_FOLLOWLOCATION, 1L);
+#if LIBCURL_VERSION_NUM >= 0x075000 /* 7.80.0 */
+        (void)curl_easy_setopt(e, CURLOPT_MAXLIFETIME_CONN, MaxlifetimeConn);
+#endif
         (void)curl_easy_setopt(e, CURLOPT_MAXREDIRS, MaxRedirects);
         (void)curl_easy_setopt(e, CURLOPT_NOSIGNAL, 1L);
         (void)curl_easy_setopt(e, CURLOPT_PRIVATE, &task);


### PR DESCRIPTION
## Description

Explicitly limit connection lifetime to 24 hours, matching the default since curl 8.17.0.

curl < 8.17.0 by default allows connections to be reused forever in theory, in practice, a connection can persist for years according to official curl docs. Certificates can expire or be revoked in the meantime, and the client wouldn't know until the connection is dropped, then attempted again.

Ref: https://curl.se/libcurl/security.html

Notes: Improved the security of connections to trackers, web seeds, and blocklist servers.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
