### PR TITLE
fix: correct semantics for RPC error code

### DIFF
--- a/docs/rpc-spec.md
+++ b/docs/rpc-spec.md
@@ -74,8 +74,8 @@ In Transmission, this key is an Object that includes:
 {
    "jsonrpc": "2.0",
    "error": {
-      "code": 7,
-      "message": "HTTP error from backend service",
+      "code": 8,
+      "message": "error when fetching from remote service",
       "data": {
          "error_string": "Couldn't test port: No Response (0)",
          "result": {

--- a/libtransmission/api-compat.cc
+++ b/libtransmission/api-compat.cc
@@ -523,9 +523,9 @@ auto constexpr PreferClearLegacy = std::string_view{ "tolerated" };
 
     static auto constexpr Phrases = std::to_array<std::pair<std::string_view, Error::Code>>({
         { "absolute", Error::PATH_NOT_ABSOLUTE },
-        { "couldn't fetch blocklist", Error::HTTP_ERROR },
+        { "couldn't fetch blocklist", Error::FETCH_ERROR },
         { "couldn't save", Error::SYSTEM_ERROR },
-        { "couldn't test port", Error::HTTP_ERROR },
+        { "couldn't test port", Error::FETCH_ERROR },
         { "file index out of range", Error::FILE_IDX_OOR },
         { "invalid ip protocol", Error::INVALID_PARAMS },
         { "invalid or corrupt torrent", Error::CORRUPT_TORRENT },

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -87,8 +87,8 @@ namespace Error
         return "file index out of range"sv;
     case PIECE_IDX_OOR:
         return "piece index out of range"sv;
-    case HTTP_ERROR:
-        return "HTTP error from backend service"sv;
+    case FETCH_ERROR:
+        return "error when fetching from remote service"sv;
     case CORRUPT_TORRENT:
         return "invalid or corrupt torrent file"sv;
     case INVALID_BLOCKLIST_DATA:
@@ -1381,7 +1381,7 @@ void onPortTested(tr_web::FetchResponse const& web_response)
     if (status != 200) {
         tr_rpc_idle_done(
             data,
-            Error::HTTP_ERROR,
+            Error::FETCH_ERROR,
             fmt::format(
                 fmt::runtime(_("Couldn't test port: {error} ({error_code})")),
                 fmt::arg("error", tr_webGetResponseStr(status)),
@@ -1443,7 +1443,7 @@ void blocklistUpdate(tr_session* session, tr_variant::Map const& /*args_in*/, st
             break;
 
         case tr_blocklist_update_status::DownloadError:
-            tr_rpc_idle_done(idle_data, Error::HTTP_ERROR, result.error);
+            tr_rpc_idle_done(idle_data, Error::FETCH_ERROR, result.error);
             break;
 
         case tr_blocklist_update_status::SaveError:
@@ -1521,7 +1521,7 @@ void onMetadataFetched(tr_web::FetchResponse const& web_response)
     } else {
         tr_rpc_idle_done(
             data->data,
-            JsonRpc::Error::HTTP_ERROR,
+            JsonRpc::Error::FETCH_ERROR,
             fmt::format(
                 fmt::runtime(_("Couldn't fetch torrent: {error} ({error_code})")),
                 fmt::arg("error", tr_webGetResponseStr(status)),

--- a/libtransmission/rpcimpl.h
+++ b/libtransmission/rpcimpl.h
@@ -40,7 +40,7 @@ enum Code : int16_t {
     SYSTEM_ERROR = 5,
     FILE_IDX_OOR = 6,
     PIECE_IDX_OOR = 7,
-    HTTP_ERROR = 8,
+    FETCH_ERROR = 8,
     CORRUPT_TORRENT = 9,
     INVALID_BLOCKLIST_DATA = 10,
 };

--- a/tests/libtransmission/api-compat-test.cc
+++ b/tests/libtransmission/api-compat-test.cc
@@ -433,7 +433,7 @@ constexpr std::string_view CurrentPortTestErrorResponse = R"json({
                 "ip_protocol": "ipv6"
             }
         },
-        "message": "HTTP error from backend service"
+        "message": "error when fetching from remote service"
     },
     "id": 9,
     "jsonrpc": "2.0"


### PR DESCRIPTION
## Description

Fetching via curl in RPC is not always on HTTP, it can be on FTP too. Fix the assumption in the error codes that the curl requests are always HTTP. 

Notes: Corrected RPC error messages.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
