### PR TITLE
refactor: replace PiecesView mouseDown override with gesture recognizer.

### DIFF
--- a/macosx/Base.lproj/InfoActivityView.xib
+++ b/macosx/Base.lproj/InfoActivityView.xib
@@ -119,9 +119,6 @@
                                         <constraint firstAttribute="width" constant="93" id="euA-Qi-kqQ"/>
                                     </constraints>
                                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="axesIndependently" id="40"/>
-                                    <connections>
-                                        <action selector="updatePiecesView:" target="-2" id="lAc-eh-g8B"/>
-                                    </connections>
                                 </imageView>
                                 <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="29">
                                     <rect key="frame" x="-2" y="120" width="73" height="14"/>

--- a/macosx/InfoActivityViewController.h
+++ b/macosx/InfoActivityViewController.h
@@ -16,8 +16,6 @@
 - (void)setInfoForTorrents:(NSArray<Torrent*>*)torrents;
 - (void)updateInfo;
 
-- (IBAction)setPiecesView:(id)sender;
-- (IBAction)updatePiecesView:(id)sender;
 - (void)clearView;
 
 @property(nonatomic) IBOutlet NSView* fTransferView;

--- a/macosx/InfoActivityViewController.mm
+++ b/macosx/InfoActivityViewController.mm
@@ -260,7 +260,7 @@ static CGFloat const kStackViewVerticalSpacing = 8.0;
 
 - (void)updatePiecesView:(id)sender
 {
-    if (self.fTorrents.count == 1) {
+    if (self.fTorrents.count == 1 && self.fTorrents[0].magnet == NO) {
         BOOL const availablity = [NSUserDefaults.standardUserDefaults boolForKey:@"PiecesViewShowAvailability"];
         [self setPiecesViewAvailability:!availablity];
     }

--- a/macosx/InfoActivityViewController.mm
+++ b/macosx/InfoActivityViewController.mm
@@ -40,7 +40,6 @@ static CGFloat const kStackViewVerticalSpacing = 8.0;
 
 @property(nonatomic) IBOutlet PiecesView* fPiecesView;
 @property(nonatomic) IBOutlet NSSegmentedControl* fPiecesControl;
-@property(nonatomic, readonly) NSClickGestureRecognizer* fGestureRecognizer;
 
 @property(nonatomic) IBOutlet NSStackView* fActivityStackView;
 @property(nonatomic) IBOutlet NSView* fDatesView;
@@ -68,10 +67,8 @@ static CGFloat const kStackViewVerticalSpacing = 8.0;
     [super awakeFromNib];
     [self checkWindowSize];
 
-    if (self.fGestureRecognizer == nil) {
-        _fGestureRecognizer = [[NSClickGestureRecognizer alloc] initWithTarget:self action:@selector(updatePiecesView:)];
-        [self.fPiecesView addGestureRecognizer:_fGestureRecognizer];
-    }
+    auto gestureRecognizer = [[NSClickGestureRecognizer alloc] initWithTarget:self action:@selector(togglePiecesViewAvailability:)];
+    [self.fPiecesView addGestureRecognizer:gestureRecognizer];
 }
 
 - (CGFloat)fHorizLayoutHeight
@@ -242,27 +239,39 @@ static CGFloat const kStackViewVerticalSpacing = 8.0;
     }
 }
 
+- (BOOL)shouldTogglePiecesViewAvailability
+{
+    return self.fPiecesView.torrent != nil;
+}
+
 - (void)setPiecesViewAvailability:(BOOL)piecesAvailableSegment
 {
     [NSUserDefaults.standardUserDefaults setBool:piecesAvailableSegment forKey:@"PiecesViewShowAvailability"];
 
-    [self.fPiecesControl setSelected:piecesAvailableSegment forSegment:PiecesControlSegmentAvailable];
-    [self.fPiecesControl setSelected:!piecesAvailableSegment forSegment:PiecesControlSegmentProgress];
+    [self syncPiecesControl:piecesAvailableSegment];
 
     [self.fPiecesView updateView];
 }
 
-- (void)setPiecesView:(id)sender
+- (void)syncPiecesControl:(BOOL)piecesAvailableSegment
 {
-    BOOL const availability = [sender selectedSegment] == PiecesControlSegmentAvailable;
-    [self setPiecesViewAvailability:availability];
+    [self.fPiecesControl setSelected:piecesAvailableSegment forSegment:PiecesControlSegmentAvailable];
+    [self.fPiecesControl setSelected:!piecesAvailableSegment forSegment:PiecesControlSegmentProgress];
 }
 
-- (void)updatePiecesView:(id)sender
+- (IBAction)setPiecesView:(id)sender
 {
-    if (self.fTorrents.count == 1 && self.fTorrents[0].magnet == NO) {
-        BOOL const availablity = [NSUserDefaults.standardUserDefaults boolForKey:@"PiecesViewShowAvailability"];
-        [self setPiecesViewAvailability:!availablity];
+    if (self.shouldTogglePiecesViewAvailability) {
+        BOOL const availability = [sender selectedSegment] == PiecesControlSegmentAvailable;
+        [self setPiecesViewAvailability:availability];
+    }
+}
+
+- (void)togglePiecesViewAvailability:(id)sender
+{
+    if (self.shouldTogglePiecesViewAvailability) {
+        BOOL const availability = [NSUserDefaults.standardUserDefaults boolForKey:@"PiecesViewShowAvailability"];
+        [self setPiecesViewAvailability:!availability];
     }
 }
 
@@ -300,17 +309,17 @@ static CGFloat const kStackViewVerticalSpacing = 8.0;
 
         [self.fPiecesControl setSelected:NO forSegment:PiecesControlSegmentAvailable];
         [self.fPiecesControl setSelected:NO forSegment:PiecesControlSegmentProgress];
-        self.fPiecesControl.enabled = NO;
         self.fPiecesView.torrent = nil;
+
+        self.fPiecesControl.enabled = self.shouldTogglePiecesViewAvailability;
     } else {
         Torrent* torrent = self.fTorrents[0];
 
         BOOL const piecesAvailableSegment = [NSUserDefaults.standardUserDefaults boolForKey:@"PiecesViewShowAvailability"];
-        [self.fPiecesControl setSelected:piecesAvailableSegment forSegment:PiecesControlSegmentAvailable];
-        [self.fPiecesControl setSelected:!piecesAvailableSegment forSegment:PiecesControlSegmentProgress];
-        self.fPiecesControl.enabled = YES;
-
+        [self syncPiecesControl:piecesAvailableSegment];
         self.fPiecesView.torrent = torrent;
+
+        self.fPiecesControl.enabled = self.shouldTogglePiecesViewAvailability;
     }
 
     self.fSet = YES;

--- a/macosx/InfoActivityViewController.mm
+++ b/macosx/InfoActivityViewController.mm
@@ -40,6 +40,7 @@ static CGFloat const kStackViewVerticalSpacing = 8.0;
 
 @property(nonatomic) IBOutlet PiecesView* fPiecesView;
 @property(nonatomic) IBOutlet NSSegmentedControl* fPiecesControl;
+@property(nonatomic, readonly) NSClickGestureRecognizer* fGestureRecognizer;
 
 @property(nonatomic) IBOutlet NSStackView* fActivityStackView;
 @property(nonatomic) IBOutlet NSView* fDatesView;
@@ -66,6 +67,11 @@ static CGFloat const kStackViewVerticalSpacing = 8.0;
 {
     [super awakeFromNib];
     [self checkWindowSize];
+
+    if (self.fGestureRecognizer == nil) {
+        _fGestureRecognizer = [[NSClickGestureRecognizer alloc] initWithTarget:self action:@selector(updatePiecesView:)];
+        [self.fPiecesView addGestureRecognizer:_fGestureRecognizer];
+    }
 }
 
 - (CGFloat)fHorizLayoutHeight
@@ -236,21 +242,28 @@ static CGFloat const kStackViewVerticalSpacing = 8.0;
     }
 }
 
-- (void)setPiecesView:(id)sender
+- (void)setPiecesViewAvailability:(BOOL)piecesAvailableSegment
 {
-    BOOL const availability = [sender selectedSegment] == PiecesControlSegmentAvailable;
-    [NSUserDefaults.standardUserDefaults setBool:availability forKey:@"PiecesViewShowAvailability"];
-    [self updatePiecesView:nil];
-}
-
-- (void)updatePiecesView:(id)sender
-{
-    BOOL const piecesAvailableSegment = [NSUserDefaults.standardUserDefaults boolForKey:@"PiecesViewShowAvailability"];
+    [NSUserDefaults.standardUserDefaults setBool:piecesAvailableSegment forKey:@"PiecesViewShowAvailability"];
 
     [self.fPiecesControl setSelected:piecesAvailableSegment forSegment:PiecesControlSegmentAvailable];
     [self.fPiecesControl setSelected:!piecesAvailableSegment forSegment:PiecesControlSegmentProgress];
 
     [self.fPiecesView updateView];
+}
+
+- (void)setPiecesView:(id)sender
+{
+    BOOL const availability = [sender selectedSegment] == PiecesControlSegmentAvailable;
+    [self setPiecesViewAvailability:availability];
+}
+
+- (void)updatePiecesView:(id)sender
+{
+    if (self.fTorrents.count == 1) {
+        BOOL const availablity = [NSUserDefaults.standardUserDefaults boolForKey:@"PiecesViewShowAvailability"];
+        [self setPiecesViewAvailability:!availablity];
+    }
 }
 
 - (void)clearView

--- a/macosx/PiecesView.mm
+++ b/macosx/PiecesView.mm
@@ -191,21 +191,4 @@ typedef struct PieceInfo {
     fRenderedHashString = self.torrent.hashString;
 }
 
-- (BOOL)acceptsFirstMouse:(NSEvent*)event
-{
-    return YES;
-}
-
-- (void)mouseDown:(NSEvent*)event
-{
-    if (self.torrent) {
-        BOOL const availability = ![NSUserDefaults.standardUserDefaults boolForKey:@"PiecesViewShowAvailability"];
-        [NSUserDefaults.standardUserDefaults setBool:availability forKey:@"PiecesViewShowAvailability"];
-
-        [self sendAction:self.action to:self.target];
-    }
-
-    [super mouseDown:event];
-}
-
 @end

--- a/macosx/PiecesView.mm
+++ b/macosx/PiecesView.mm
@@ -191,4 +191,9 @@ typedef struct PieceInfo {
     fRenderedHashString = self.torrent.hashString;
 }
 
+- (BOOL)acceptsFirstMouse:(NSEvent*)event
+{
+    return YES;
+}
+
 @end


### PR DESCRIPTION
### Description
This PR addresses one of the legacy macOS code architectural issues mentioned in #289. It removes the custom `mouseDown:` override from `PiecesView` and migrates the click interaction to a modern `NSClickGestureRecognizer` within `InfoActivityViewController`.

### Changes Included
- **UI & Architecture:** Removed the legacy action/target connections from `InfoActivityView.xib` and deleted the `mouseDown:` override in `PiecesView.mm`.
- **Modern AppKit Standards:** Initialized and attached an `NSClickGestureRecognizer` to `fPiecesView` in `InfoActivityViewController.mm` to abstract core input handling [TN3212].
- **UX Improvement:** Clicking now triggers standard macOS behavior (on mouse release instead of press), aligning with Apple's Human Interface Guidelines.
- **Separation of Concerns:** Moved the settings toggling logic (`PiecesViewShowAvailability`) out of the View class and into the View Controller.
- **Bug Fix:** Added a strict safeguard (`self.fTorrents.count == 1`) to ensure this interaction changes state only when a single torrent is selected.

### Verification
- [x] Verified that clicking `PiecesView` correctly toggles the availability view when one torrent is selected.
- [x] Verified that clicking is completely ignored when multiple torrents are selected.
- [x] Checked cross-device compliance (works seamlessly with trackpads, mouse clicks, and simulated taps).
