### PR TITLE
fix: limit curl response size to 10 MiB by default

### DIFF
--- a/libtransmission-app/rpc-client.cc
+++ b/libtransmission-app/rpc-client.cc
@@ -230,6 +230,7 @@ void RpcClient::send_remote_request(std::string body, ResponseFunc on_done)
     options.auth_scheme = tr_web::FetchOptions::AuthScheme::Any;
     options.headers.insert_or_assign("Content-Type", "application/json; charset=UTF-8");
     options.headers.insert_or_assign("User-Agent", TR_PROJ_APPNAME_CAPITALIZED "/" SHORT_VERSION_STRING);
+    options.max_file_size = 0U;
 
     if (!std::empty(session_id_)) {
         options.headers.insert_or_assign(std::string{ TrRpcSessionIdHeader }, session_id_);

--- a/libtransmission/blocklist-download.cc
+++ b/libtransmission/blocklist-download.cc
@@ -50,7 +50,7 @@ auto constexpr UpdateInterval = std::chrono::hours{ 24 * 7 };
 auto constexpr StartupDelay = std::chrono::seconds{ 60 };
 
 // Real blocklists are tens of MB; refuse to block anything larger than 128 MiB.
-auto constexpr MaxDecompressedSize = size_t{ 128U } * 1024U * 1024U;
+auto constexpr MaxBlocklistSize = 128U * 1024U * 1024U;
 
 // Read the first regular file out of `body`, transparently gunzipping it first,
 // using whichever archive formats `configure` enables. Returns nullopt when
@@ -97,13 +97,13 @@ auto constexpr MaxDecompressedSize = size_t{ 128U } * 1024U * 1024U;
                 break;
             }
             content.append(std::data(buf), static_cast<size_t>(n_read));
-            if (std::size(content) > MaxDecompressedSize) {
+            if (std::size(content) > MaxBlocklistSize) {
                 // likely a decompression bomb; discard it entirely so a
                 // truncated prefix isn't mistaken for a valid blocklist
                 tr_logAddWarn(
                     fmt::format(
                         fmt::runtime(_("Blocklist is larger than {limit} MiB; ignoring it")),
-                        fmt::arg("limit", MaxDecompressedSize / (1024U * 1024U))));
+                        fmt::arg("limit", MaxBlocklistSize / (1024U * 1024U))));
                 content.clear();
                 break;
             }
@@ -234,10 +234,13 @@ void Updater::update(tr_blocklist_update_func on_done)
 
         auto pending = std::make_shared<Pending>(Pending{ .mediator = &mediator_, .waiters = std::move(waiters) });
         latest_ = pending;
-        mediator_.fetch(
-            { mediator_.blocklist_url(),
-              [pending](tr_web::FetchResponse const& response) { finish_request(response, pending); },
-              nullptr });
+        auto options = tr_web::FetchOptions{
+            mediator_.blocklist_url(),
+            [pending](tr_web::FetchResponse const& response) { finish_request(response, pending); },
+            nullptr,
+        };
+        options.max_file_size = MaxBlocklistSize;
+        mediator_.fetch(std::move(options));
     });
 }
 

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -14,6 +14,7 @@
 #include <cstdint> // for uint64_t
 #include <functional> // for std::less()
 #include <list>
+#include <limits>
 #include <map>
 #include <memory>
 #include <ranges>
@@ -353,14 +354,25 @@ public:
             }
         }
 
-        void add_data(void const* data, size_t const n_bytes)
+        [[nodiscard]] bool add_data(void const* data, size_t const n_bytes)
         {
+            // Needed for curl < 8.4.0, newer versions handles this for us
+            if (auto const max = options().effective_max_file_size(); response.body.size() + n_bytes > max) {
+                tr_logAddWarn(
+                    fmt::format(
+                        fmt::runtime(_("Aborting request: response body exceeded max size of {max_file_size} bytes")),
+                        fmt::arg("max_file_size", max)));
+                return false;
+            }
+
             response.body.append(static_cast<char const*>(data), n_bytes);
             tr_logAddTrace(fmt::format("wrote {} bytes to task {}'s buffer", n_bytes, fmt::ptr(this)));
 
             if (options_.on_data_received) {
                 options_.on_data_received(n_bytes);
             }
+
+            return true;
         }
 
         void add_response_header(std::string_view line)
@@ -505,7 +517,7 @@ public:
         auto* task = static_cast<Task*>(vtask);
         TR_ASSERT(std::this_thread::get_id() == task->impl.curl_thread->get_id());
 
-        if (auto const range = task->options().range) {
+        if (task->options().range) {
             // https://curl.se/libcurl/c/CURLINFO_RESPONSE_CODE.html
             // "The stored value will be zero if no server response code has been received"
             static auto constexpr NoResponseCode = 0L;
@@ -540,7 +552,11 @@ public:
             }
         }
 
-        task->add_data(data, bytes_used);
+        if (!task->add_data(data, bytes_used)) {
+            // Tell curl to error out. Failed to add data to the buffer
+            return bytes_used + 1;
+        }
+
         return bytes_used;
     }
 
@@ -583,6 +599,12 @@ public:
         (void)curl_easy_setopt(e, CURLOPT_AUTOREFERER, 1L);
         (void)curl_easy_setopt(e, CURLOPT_ACCEPT_ENCODING, "");
         (void)curl_easy_setopt(e, CURLOPT_FOLLOWLOCATION, 1L);
+        (void)curl_easy_setopt(
+            e,
+            CURLOPT_MAXFILESIZE_LARGE,
+            static_cast<curl_off_t>(std::min(
+                task.options().effective_max_file_size(),
+                static_cast<uint64_t>(std::numeric_limits<curl_off_t>::max()))));
 #if LIBCURL_VERSION_NUM >= 0x075000 /* 7.80.0 */
         (void)curl_easy_setopt(e, CURLOPT_MAXLIFETIME_CONN, MaxlifetimeConn);
 #endif

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -357,7 +357,7 @@ public:
         [[nodiscard]] bool add_data(void const* data, size_t const n_bytes)
         {
             // Needed for curl < 8.4.0, newer versions handles this for us
-            if (auto const max = options().effective_max_file_size(); response.body.size() + n_bytes > max) {
+            if (auto const max = options().effective_max_file_size(); max != 0U && response.body.size() + n_bytes > max) {
                 tr_logAddWarn(
                     fmt::format(
                         fmt::runtime(_("Aborting request: response body exceeded max size of {max_file_size} bytes")),

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -446,6 +446,13 @@ public:
         return in_range;
     }
 
+    // https://github.com/curl/curl/issues/14899
+    [[nodiscard]] static bool check_curl_gh14899() noexcept
+    {
+        static bool const in_range = get_curl_version() < 0x080a01 /* 8.10.1 */;
+        return in_range;
+    }
+
     static auto constexpr BandwidthPauseMsec = long{ 500 };
     static auto constexpr DnsCacheTimeoutSecs = long{ 60 * 60 };
     static auto constexpr MaxRedirects = long{ 10 };
@@ -458,6 +465,7 @@ public:
     bool const curl_ssl_verify = !tr_env_key_exists("TR_CURL_SSL_NO_VERIFY");
     bool const curl_proxy_ssl_verify = !tr_env_key_exists("TR_CURL_PROXY_SSL_NO_VERIFY");
     bool const curl_avoid_http2 = check_curl_gh10936() || check_curl_gh6312(); // both related to curl http2 bugs
+    bool const curl_dont_limit_range_requests = check_curl_gh14899();
 
     Mediator& mediator;
 
@@ -600,12 +608,6 @@ public:
         (void)curl_easy_setopt(e, CURLOPT_AUTOREFERER, 1L);
         (void)curl_easy_setopt(e, CURLOPT_ACCEPT_ENCODING, "");
         (void)curl_easy_setopt(e, CURLOPT_FOLLOWLOCATION, 1L);
-        (void)curl_easy_setopt(
-            e,
-            CURLOPT_MAXFILESIZE_LARGE,
-            static_cast<curl_off_t>(std::min(
-                task.options().effective_max_file_size(),
-                static_cast<uint64_t>(std::numeric_limits<curl_off_t>::max()))));
 #if LIBCURL_VERSION_NUM >= 0x075000 /* 7.80.0 */
         (void)curl_easy_setopt(e, CURLOPT_MAXLIFETIME_CONN, MaxlifetimeConn);
 #endif
@@ -724,6 +726,17 @@ public:
 
         if (curl_avoid_http2) {
             (void)curl_easy_setopt(e, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+        }
+
+        if (!curl_dont_limit_range_requests || !task.options().range) {
+            (void)curl_easy_setopt(
+                e,
+                CURLOPT_MAXFILESIZE_LARGE,
+                static_cast<curl_off_t>(std::min(
+                    task.options().effective_max_file_size(),
+                    static_cast<uint64_t>(std::numeric_limits<curl_off_t>::max()))));
+        } else {
+            // Rely on the write function to limit the size of range requests as a workaround for curl bug #14899.
         }
     }
 

--- a/libtransmission/web.cc
+++ b/libtransmission/web.cc
@@ -357,7 +357,8 @@ public:
         [[nodiscard]] bool add_data(void const* data, size_t const n_bytes)
         {
             // Needed for curl < 8.4.0, newer versions handles this for us
-            if (auto const max = options().effective_max_file_size(); max != 0U && response.body.size() + n_bytes > max) {
+            if (auto const max = options().effective_max_file_size();
+                max != 0U && (response.body.size() > max || n_bytes > max - response.body.size())) {
                 tr_logAddWarn(
                     fmt::format(
                         fmt::runtime(_("Aborting request: response body exceeded max size of {max_file_size} bytes")),

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -146,7 +146,8 @@ public:
         IPProtocol ip_proto = IPProtocol::ANY;
 
         // Maximum size of the response body to accept before aborting the request.
-        // Use `effective_max_file_size` instead of reading this value directly
+        // Use `effective_max_file_size` instead of reading this value directly.
+        // Set to 0 to disable the limit.
         size_t max_file_size = DefaultMaxFileSize;
 
         static auto constexpr DefaultTimeoutSecs = std::chrono::seconds{ 120 };

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -67,6 +67,15 @@ public:
         {
         }
 
+        [[nodiscard]] constexpr uint64_t effective_max_file_size() const noexcept
+        {
+            if (range) {
+                auto const [first, last] = *range;
+                return last + 1U - first;
+            }
+            return max_file_size;
+        }
+
         // the URL to fetch
         std::string url;
 
@@ -136,7 +145,12 @@ public:
         // IP protocol to use when making the request
         IPProtocol ip_proto = IPProtocol::ANY;
 
+        // Maximum size of the response body to accept before aborting the request.
+        // Use `effective_max_file_size` instead of reading this value directly
+        size_t max_file_size = DefaultMaxFileSize;
+
         static auto constexpr DefaultTimeoutSecs = std::chrono::seconds{ 120 };
+        static auto constexpr DefaultMaxFileSize = 10U * 1024U * 1024U;
     };
 
     void fetch(FetchOptions&& options);

--- a/tests/libtransmission/loopback-server.h
+++ b/tests/libtransmission/loopback-server.h
@@ -106,7 +106,7 @@ public:
         return request_;
     }
 
-    // Convenience: send a reply with the given status, reason and body.
+    // Convenience: send a reply with the given status, reason, body, and headers.
     static void reply(
         evhttp_request* const req,
         int const code,

--- a/tests/libtransmission/loopback-server.h
+++ b/tests/libtransmission/loopback-server.h
@@ -8,6 +8,9 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#ifndef _WIN32
+#include <csignal>
+#endif
 #include <functional>
 #include <map>
 #include <mutex>
@@ -51,6 +54,11 @@ public:
         : base_{ event_base_new() }
         , http_{ evhttp_new(base_) }
     {
+#ifndef _WIN32
+        // The client may close a response-limited connection while libevent is still writing.
+        (void)signal(SIGPIPE, SIG_IGN);
+#endif
+
         evhttp_set_allowed_methods(
             http_,
             EVHTTP_REQ_GET | EVHTTP_REQ_POST | EVHTTP_REQ_HEAD | EVHTTP_REQ_PUT | EVHTTP_REQ_DELETE | EVHTTP_REQ_OPTIONS);

--- a/tests/libtransmission/loopback-server.h
+++ b/tests/libtransmission/loopback-server.h
@@ -107,10 +107,21 @@ public:
     }
 
     // Convenience: send a reply with the given status, reason and body.
-    static void reply(evhttp_request* req, int code, char const* reason, std::string_view body)
+    static void reply(
+        evhttp_request* const req,
+        int const code,
+        char const* const reason,
+        std::string_view const body,
+        std::span<std::pair<std::string, std::string> const> headers = {})
     {
         auto* const out = evbuffer_new();
         evbuffer_add(out, std::data(body), std::size(body));
+        if (!headers.empty()) {
+            auto* const output_headers = evhttp_request_get_output_headers(req);
+            for (auto const& [key, value] : headers) {
+                evhttp_add_header(output_headers, key.c_str(), value.c_str());
+            }
+        }
         evhttp_send_reply(req, code, reason, out);
         evbuffer_free(out);
     }

--- a/tests/libtransmission/web-test.cc
+++ b/tests/libtransmission/web-test.cc
@@ -135,6 +135,15 @@ TEST_F(WebTest, httpErrorStatusIsSurfaced)
     EXPECT_FALSE(response.errmsg);
 }
 
+TEST_F(WebTest, curlErrorIsReported)
+{
+    auto const response = fetch(tr_web::FetchOptions{ "http://example.invalid", nullptr, nullptr });
+    EXPECT_EQ(0, response.status);
+    EXPECT_FALSE(response.did_timeout);
+    ASSERT_TRUE(response.errmsg);
+    EXPECT_NE(std::string::npos, response.errmsg->find("curl error: "));
+}
+
 TEST_F(WebTest, postSendsBody)
 {
     auto opts = options();
@@ -255,6 +264,21 @@ TEST_F(WebTest, rangeRequestSetsHeader)
     EXPECT_EQ("bytes=0-3"sv, server_.lastRequest().headers.at("range"));
 }
 
+TEST_F(WebTest, rangeLengthTakesPrecedenceOverMaxFileSize)
+{
+    static auto constexpr Body = "data"sv;
+    server_.setHandler([](evhttp_request* req) { LoopbackServer::reply(req, 206, "Partial Content", Body); });
+
+    auto opts = options();
+    opts.max_file_size = 1U;
+    opts.range = std::make_pair(uint64_t{ 0 }, uint64_t{ 3 });
+
+    auto const response = fetch(std::move(opts));
+    EXPECT_EQ(206, response.status);
+    EXPECT_FALSE(response.errmsg);
+    EXPECT_EQ(Body, response.body);
+}
+
 TEST_F(WebTest, cookiesAreSent)
 {
     auto opts = options();
@@ -324,6 +348,20 @@ TEST_F(WebTest, defaultResponseBodyLimitReportsCurlError)
     EXPECT_LE(std::size(response.body), tr_web::FetchOptions::DefaultMaxFileSize);
 }
 
+TEST_F(WebTest, zeroMaxFileSizeDisablesLimit)
+{
+    auto body = std::string(tr_web::FetchOptions::DefaultMaxFileSize + 1U, 'x');
+    server_.setHandler([&body](evhttp_request* req) { LoopbackServer::reply(req, HTTP_OK, "OK", body); });
+
+    auto opts = options();
+    opts.max_file_size = 0U;
+
+    auto const response = fetch(std::move(opts));
+    EXPECT_EQ(200, response.status);
+    EXPECT_FALSE(response.errmsg);
+    EXPECT_EQ(std::size(body), std::size(response.body));
+}
+
 TEST_F(WebTest, timeoutIsReported)
 {
     // Handler that never replies, so the transfer exceeds the timeout.
@@ -335,6 +373,8 @@ TEST_F(WebTest, timeoutIsReported)
     auto const response = fetch(std::move(opts));
     EXPECT_EQ(0, response.status);
     EXPECT_TRUE(response.did_timeout);
+    ASSERT_TRUE(response.errmsg);
+    EXPECT_NE(std::string::npos, response.errmsg->find("curl error: "));
 }
 
 TEST_F(WebTest, destroyRightAfterFetchDoesNotHang)

--- a/tests/libtransmission/web-test.cc
+++ b/tests/libtransmission/web-test.cc
@@ -4,6 +4,7 @@
 // License text can be found in the licenses/ folder.
 
 #include <chrono>
+#include <cinttypes>
 #include <cstdint>
 #include <future>
 #include <memory>
@@ -346,6 +347,43 @@ TEST_F(WebTest, destroyRightAfterFetchDoesNotHang)
         auto web = tr_web::create(mediator_);
         fetch(*web, options());
     }
+}
+
+TEST_F(WebTest, redirectBodyBiggerThanRangeDoesNotAbort)
+{
+    static auto constexpr Body = "0123456789"sv;
+    static auto constexpr First = uint64_t{ 0 };
+    static auto constexpr Last = uint64_t{ 3 };
+
+    server_.setHandler([this](evhttp_request* req) {
+        if (auto const& path = server_.lastRequest().uri; path.ends_with("/redirect"sv)) {
+            static auto constexpr RedirectBody = "Moved permanently to /bigfile"sv;
+            static_assert(std::size(RedirectBody) > Last + 1U - First);
+            LoopbackServer::reply(
+                req,
+                HTTP_MOVEPERM,
+                "Moved Permanently",
+                RedirectBody,
+                { { { "Location", server_.url("/bigfile") } } });
+        } else if (path.ends_with("/bigfile"sv)) {
+            auto const range = server_.lastRequest().headers.at("range");
+            auto first = uint64_t{};
+            auto last = uint64_t{};
+            std::sscanf(range.c_str(), "bytes=%" SCNu64 "-%" SCNu64, &first, &last);
+            LoopbackServer::reply(req, 206, "Partial Content", Body.substr(first, last + 1U - first));
+        } else {
+            LoopbackServer::reply(req, HTTP_NOTFOUND, "Not Found", ""sv);
+        }
+    });
+
+    auto opts = options("/redirect");
+    opts.range = std::make_pair(First, Last);
+
+    auto const response = fetch(std::move(opts));
+    EXPECT_EQ(206, response.status);
+    EXPECT_TRUE(response.did_connect);
+    EXPECT_FALSE(response.errmsg);
+    EXPECT_EQ(Body.substr(First, Last + 1U - First), response.body);
 }
 
 } // namespace

--- a/tests/libtransmission/web-test.cc
+++ b/tests/libtransmission/web-test.cc
@@ -30,6 +30,19 @@ namespace
 // LoopbackServer is shared via loopback-server.h.
 using tr::test::LoopbackServer;
 
+TEST(FetchOptionsTest, effectiveMaxFileSize)
+{
+    auto options = tr_web::FetchOptions{ "http://example.invalid/"s, nullptr, nullptr };
+
+    EXPECT_EQ(tr_web::FetchOptions::DefaultMaxFileSize, options.effective_max_file_size());
+
+    options.max_file_size = 123U;
+    EXPECT_EQ(123U, options.effective_max_file_size());
+
+    options.range = std::make_pair(uint64_t{ 100 }, uint64_t{ 199 });
+    EXPECT_EQ(100U, options.effective_max_file_size());
+}
+
 // tr_web needs a Mediator; this one only overrides the user-agent so a test
 // can confirm the header reaches the server.
 class TestMediator final : public tr_web::Mediator
@@ -92,6 +105,7 @@ TEST_F(WebTest, getReturnsBody)
     EXPECT_EQ("hello world"sv, response.body);
     EXPECT_TRUE(response.did_connect);
     EXPECT_FALSE(response.did_timeout);
+    EXPECT_FALSE(response.errmsg);
     EXPECT_EQ("127.0.0.1"sv, response.primary_ip);
 }
 
@@ -117,6 +131,7 @@ TEST_F(WebTest, httpErrorStatusIsSurfaced)
     auto const response = fetch(options());
     EXPECT_EQ(404, response.status);
     EXPECT_TRUE(response.did_connect);
+    EXPECT_FALSE(response.errmsg);
 }
 
 TEST_F(WebTest, postSendsBody)
@@ -226,11 +241,16 @@ TEST_F(WebTest, userDataRoundTrips)
 
 TEST_F(WebTest, rangeRequestSetsHeader)
 {
+    server_.setHandler([](evhttp_request* req) { LoopbackServer::reply(req, 206, "Partial Content", "data"sv); });
+
     auto opts = options();
     opts.range = std::make_pair(uint64_t{ 0 }, uint64_t{ 3 });
 
-    fetch(std::move(opts));
+    auto const response = fetch(std::move(opts));
 
+    EXPECT_EQ(206, response.status);
+    EXPECT_FALSE(response.errmsg);
+    EXPECT_EQ("data"sv, response.body);
     EXPECT_EQ("bytes=0-3"sv, server_.lastRequest().headers.at("range"));
 }
 
@@ -270,6 +290,37 @@ TEST_F(WebTest, onDataReceivedReportsByteCount)
     auto const response = fetch(std::move(opts));
     EXPECT_EQ(std::size(Body), std::size(response.body));
     EXPECT_EQ(std::size(Body), total);
+}
+
+TEST_F(WebTest, responseBodyLimitReportsCurlError)
+{
+    static auto constexpr Body = "0123456789"sv;
+    static auto constexpr MaxFileSize = std::size_t{ 4 };
+    server_.setHandler([](evhttp_request* req) { LoopbackServer::reply(req, HTTP_OK, "OK", Body); });
+
+    auto opts = options();
+    opts.max_file_size = MaxFileSize;
+
+    auto const response = fetch(std::move(opts));
+    EXPECT_EQ(200, response.status);
+    EXPECT_TRUE(response.did_connect);
+    ASSERT_TRUE(response.errmsg);
+    EXPECT_FALSE(std::empty(*response.errmsg));
+    EXPECT_LT(std::size(response.body), std::size(Body));
+    EXPECT_LE(std::size(response.body), MaxFileSize);
+}
+
+TEST_F(WebTest, defaultResponseBodyLimitReportsCurlError)
+{
+    auto body = std::string(tr_web::FetchOptions::DefaultMaxFileSize + 1U, 'x');
+    server_.setHandler([&body](evhttp_request* req) { LoopbackServer::reply(req, HTTP_OK, "OK", body); });
+
+    auto const response = fetch(options());
+    EXPECT_EQ(200, response.status);
+    EXPECT_TRUE(response.did_connect);
+    ASSERT_TRUE(response.errmsg);
+    EXPECT_FALSE(std::empty(*response.errmsg));
+    EXPECT_LE(std::size(response.body), tr_web::FetchOptions::DefaultMaxFileSize);
 }
 
 TEST_F(WebTest, timeoutIsReported)

--- a/tests/libtransmission/web-test.cc
+++ b/tests/libtransmission/web-test.cc
@@ -441,7 +441,7 @@ TEST_F(WebTest, redirectBodyBiggerThanRangeDoesNotAbort)
     auto const response = fetch(std::move(opts));
     EXPECT_EQ(206, response.status);
     EXPECT_TRUE(response.did_connect);
-    EXPECT_FALSE(response.errmsg);
+    EXPECT_FALSE(response.errmsg) << *response.errmsg;
     EXPECT_EQ(Body.substr(First, Last + 1U - First), response.body);
 }
 

--- a/tests/libtransmission/web-test.cc
+++ b/tests/libtransmission/web-test.cc
@@ -4,7 +4,6 @@
 // License text can be found in the licenses/ folder.
 
 #include <chrono>
-#include <cinttypes>
 #include <cstdint>
 #include <future>
 #include <memory>
@@ -18,6 +17,7 @@
 #include <fmt/format.h>
 
 #include <libtransmission/crypto-utils.h> // tr_base64_encode()
+#include <libtransmission/utils.h> // tr_num_parse()
 #include <libtransmission/web.h>
 
 #include "loopback-server.h"
@@ -407,10 +407,29 @@ TEST_F(WebTest, redirectBodyBiggerThanRangeDoesNotAbort)
                 { { { "Location", server_.url("/bigfile") } } });
         } else if (path.ends_with("/bigfile"sv)) {
             auto const range = server_.lastRequest().headers.at("range");
-            auto first = uint64_t{};
-            auto last = uint64_t{};
-            std::sscanf(range.c_str(), "bytes=%" SCNu64 "-%" SCNu64, &first, &last);
-            LoopbackServer::reply(req, 206, "Partial Content", Body.substr(first, last + 1U - first));
+            auto constexpr Prefix = "bytes="sv;
+            if (!range.starts_with(Prefix)) {
+                LoopbackServer::reply(req, HTTP_BADREQUEST, "Bad Request", {});
+                return;
+            }
+
+            auto const range_values = std::string_view{ range }.substr(Prefix.size());
+            auto const separator = range_values.find('-');
+            if (separator == std::string_view::npos) {
+                LoopbackServer::reply(req, HTTP_BADREQUEST, "Bad Request", {});
+                return;
+            }
+
+            auto first_remainder = std::string_view{};
+            auto const first = tr_num_parse<uint64_t>(range_values.substr(0, separator), &first_remainder);
+            auto last_remainder = std::string_view{};
+            auto const last = tr_num_parse<uint64_t>(range_values.substr(separator + 1U), &last_remainder);
+            if (!first || !last || !first_remainder.empty() || !last_remainder.empty() || *last < *first) {
+                LoopbackServer::reply(req, HTTP_BADREQUEST, "Bad Request", {});
+                return;
+            }
+
+            LoopbackServer::reply(req, 206, "Partial Content", Body.substr(*first, *last + 1U - *first));
         } else {
             LoopbackServer::reply(req, HTTP_NOTFOUND, "Not Found", ""sv);
         }


### PR DESCRIPTION
## Description

Added an opt-out response body size limit to all curl requests. One exception is requests using the `Range` header, the limit will be set to exactly the range span, and there is no opting out or customising the limit.

Requests will fail immediately if `Content-Length` exceeded the limit, or abort as soon as the received data size exceeded the limit.

Requests that are aborted in the midst of receiving the response will preserve the status code and response body received so far, so successful response codes like HTTP 200 does not mean the fetch operation succeeded.

I arbitrarily chose the default limit to be 10 MiB. This should comfortably accommodate almost all torrent files, tracker responses and whatnot.

Ref: https://curl.se/libcurl/security.html

Notes: Improved the security of connections to trackers, web seeds, and blocklist servers.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
