### PR TITLE
fix: potential infinite loop in webseed code

### DIFF
--- a/libtransmission/webseed.cc
+++ b/libtransmission/webseed.cc
@@ -403,10 +403,9 @@ void tr_webseed_task::on_partial_data_fetched(tr_web::FetchResponse const& web_r
 {
     auto const& [url, errmsg, status, headers, body, primary_ip, did_connect, did_timeout, vtask] = web_response;
 
-    // We could check curl error codes here, but this code has been working fine
-    // without it for years. The piece hash verifier will catch any corrupt data.
-    // Let's keep it this way until we see a problem.
-    auto const success = status == 206;
+    // We don't care about curl error codes here as long as there is data
+    // coming in. The piece hash verifier will catch any corrupt data.
+    auto const success = !body.empty() && status == 206;
 
     auto* const task = static_cast<tr_webseed_task*>(vtask);
 


### PR DESCRIPTION
## Description

`tr_web` can now return successful response code, yet also returning an empty body. The old webseed code will get stuck in an infinite loop in this case:

1. `tr_web` calls `tr_webseed_task::on_partial_data_fetched` with HTTP 206 status and empty body.
2. The task's cursor does not advance, but it does not fail either, so it calls `tr_webseed_task::request_next_chunk` and repeats the request that yielded this result.
3. The webseed will most likely reply with the exact same response.
4. Back to Step 1.

One example of how this can happen:

1. We make a request to a webseed. The first data block it sends exceeded the response size limit.
2. `tr_web::Impl::Task::add_data` returns false on the first time it is called for the request, and so no response body is buffered.
3. `tr_webseed_task::on_partial_data_fetched` will be called with HTTP 206 and an empty body.

Related past dicussions: https://github.com/retransmission/retransmission/pull/305#discussion_r3940635601

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
