### PR TITLE
chore: bump dht to 0.28

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "third-party/dht"]
 	path = third-party/dht
 	url = https://github.com/retransmission/dht.git
-	branch = post-0.27-retransmission
+	branch = post-0.28-retransmission
 [submodule "third-party/libevent"]
 	path = third-party/libevent
 	url = https://github.com/transmissiontorrent/libevent.git


### PR DESCRIPTION
## Description

dht 0.28 was released a few hours ago. It's no different from our fork's post-0.27 branch because I had just cherry-picked some new fixes into it.

Notes: Bumped DHT library to version 0.28.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
