### PR TITLE
fix: set limit for rpc request body size

### DIFF
--- a/libtransmission/constants.h
+++ b/libtransmission/constants.h
@@ -29,5 +29,6 @@ inline auto constexpr TrHttpServerRpcRelativePath = std::string_view{ "rpc" };
 inline auto constexpr TrHttpServerWebRelativePath = std::string_view{ "web/" };
 inline auto constexpr TrRpcSessionIdHeader = std::string_view{ TR_PROJ_SHARED_RPC_SESSION_ID_HEADER };
 inline auto constexpr TrRpcVersionHeader = std::string_view{ TR_PROJ_SHARED_RPC_VERSION_HEADER };
+inline auto constexpr TrWebMaxBodyBytes = 10U * 1024U * 1024U;
 
 inline auto constexpr TrBlockSize = uint32_t{ 1024U * 16U };

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -617,6 +617,9 @@ auto constexpr ServerStartRetryCount = 10;
 auto constexpr ServerStartRetryDelayIncrement = 5s;
 auto constexpr ServerStartRetryMaxDelay = 60s;
 
+// Arbitrary limit to prevent DoS attacks
+auto constexpr ServerMaxRequestBodyBytes = 10 * 1024 * 1024;
+
 bool bindUnixSocket(
     [[maybe_unused]] struct event_base* base,
     [[maybe_unused]] struct evhttp* httpd,
@@ -767,6 +770,13 @@ void start_server(tr_rpc_server* server)
                 fmt::arg("count", ServerStartRetryCount)));
     } else {
         evhttp_set_gencb(httpd, handle_request, server);
+
+        // N.B. https://github.com/libevent/libevent/issues/321
+        // Some browsers cannot handle HTTP 413 responses unless the server reads
+        // the entire request, which is what EVHTTP_SERVER_LINGERING_CLOSE does.
+        evhttp_set_max_body_size(httpd, ServerMaxRequestBodyBytes);
+        evhttp_set_flags(httpd, EVHTTP_SERVER_LINGERING_CLOSE);
+
         server->httpd.reset(httpd);
 
         tr_logAddInfo(

--- a/libtransmission/rpc-server.cc
+++ b/libtransmission/rpc-server.cc
@@ -34,6 +34,7 @@
 #define ZLIB_CONST
 #include <zlib.h>
 
+#include "libtransmission/constants.h"
 #include "libtransmission/crypto-utils.h" /* tr_ssha1_matches() */
 #include "libtransmission/error.h"
 #include "libtransmission/file-utils.h"
@@ -617,9 +618,6 @@ auto constexpr ServerStartRetryCount = 10;
 auto constexpr ServerStartRetryDelayIncrement = 5s;
 auto constexpr ServerStartRetryMaxDelay = 60s;
 
-// Arbitrary limit to prevent DoS attacks
-auto constexpr ServerMaxRequestBodyBytes = 10 * 1024 * 1024;
-
 bool bindUnixSocket(
     [[maybe_unused]] struct event_base* base,
     [[maybe_unused]] struct evhttp* httpd,
@@ -774,7 +772,7 @@ void start_server(tr_rpc_server* server)
         // N.B. https://github.com/libevent/libevent/issues/321
         // Some browsers cannot handle HTTP 413 responses unless the server reads
         // the entire request, which is what EVHTTP_SERVER_LINGERING_CLOSE does.
-        evhttp_set_max_body_size(httpd, ServerMaxRequestBodyBytes);
+        evhttp_set_max_body_size(httpd, static_cast<ev_ssize_t>(TrWebMaxBodyBytes));
         evhttp_set_flags(httpd, EVHTTP_SERVER_LINGERING_CLOSE);
 
         server->httpd.reset(httpd);

--- a/libtransmission/web.h
+++ b/libtransmission/web.h
@@ -16,6 +16,8 @@
 #include <string_view>
 #include <utility>
 
+#include "libtransmission/constants.h"
+
 class tr_web
 {
 public:
@@ -148,10 +150,9 @@ public:
         // Maximum size of the response body to accept before aborting the request.
         // Use `effective_max_file_size` instead of reading this value directly.
         // Set to 0 to disable the limit.
-        size_t max_file_size = DefaultMaxFileSize;
+        size_t max_file_size = TrWebMaxBodyBytes;
 
         static auto constexpr DefaultTimeoutSecs = std::chrono::seconds{ 120 };
-        static auto constexpr DefaultMaxFileSize = 10U * 1024U * 1024U;
     };
 
     void fetch(FetchOptions&& options);

--- a/tests/libtransmission/web-test.cc
+++ b/tests/libtransmission/web-test.cc
@@ -16,6 +16,7 @@
 
 #include <fmt/format.h>
 
+#include <libtransmission/constants.h> // tr_base64_encode()
 #include <libtransmission/crypto-utils.h> // tr_base64_encode()
 #include <libtransmission/utils.h> // tr_num_parse()
 #include <libtransmission/web.h>
@@ -35,7 +36,7 @@ TEST(FetchOptionsTest, effectiveMaxFileSize)
 {
     auto options = tr_web::FetchOptions{ "http://example.invalid/"s, nullptr, nullptr };
 
-    EXPECT_EQ(tr_web::FetchOptions::DefaultMaxFileSize, options.effective_max_file_size());
+    EXPECT_EQ(TrWebMaxBodyBytes, options.effective_max_file_size());
 
     options.max_file_size = 123U;
     EXPECT_EQ(123U, options.effective_max_file_size());
@@ -337,7 +338,7 @@ TEST_F(WebTest, responseBodyLimitReportsCurlError)
 
 TEST_F(WebTest, defaultResponseBodyLimitReportsCurlError)
 {
-    auto body = std::string(tr_web::FetchOptions::DefaultMaxFileSize + 1U, 'x');
+    auto body = std::string(TrWebMaxBodyBytes + 1U, 'x');
     server_.setHandler([&body](evhttp_request* req) { LoopbackServer::reply(req, HTTP_OK, "OK", body); });
 
     auto const response = fetch(options());
@@ -345,12 +346,12 @@ TEST_F(WebTest, defaultResponseBodyLimitReportsCurlError)
     EXPECT_TRUE(response.did_connect);
     ASSERT_TRUE(response.errmsg);
     EXPECT_FALSE(std::empty(*response.errmsg));
-    EXPECT_LE(std::size(response.body), tr_web::FetchOptions::DefaultMaxFileSize);
+    EXPECT_LE(std::size(response.body), TrWebMaxBodyBytes);
 }
 
 TEST_F(WebTest, zeroMaxFileSizeDisablesLimit)
 {
-    auto body = std::string(tr_web::FetchOptions::DefaultMaxFileSize + 1U, 'x');
+    auto body = std::string(TrWebMaxBodyBytes, 'x');
     server_.setHandler([&body](evhttp_request* req) { LoopbackServer::reply(req, HTTP_OK, "OK", body); });
 
     auto opts = options();


### PR DESCRIPTION
## Description

Add a maximum request body size limit to the RPC server. Had a look at all the RPC methods, and the largest request body I can spot is torrent metainfo in `torrent_add` requests.

It shares the constant with the web client as both values are set based on the size of torrent files.

Notes: Improved security of the RPC server.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
