### PR TITLE
build: link gtest statically

### DIFF
--- a/cmake/TrGTest.cmake
+++ b/cmake/TrGTest.cmake
@@ -7,8 +7,7 @@ tr_add_external_auto_library(GTEST GTest
     SOURCE_DIR googletest
     CMAKE_ARGS
         -DBUILD_GMOCK=OFF
-        -DINSTALL_GTEST=OFF
-        -DBUILD_SHARED_LIBS=ON)
+        -DINSTALL_GTEST=OFF)
 
 # The GTest::gtest_main target is new in CMake 3.20
 if(NOT TARGET GTest::gtest_main)

--- a/cmake/TrMacros.cmake
+++ b/cmake/TrMacros.cmake
@@ -2,23 +2,6 @@ include(CheckFunctionExists)
 include(CheckIncludeFile)
 
 macro(tr_setup_gtest_target TARGET_NAME TEST_PREFIX)
-    if(WIN32)
-        cmake_policy(PUSH)
-        cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
-
-        add_custom_command(
-            TARGET ${TARGET_NAME} POST_BUILD
-            COMMAND
-                ${CMAKE_COMMAND}
-                -E copy_if_different
-                $<TARGET_RUNTIME_DLLS:${TARGET_NAME}>
-                $<TARGET_FILE_DIR:${TARGET_NAME}>
-            COMMAND_EXPAND_LISTS
-        )
-
-        cmake_policy(POP)
-    endif()
-
     if(NOT CMAKE_CROSSCOMPILING OR CMAKE_CROSSCOMPILING_EMULATOR)
         # PRE_TEST enumerates at ctest time; the POST_BUILD default runs the
         # fresh binary during the build, where concurrent LTO links can starve


### PR DESCRIPTION
## Description

Fixed #287.

When I worked on a89ca4f2c9a0c284bacc47b32c1af9083f77132e, for reasons I could never figure out, the Windows CI just refused to discover tests if I linked gtest statically. So I had to link dynamically and do some weird copying DLL workaround.

Et voila, it's fixed, somehow.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
