### PR TITLE
fix: handle curl error codes

### DIFF
--- a/libtransmission-app/rpc-client.cc
+++ b/libtransmission-app/rpc-client.cc
@@ -150,11 +150,12 @@ void RpcClient::send_remote_request(std::string body, ResponseFunc on_done)
             auto const is_tr5 = response.header(TrRpcVersionHeader).has_value();
 
             // captured for a human-readable message when the transport failed
+            // and no error message was provided
             auto const did_timeout = response.did_timeout;
             auto const did_connect = response.did_connect;
 
             auto parsed = std::shared_ptr<tr_variant>{};
-            if (status == 200) {
+            if (!response.errmsg && status == 200) {
                 if (auto var = tr_variant_serde::json().parse(response.body); var) {
                     api_compat::convert_incoming_data(*var);
                     parsed = std::make_shared<tr_variant>(std::move(*var));
@@ -164,6 +165,7 @@ void RpcClient::send_remote_request(std::string body, ResponseFunc on_done)
             run_on_ui_thread_([this,
                                body = std::move(body),
                                on_done = std::move(on_done),
+                               errmsg = response.errmsg,
                                new_session_id,
                                is_tr5,
                                did_timeout,
@@ -193,7 +195,11 @@ void RpcClient::send_remote_request(std::string body, ResponseFunc on_done)
                 auto result = RpcResponse{};
                 result.http_status = status;
 
-                if (status == 0) {
+                if (errmsg) {
+                    result.network_error = true;
+                    result.errmsg = *errmsg;
+                    network_response(false, result.errmsg);
+                } else if (status == 0) {
                     result.network_error = true;
                     if (did_timeout) {
                         result.errmsg = "connection timed out";
@@ -202,14 +208,14 @@ void RpcClient::send_remote_request(std::string body, ResponseFunc on_done)
                     } else {
                         result.errmsg = "the connection was lost";
                     }
-                    network_response(status, result.errmsg);
+                    network_response(false, result.errmsg);
                 } else if (parsed) {
                     result = parse_response_data(*parsed);
                     result.http_status = status;
-                    network_response(status, std::string_view{});
+                    network_response(true, std::string_view{});
                 } else {
                     result.errmsg = fmt::format("unexpected response (HTTP {:d})", status);
-                    network_response(status, result.errmsg);
+                    network_response(false, result.errmsg);
                 }
 
                 if (on_done) {

--- a/libtransmission-app/rpc-client.h
+++ b/libtransmission-app/rpc-client.h
@@ -67,7 +67,7 @@ public:
     void exec(tr_quark method, tr_variant* args, ResponseFunc on_done);
 
     // Signals, fired on the UI thread. Connect with connect_scoped().
-    sigslot::signal<long /*http_status*/, std::string_view /*message*/> network_response;
+    sigslot::signal<bool /*is_success*/, std::string_view /*message*/> network_response;
     sigslot::signal<> auth_required;
     sigslot::signal<> data_read_progress;
     sigslot::signal<> data_send_progress;

--- a/libtransmission/announcer-common.h
+++ b/libtransmission/announcer-common.h
@@ -150,12 +150,7 @@ struct tr_announce_response {
             return val;
         }
 
-        if (auto const val = static_cast<int>(rhs.did_timeout) <=> static_cast<int>(lhs.did_timeout); val != 0) {
-            return val;
-        }
-
-        // Non-empty error message most likely means we reached the tracker
-        return static_cast<int>(std::empty(rhs.errmsg)) <=> static_cast<int>(std::empty(lhs.errmsg));
+        return static_cast<int>(rhs.did_timeout) <=> static_cast<int>(lhs.did_timeout);
     }
 };
 

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -97,17 +97,24 @@ struct http_announce_data {
 
 bool handleAnnounceResponse(tr_web::FetchResponse const& web_response, tr_announce_response& response)
 {
-    auto const& [url, status, headers, body, primary_ip, did_connect, did_timeout, vdata] = web_response;
+    auto const& [url, errmsg, status, headers, body, primary_ip, did_connect, did_timeout, vdata] = web_response;
     auto const& log_name = static_cast<http_announce_data const*>(vdata)->log_name;
 
     response.did_connect = did_connect;
     response.did_timeout = did_timeout;
     tr_logAddTrace("Got announce response", log_name);
 
-    if (status != HTTP_OK) {
-        auto const* const response_str = tr_webGetResponseStr(status);
-        response.errmsg = fmt::format("Tracker HTTP response {:d} ({:s})", status, response_str);
+    if (errmsg) {
+        response.errmsg = fmt::format(
+            "Tracker announce failed: {:s}, response code: {:s} ({:d})",
+            *errmsg,
+            tr_webGetResponseStr(status),
+            status);
+        return false;
+    }
 
+    if (status != HTTP_OK) {
+        response.errmsg = fmt::format("Tracker HTTP response {:s} ({:d})", tr_webGetResponseStr(status), status);
         return false;
     }
 
@@ -130,8 +137,7 @@ bool handleAnnounceResponse(tr_web::FetchResponse const& web_response, tr_announ
 
 void onAnnounceDone(tr_web::FetchResponse const& web_response)
 {
-    auto const& [url, status, headers, body, primary_ip, did_connect, did_timeout, vdata] = web_response;
-    auto* const data = static_cast<http_announce_data*>(vdata);
+    auto* const data = static_cast<http_announce_data*>(web_response.user_data);
 
     auto const got_all_responses = ++data->requests_answered_count == data->requests_sent_count;
 
@@ -434,7 +440,7 @@ private:
 
 void onScrapeDone(tr_web::FetchResponse const& web_response)
 {
-    auto const& [url, status, headers, body, primary_ip, did_connect, did_timeout, vdata] = web_response;
+    auto const& [url, errmsg, status, headers, body, primary_ip, did_connect, did_timeout, vdata] = web_response;
     auto* const data = static_cast<scrape_data*>(vdata);
 
     auto& response = data->response();
@@ -444,9 +450,14 @@ void onScrapeDone(tr_web::FetchResponse const& web_response)
     auto const scrape_url_sv = response.scrape_url.sv();
     tr_logAddTrace(fmt::format("Got scrape response for '{}'", scrape_url_sv), data->log_name());
 
-    if (status != HTTP_OK) {
-        auto const* const response_str = tr_webGetResponseStr(status);
-        response.errmsg = fmt::format("Tracker HTTP response {:d} ({:s})", status, response_str);
+    if (errmsg) {
+        response.errmsg = fmt::format(
+            "Tracker scrape failed: {}, response code: {:s} ({:d})",
+            *errmsg,
+            tr_webGetResponseStr(status),
+            status);
+    } else if (status != HTTP_OK) {
+        response.errmsg = fmt::format("Tracker HTTP response {:s} ({:d})", tr_webGetResponseStr(status), status);
     } else if (!std::empty(body)) {
         tr_announcerParseHttpScrapeResponse(response, body, data->log_name());
     }

--- a/libtransmission/announcer-http.cc
+++ b/libtransmission/announcer-http.cc
@@ -452,7 +452,7 @@ void onScrapeDone(tr_web::FetchResponse const& web_response)
 
     if (errmsg) {
         response.errmsg = fmt::format(
-            "Tracker scrape failed: {}, response code: {:s} ({:d})",
+            "Tracker scrape failed: {:s}, response code: {:s} ({:d})",
             *errmsg,
             tr_webGetResponseStr(status),
             status);

--- a/libtransmission/blocklist-download.cc
+++ b/libtransmission/blocklist-download.cc
@@ -160,6 +160,17 @@ void finish_request(tr_web::FetchResponse const& response, std::shared_ptr<Pendi
 
     auto result = tr_blocklist_update_result{};
 
+    if (response.errmsg) {
+        result.status = tr_blocklist_update_status::DownloadError;
+        result.error = fmt::format(
+            fmt::runtime(_("Couldn't fetch blocklist: {errmsg}, response code: {error} ({error_code})")),
+            fmt::arg("errmsg", *response.errmsg),
+            fmt::arg("error", tr_webGetResponseStr(response.status)),
+            fmt::arg("error_code", response.status));
+        deliver(*pending, result);
+        return;
+    }
+
     if (response.status != 200) {
         // we failed to download the blocklist...
         result.status = tr_blocklist_update_status::DownloadError;

--- a/libtransmission/ip-cache.cc
+++ b/libtransmission/ip-cache.cc
@@ -28,6 +28,7 @@
 #include "libtransmission/string-utils.h"
 #include "libtransmission/tr-assert.h"
 #include "libtransmission/utils.h"
+#include "libtransmission/web-utils.h"
 #include "libtransmission/web.h"
 
 namespace
@@ -302,7 +303,26 @@ void tr_ip_cache::on_response_ip_query(tr_address_type const type, tr_web::Fetch
     auto const protocol = tr_ip_protocol_to_sv(type);
     auto success = false;
 
-    if (response.status == 200 /* HTTP_OK */) {
+    if (response.errmsg) {
+        tr_logAddDebug(
+            fmt::format(
+                "Couldn't fetch global {} address: {}, response code: {} ({}), did_connect: {}, did_timeout: {}",
+                protocol,
+                *response.errmsg,
+                tr_webGetResponseStr(response.status),
+                response.status,
+                response.did_connect,
+                response.did_timeout));
+    } else if (response.status != 200 /* HTTP_OK */) {
+        tr_logAddDebug(
+            fmt::format(
+                "Couldn't fetch global {} address: {} ({}), did_connect: {}, did_timeout: {}",
+                protocol,
+                tr_webGetResponseStr(response.status),
+                response.status,
+                response.did_connect,
+                response.did_timeout));
+    } else {
         // Update member
         if (auto const addr = tr_address::from_string(tr_strv_strip(response.body));
             addr && type == addr->type && set_global_addr(*addr)) {
@@ -325,13 +345,6 @@ void tr_ip_cache::on_response_ip_query(tr_address_type const type, tr_web::Fetch
             return;
         }
 
-        tr_logAddDebug(
-            fmt::format(
-                "Couldn't obtain global {} address, HTTP status = {}, did_connect = {}, did_timeout = {}",
-                protocol,
-                response.status,
-                response.did_connect,
-                response.did_timeout));
         unset_global_addr(type);
         upkeep_timers_[type]->set_interval(RetryUpkeepInterval);
     }

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1537,14 +1537,18 @@ void onMetadataFetched(tr_web::FetchResponse const& web_response)
             data->data,
             JsonRpc::Error::FETCH_ERROR,
             fmt::format(
-                fmt::runtime(_("Couldn't fetch torrent: {errmsg}, Response code: ({error_code})")),
+                fmt::runtime(_("Couldn't fetch torrent: {errmsg}, Response code: {error} ({error_code})")),
                 fmt::arg("errmsg", *errmsg),
+                fmt::arg("error", response_str),
                 fmt::arg("error_code", status)));
     } else if (status != 200 && status != 221) /* not http or ftp success.. */ {
         tr_rpc_idle_done(
             data->data,
             JsonRpc::Error::FETCH_ERROR,
-            fmt::format(fmt::runtime(_("Couldn't fetch torrent: ({error_code})")), fmt::arg("error_code", status)));
+            fmt::format(
+                fmt::runtime(_("Couldn't fetch torrent: {error} ({error_code})")),
+                fmt::arg("error", response_str),
+                fmt::arg("error_code", status)));
     } else {
         data->builder.set_metainfo(body);
         add_torrent_impl(data->data, data->builder);

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -1370,12 +1370,24 @@ void onPortTested(tr_web::FetchResponse const& web_response)
 {
     using namespace JsonRpc;
 
-    auto const& [url, status, headers, body, primary_ip, did_connect, did_timeout, user_data] = web_response;
+    auto const& [url, errmsg, status, headers, body, primary_ip, did_connect, did_timeout, user_data] = web_response;
     auto* data = static_cast<tr_rpc_idle_data*>(user_data);
 
     if (auto const addr = tr_address::from_string(primary_ip);
         !data->args_out.value_if<std::string_view>(TR_KEY_ip_protocol).has_value() && addr && addr->is_valid()) {
         data->args_out.try_emplace(TR_KEY_ip_protocol, addr->is_ipv4() ? "ipv4"sv : "ipv6"sv);
+    }
+
+    if (errmsg) {
+        tr_rpc_idle_done(
+            data,
+            Error::FETCH_ERROR,
+            fmt::format(
+                fmt::runtime(_("Couldn't test port: {errmsg}, response code: {error} ({error_code})")),
+                fmt::arg("errmsg", *errmsg),
+                fmt::arg("error", tr_webGetResponseStr(status)),
+                fmt::arg("error_code", status)));
+        return;
     }
 
     if (status != 200) {
@@ -1504,7 +1516,7 @@ struct add_torrent_idle_data {
 
 void onMetadataFetched(tr_web::FetchResponse const& web_response)
 {
-    auto const& [url, status, headers, body, primary_ip, did_connect, did_timeout, user_data] = web_response;
+    auto const& [url, errmsg, status, headers, body, primary_ip, did_connect, did_timeout, user_data] = web_response;
     auto* data = static_cast<struct add_torrent_idle_data*>(user_data);
 
     auto const parsed_url = tr_urlParse(url);
@@ -1520,18 +1532,22 @@ void onMetadataFetched(tr_web::FetchResponse const& web_response)
             status,
             std::size(body)));
 
-    if (status == 200 || status == 221) // http or ftp success..
-    {
-        data->builder.set_metainfo(body);
-        add_torrent_impl(data->data, data->builder);
-    } else {
+    if (errmsg) {
         tr_rpc_idle_done(
             data->data,
             JsonRpc::Error::FETCH_ERROR,
             fmt::format(
-                fmt::runtime(_("Couldn't fetch torrent: {error} ({error_code})")),
-                fmt::arg("error", response_str),
+                fmt::runtime(_("Couldn't fetch torrent: {errmsg}, Response code: ({error_code})")),
+                fmt::arg("errmsg", *errmsg),
                 fmt::arg("error_code", status)));
+    } else if (status != 200 && status != 221) /* not http or ftp success.. */ {
+        tr_rpc_idle_done(
+            data->data,
+            JsonRpc::Error::FETCH_ERROR,
+            fmt::format(fmt::runtime(_("Couldn't fetch torrent: ({error_code})")), fmt::arg("error_code", status)));
+    } else {
+        data->builder.set_metainfo(body);
+        add_torrent_impl(data->data, data->builder);
     }
 
     delete data;

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -21,6 +21,7 @@
 #include <stack>
 #include <string>
 #include <thread>
+#include <type_traits>
 #include <utility>
 
 #ifdef _WIN32
@@ -825,11 +826,16 @@ public:
             CURLMsg* msg = nullptr;
             auto unused = int{};
             while ((msg = curl_multi_info_read(multi.get(), &unused)) != nullptr) {
-                if (msg->msg == CURLMSG_DONE && msg->easy_handle != nullptr) {
-                    auto* const e = msg->easy_handle;
-
+                if (auto* const e = msg->easy_handle; msg->msg == CURLMSG_DONE && e != nullptr) {
                     Task* task = nullptr;
                     curl_easy_getinfo(e, CURLINFO_PRIVATE, &task);
+
+                    if (msg->data.result != CURLE_OK) {
+                        task->response.errmsg = fmt::format(
+                            "curl error: {} ({})",
+                            curl_easy_strerror(msg->data.result),
+                            static_cast<std::underlying_type_t<CURLcode>>(msg->data.result));
+                    }
 
                     auto req_bytes_sent = long{};
                     auto total_time = double{};

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -23,6 +23,7 @@ public:
     // when a fetch() finishes.
     struct FetchResponse {
         std::string request_url;
+        std::optional<std::string> errmsg; // empty if no error
 
         long status = 0; // http server response, e.g. 200
         std::map<std::string, std::string> headers; // keys are lowercased

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -401,8 +401,8 @@ void tr_webseed_task::on_data_received(size_t const n_bytes)
 
 void tr_webseed_task::on_partial_data_fetched(tr_web::FetchResponse const& web_response)
 {
-    auto const& [url, status, headers, body, primary_ip, did_connect, did_timeout, vtask] = web_response;
-    auto const success = status == 206;
+    auto const& [url, errmsg, status, headers, body, primary_ip, did_connect, did_timeout, vtask] = web_response;
+    auto const success = !errmsg && status == 206;
 
     auto* const task = static_cast<tr_webseed_task*>(vtask);
 

--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -402,7 +402,11 @@ void tr_webseed_task::on_data_received(size_t const n_bytes)
 void tr_webseed_task::on_partial_data_fetched(tr_web::FetchResponse const& web_response)
 {
     auto const& [url, errmsg, status, headers, body, primary_ip, did_connect, did_timeout, vtask] = web_response;
-    auto const success = !errmsg && status == 206;
+
+    // We could check curl error codes here, but this code has been working fine
+    // without it for years. The piece hash verifier will catch any corrupt data.
+    // Let's keep it this way until we see a problem.
+    auto const success = status == 206;
 
     auto* const task = static_cast<tr_webseed_task*>(vtask);
 

--- a/qt/RpcClient.cc
+++ b/qt/RpcClient.cc
@@ -37,8 +37,8 @@ RpcClient::RpcClient(QObject* parent)
     : QObject{ parent }
     , impl_{ makeUiMarshaler(this) }
 {
-    connections_[0] = impl_.network_response.connect_scoped([this](long const status, std::string_view const message) {
-        auto const code = status == 200 ? QNetworkReply::NoError : QNetworkReply::UnknownNetworkError;
+    connections_[0] = impl_.network_response.connect_scoped([this](bool const is_success, std::string_view const message) {
+        auto const code = is_success ? QNetworkReply::NoError : QNetworkReply::UnknownNetworkError;
         emit networkResponse(code, Utils::qstringFromUtf8(message));
     });
     connections_[1] = impl_.auth_required.connect_scoped([this]() { emit httpAuthenticationRequired(); });

--- a/tests/libtransmission-app/rpc-client-test.cc
+++ b/tests/libtransmission-app/rpc-client-test.cc
@@ -396,10 +396,10 @@ TEST_F(AppRpcClientTest, reportsNetworkErrorWhenServerIsUnreachable)
     auto client = RpcClient{ loop.marshaler() };
     client.start(url_str);
 
-    auto network_response_status = long{ -1 };
+    auto network_response_success = false;
     auto network_response_message = std::string{};
-    auto const tag = client.network_response.connect_scoped([&](long const status, std::string_view const message) {
-        network_response_status = status;
+    auto const tag = client.network_response.connect_scoped([&](bool const is_success, std::string_view const message) {
+        network_response_success = is_success;
         network_response_message = std::string{ message };
     });
 
@@ -409,7 +409,7 @@ TEST_F(AppRpcClientTest, reportsNetworkErrorWhenServerIsUnreachable)
     EXPECT_EQ(0, response.http_status);
     EXPECT_FALSE(std::empty(response.errmsg));
 
-    EXPECT_EQ(0, network_response_status);
+    EXPECT_FALSE(network_response_success);
     EXPECT_EQ(response.errmsg, network_response_message);
 }
 

--- a/tests/libtransmission/blocklist-download-test.cc
+++ b/tests/libtransmission/blocklist-download-test.cc
@@ -336,6 +336,7 @@ public:
     {
         auto response = tr_web::FetchResponse{
             .request_url = "https://example.com/blocklist"s,
+            .errmsg = {},
             .status = status,
             .headers = {},
             .body = std::move(body),

--- a/tests/libtransmission/ip-cache-test.cc
+++ b/tests/libtransmission/ip-cache-test.cc
@@ -221,6 +221,7 @@ TEST_F(IPCacheTest, onResponseIPQuery)
         {
             auto response = tr_web::FetchResponse{
                 .request_url = options.url,
+                .errmsg = {},
                 .status = http_code,
                 .headers = {},
                 .body = std::string{ AddrStr[k_] },


### PR DESCRIPTION
## Description

In curl, it is possible for the fetch to fail (return a non-`CURLE_OK` code), while still getting a successful response code (e.g. HTTP 200), yet we never handled this case for the longest time.

Having said that, I don't think our current usage of curl will trigger this. However, this will matter for the next PR in the stack, which can abort an HTTP 200 transfer if the remote sends too much data.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
