### PR TITLE
Fix the both-null guard in SorterBase to test the right-hand side

### DIFF
--- a/gtk/SorterBase.hh
+++ b/gtk/SorterBase.hh
@@ -15,7 +15,7 @@ Gtk::Ordering SorterBase<T>::compare_vfunc(gpointer lhs, gpointer rhs)
     auto const* const concrete_lhs = dynamic_cast<T const*>(Glib::wrap_auto(static_cast<GObject*>(lhs)));
     auto const* const concrete_rhs = dynamic_cast<T const*>(Glib::wrap_auto(static_cast<GObject*>(rhs)));
 
-    if (concrete_lhs == nullptr && concrete_lhs == nullptr)
+    if (concrete_lhs == nullptr && concrete_rhs == nullptr)
     {
         g_return_val_if_reached(Gtk::Ordering::EQUAL);
     }


### PR DESCRIPTION
Cherry-pick of https://github.com/transmission/transmission/pull/9098 by @darkdi

In `SorterBase<T>::compare_vfunc` the "both sides failed to cast" guard tests `concrete_lhs` twice, so it never looks at the right side at all. The two `g_return_val_if_fail` lines under it are written to separate the one-sided cases, and the first of them can't be reached the way it stands: with `concrete_lhs` null and `concrete_rhs` fine, the guard already fired and returned `EQUAL` instead of `SMALLER`.

This only shows up on the GTK4 path when `Glib::wrap_auto` hands back something that isn't a `T`, which is why nothing has complained about it. The names sit next to each other on consecutive lines, which is probably how it happened.
