### PR TITLE
test: web request url is captured in response object

### DIFF
--- a/tests/libtransmission/web-test.cc
+++ b/tests/libtransmission/web-test.cc
@@ -95,6 +95,14 @@ TEST_F(WebTest, getReturnsBody)
     EXPECT_EQ("127.0.0.1"sv, response.primary_ip);
 }
 
+TEST_F(WebTest, requestUrlIsCaptured)
+{
+    static constexpr auto Path = "/request-url"sv;
+    auto const response = fetch(options(Path));
+
+    EXPECT_EQ(server_.url(Path), response.request_url);
+}
+
 TEST_F(WebTest, noBodyIsGet)
 {
     auto const response = fetch(options());


### PR DESCRIPTION
## Description

Add test case for the newly added `tr_web::FetchResponse::request_url.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
