### PR TITLE
fix: incompatible webserver base path

### DIFF
--- a/libtransmission-app/interop-names.h
+++ b/libtransmission-app/interop-names.h
@@ -11,17 +11,14 @@
 // Transmission builds clients that use these too, so treat them as a wire contract.
 // Change a value here and those clients can no longer find us.
 //
-// Three more shared names live in `libtransmission/macros.h`, because
+// Four more shared names live in `libtransmission/macros.h`, because
 // `transmission-cli` and `transmission-daemon` need them and do not link
 // libtransmission-app:
 //
+//   TR_PROJ_WEB_SERVER_BASE_PATH          the default RPC and web URL prefix
 //   TR_PROJ_SHARED_CONFIG_DIRNAME         the default config dir the clients share
 //   TR_PROJ_SHARED_RPC_SESSION_ID_HEADER  the CSRF header a third-party RPC client sends
 //   TR_PROJ_SHARED_RPC_VERSION_HEADER     the version header it reads back
-//
-// The RPC URL's base path is not one of them. TR_PROJ_WEB_SERVER_BASE_PATH spells ours
-// `/retransmission/` where Transmission spells it `/transmission/`, so a third-party RPC
-// client set up against one needs a new URL for the other.
 //
 // The config dir lock filename lives in `libtransmission/config-dir-lock.cc` for the
 // same reason. Those three files hold every shared name we have.

--- a/libtransmission/macros.h
+++ b/libtransmission/macros.h
@@ -45,7 +45,7 @@
 // The D-Bus names live in `libtransmission-app/interop-names.h` as literal strings,
 // where the interop tests can read them out at configure time.
 
-#define TR_PROJ_WEB_SERVER_BASE_PATH "/" TR_PROJ_APPNAME "/"
+#define TR_PROJ_WEB_SERVER_BASE_PATH "/transmission/"
 
 // Interop contract, shared with separately-built clients.
 // `libtransmission-app/interop-names.h` inventories every such name.

--- a/tests/libtransmission/settings-test.cc
+++ b/tests/libtransmission/settings-test.cc
@@ -12,6 +12,7 @@
 
 #include <libtransmission/transmission.h>
 
+#include <libtransmission/constants.h>
 #include <libtransmission/net.h>
 #include <libtransmission/open-files.h>
 #include <libtransmission/peer-io.h>
@@ -31,6 +32,31 @@ TEST_F(SettingsTest, canInstantiate)
 
     auto map = tr::serializer::save(settings);
     EXPECT_FALSE(std::empty(map));
+}
+
+TEST_F(SettingsTest, defaultRpcUrlIsCompatibleWithTransmission)
+{
+    EXPECT_EQ("/transmission/"sv, TrDefaultHttpServerBasePath);
+
+    auto const settings = tr::RpcServerSettings{};
+    EXPECT_EQ("/transmission/"sv, settings.url);
+
+    auto const map = tr::serializer::save(settings);
+    EXPECT_EQ("/transmission/"sv, map.value_if<std::string_view>(TR_KEY_rpc_url));
+}
+
+TEST_F(SettingsTest, preservesConfiguredRpcUrl)
+{
+    for (auto const url : { "/transmission/"sv, "/retransmission/"sv, "/custom/"sv }) {
+        auto map = tr::Settings{ 1U };
+        map.try_emplace(TR_KEY_rpc_url, url);
+
+        auto const settings = tr::RpcServerSettings{ map };
+        EXPECT_EQ(url, settings.url);
+
+        auto const saved = tr::serializer::save(settings);
+        EXPECT_EQ(url, saved.value_if<std::string_view>(TR_KEY_rpc_url));
+    }
 }
 
 TEST_F(SettingsTest, canLoadBools)


### PR DESCRIPTION
## Description

Fixes #293.

Marking as `notes:none` because this bug was only in `main`, never in a release

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
