### PR TITLE
fix: don't assume HTTP error codes

### DIFF
--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -97,7 +97,7 @@ struct http_announce_data {
 
 bool handleAnnounceResponse(tr_web::FetchResponse const& web_response, tr_announce_response& response)
 {
-    auto const& [status, headers, body, primary_ip, did_connect, did_timeout, vdata] = web_response;
+    auto const& [url, status, headers, body, primary_ip, did_connect, did_timeout, vdata] = web_response;
     auto const& log_name = static_cast<http_announce_data const*>(vdata)->log_name;
 
     response.did_connect = did_connect;
@@ -130,7 +130,7 @@ bool handleAnnounceResponse(tr_web::FetchResponse const& web_response, tr_announ
 
 void onAnnounceDone(tr_web::FetchResponse const& web_response)
 {
-    auto const& [status, headers, body, primary_ip, did_connect, did_timeout, vdata] = web_response;
+    auto const& [url, status, headers, body, primary_ip, did_connect, did_timeout, vdata] = web_response;
     auto* const data = static_cast<http_announce_data*>(vdata);
 
     auto const got_all_responses = ++data->requests_answered_count == data->requests_sent_count;
@@ -434,7 +434,7 @@ private:
 
 void onScrapeDone(tr_web::FetchResponse const& web_response)
 {
-    auto const& [status, headers, body, primary_ip, did_connect, did_timeout, vdata] = web_response;
+    auto const& [url, status, headers, body, primary_ip, did_connect, did_timeout, vdata] = web_response;
     auto* const data = static_cast<scrape_data*>(vdata);
 
     auto& response = data->response();

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1508,13 +1508,9 @@ void onMetadataFetched(tr_web::FetchResponse const& web_response)
     auto* data = static_cast<struct add_torrent_idle_data*>(user_data);
 
     tr_logAddTrace(
-        fmt::format(
-            "torrentAdd: HTTP response code was {} ({}); response length was {} bytes",
-            status,
-            tr_webGetResponseStr(status),
-            std::size(body)));
+        fmt::format("torrentAdd: fetch response code was ({}); response length was {} bytes", status, std::size(body)));
 
-    if (status == 200 || status == 221) /* http or ftp success.. */
+    if (status == 200 || status == 221) // http or ftp success..
     {
         data->builder.set_metainfo(body);
         add_torrent_impl(data->data, data->builder);
@@ -1522,10 +1518,7 @@ void onMetadataFetched(tr_web::FetchResponse const& web_response)
         tr_rpc_idle_done(
             data->data,
             JsonRpc::Error::FETCH_ERROR,
-            fmt::format(
-                fmt::runtime(_("Couldn't fetch torrent: {error} ({error_code})")),
-                fmt::arg("error", tr_webGetResponseStr(status)),
-                fmt::arg("error_code", status)));
+            fmt::format(fmt::runtime(_("Couldn't fetch torrent: ({error_code})")), fmt::arg("error_code", status)));
     }
 
     delete data;

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1370,7 +1370,7 @@ void onPortTested(tr_web::FetchResponse const& web_response)
 {
     using namespace JsonRpc;
 
-    auto const& [status, headers, body, primary_ip, did_connect, did_timeout, user_data] = web_response;
+    auto const& [url, status, headers, body, primary_ip, did_connect, did_timeout, user_data] = web_response;
     auto* data = static_cast<tr_rpc_idle_data*>(user_data);
 
     if (auto const addr = tr_address::from_string(primary_ip);
@@ -1504,11 +1504,21 @@ struct add_torrent_idle_data {
 
 void onMetadataFetched(tr_web::FetchResponse const& web_response)
 {
-    auto const& [status, headers, body, primary_ip, did_connect, did_timeout, user_data] = web_response;
+    auto const& [url, status, headers, body, primary_ip, did_connect, did_timeout, user_data] = web_response;
     auto* data = static_cast<struct add_torrent_idle_data*>(user_data);
 
+    auto const parsed_url = tr_urlParse(url);
+    auto response_str = std::string{};
+    if (parsed_url && (parsed_url->scheme == "https"sv || parsed_url->scheme == "http"sv)) {
+        response_str = tr_webGetResponseStr(status);
+    }
+
     tr_logAddTrace(
-        fmt::format("torrentAdd: fetch response code was ({}); response length was {} bytes", status, std::size(body)));
+        fmt::format(
+            "torrentAdd: fetch response code was {} ({}); response length was {} bytes",
+            response_str,
+            status,
+            std::size(body)));
 
     if (status == 200 || status == 221) // http or ftp success..
     {
@@ -1518,7 +1528,10 @@ void onMetadataFetched(tr_web::FetchResponse const& web_response)
         tr_rpc_idle_done(
             data->data,
             JsonRpc::Error::FETCH_ERROR,
-            fmt::format(fmt::runtime(_("Couldn't fetch torrent: ({error_code})")), fmt::arg("error_code", status)));
+            fmt::format(
+                fmt::runtime(_("Couldn't fetch torrent: {error} ({error_code})")),
+                fmt::arg("error", response_str),
+                fmt::arg("error_code", status)));
     }
 
     delete data;

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -272,6 +272,7 @@ public:
             auto const parsed = tr_urlParse(options_.url);
             easy_ = parsed ? impl.get_easy(parsed->host) : nullptr;
 
+            response.request_url = options_.url;
             response.user_data = options_.done_func_user_data;
 
             if (options_.range) {

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -22,6 +22,8 @@ public:
     // The response struct passed to the user's FetchDoneFunc callback
     // when a fetch() finishes.
     struct FetchResponse {
+        std::string request_url;
+
         long status = 0; // http server response, e.g. 200
         std::map<std::string, std::string> headers; // keys are lowercased
         std::string body;

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -401,7 +401,7 @@ void tr_webseed_task::on_data_received(size_t const n_bytes)
 
 void tr_webseed_task::on_partial_data_fetched(tr_web::FetchResponse const& web_response)
 {
-    auto const& [status, headers, body, primary_ip, did_connect, did_timeout, vtask] = web_response;
+    auto const& [url, status, headers, body, primary_ip, did_connect, did_timeout, vtask] = web_response;
     auto const success = status == 206;
 
     auto* const task = static_cast<tr_webseed_task*>(vtask);

--- a/tests/libtransmission/blocklist-download-test.cc
+++ b/tests/libtransmission/blocklist-download-test.cc
@@ -335,6 +335,7 @@ public:
     void respond(size_t index, long status, std::string body)
     {
         auto response = tr_web::FetchResponse{
+            .request_url = "https://example.com/blocklist"s,
             .status = status,
             .headers = {},
             .body = std::move(body),

--- a/tests/libtransmission/ip-cache-test.cc
+++ b/tests/libtransmission/ip-cache-test.cc
@@ -220,6 +220,7 @@ TEST_F(IPCacheTest, onResponseIPQuery)
         void fetch(tr_web::FetchOptions&& options) override // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
         {
             auto response = tr_web::FetchResponse{
+                .request_url = options.url,
                 .status = http_code,
                 .headers = {},
                 .body = std::string{ AddrStr[k_] },


### PR DESCRIPTION
## Description

Fix some strings in `torrent_add` that assumes curl fetches are always HTTP.

Notes: Corrected RPC error messages.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
