### PR TITLE
perf: use `tr::shared_string` to dedupe some libtransmission strings

### DIFF
--- a/daemon/daemon.cc
+++ b/daemon/daemon.cc
@@ -342,7 +342,7 @@ void printMessage(
 void pumpLogMessages(FILE* log_stream)
 {
     for (auto const& l : tr_logGetQueue()) {
-        printMessage(log_stream, l.when, l.level, l.name, l.message, l.file, l.line);
+        printMessage(log_stream, l.when, l.level, l.name.sv(), l.message, l.file, l.line);
     }
 
     // two reasons to not flush stderr:

--- a/gtk/MessageLogWindow.cc
+++ b/gtk/MessageLogWindow.cc
@@ -234,7 +234,7 @@ void MessageLogWindow::Impl::doSave(std::string const& filename)
                 Glib::ustring(g_dpgettext2(nullptr, "Logging level", iter->second)) :
                 Glib::ustring("???");
 
-            fmt::print(stream, "{}\t{}\t{}\t{}\n", date, level_str, node->name, node->message);
+            fmt::print(stream, "{}\t{}\t{}\t{}\n", date, level_str, node->name.sv(), node->message);
         }
     } catch (std::ios_base::failure const& e) {
         auto w = std::make_shared<Gtk::MessageDialog>(

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -444,7 +444,7 @@ struct tr_tier {
 
     std::deque<tr_announce_event> announce_events;
 
-    std::string last_announce_str;
+    tr::shared_string last_announce_str;
     std::string last_scrape_str;
 
     /* number of up/down/corrupt bytes since the last time we sent an
@@ -1541,7 +1541,7 @@ namespace tracker_view_helpers
             view.lastAnnounceTimedOut = tier.lastAnnounceTimedOut;
             view.lastAnnouncePeerCount = tier.lastAnnouncePeerCount;
             auto& buf = view.lastAnnounceResult;
-            *fmt::format_to_n(buf, sizeof(buf) - 1, "{:s}", tier.last_announce_str).out = '\0';
+            *fmt::format_to_n(buf, sizeof(buf) - 1, "{:s}", tier.last_announce_str.sv()).out = '\0';
         }
 
         if (tier.isAnnouncing) {

--- a/libtransmission/announcer.cc
+++ b/libtransmission/announcer.cc
@@ -445,7 +445,7 @@ struct tr_tier {
     std::deque<tr_announce_event> announce_events;
 
     tr::shared_string last_announce_str;
-    std::string last_scrape_str;
+    tr::shared_string last_scrape_str;
 
     /* number of up/down/corrupt bytes since the last time we sent an
      * "event=stopped" message that was acknowledged by the tracker */
@@ -1518,7 +1518,7 @@ namespace tracker_view_helpers
             view.lastScrapeSucceeded = tier.lastScrapeSucceeded;
             view.lastScrapeTimedOut = tier.lastScrapeTimedOut;
             auto& buf = view.lastScrapeResult;
-            *fmt::format_to_n(buf, sizeof(buf) - 1, "{:s}", tier.last_scrape_str).out = '\0';
+            *fmt::format_to_n(buf, sizeof(buf) - 1, "{:s}", tier.last_scrape_str.sv()).out = '\0';
         }
 
         if (tier.isScraping) {

--- a/libtransmission/log.cc
+++ b/libtransmission/log.cc
@@ -144,7 +144,7 @@ void logAddImpl(
                 .file = file,
                 .line = line,
                 .when = now,
-                .name = std::string{ name },
+                .name = tr::shared_string{ name },
                 .message = std::move(msg),
             });
     } else {

--- a/libtransmission/log.h
+++ b/libtransmission/log.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <string_view>
 
+#include "libtransmission/shared-string.h"
 #include "libtransmission/types.h"
 
 // ---
@@ -29,7 +30,7 @@ struct tr_log_message {
     std::chrono::system_clock::time_point when;
 
     // torrent name or code module name associated with the message
-    std::string name;
+    tr::shared_string name;
 
     // the message
     std::string message;

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -765,7 +765,7 @@ namespace make_torrent_field_helpers
     case TR_KEY_corrupt_ever:
         return st.corrupt_ever;
     case TR_KEY_creator:
-        return tor.creator();
+        return tor.creator().sv();
     case TR_KEY_date_created:
         return tor.date_created();
     case TR_KEY_desired_available:

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -883,7 +883,7 @@ namespace make_torrent_field_helpers
     case TR_KEY_size_when_done:
         return st.size_when_done;
     case TR_KEY_source:
-        return tor.source();
+        return tor.source().sv();
     case TR_KEY_start_date:
         return st.start_date;
     case TR_KEY_status:

--- a/libtransmission/rpcimpl.cc
+++ b/libtransmission/rpcimpl.cc
@@ -761,7 +761,7 @@ namespace make_torrent_field_helpers
     case TR_KEY_bytes_completed:
         return make_bytes_completed_vec(tor);
     case TR_KEY_comment:
-        return tor.comment();
+        return tor.comment().sv();
     case TR_KEY_corrupt_ever:
         return st.corrupt_ever;
     case TR_KEY_creator:

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -159,7 +159,7 @@ tr_variant build_metainfo_except_info_dict(tr_torrent_metainfo const& tm)
     }
 
     if (auto const& val = tm.creator(); !std::empty(val)) {
-        top.try_emplace(TR_KEY_created_by, val);
+        top.try_emplace(TR_KEY_created_by, val.sv());
     }
 
     if (auto const val = tm.date_created(); val != 0) {

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -155,7 +155,7 @@ tr_variant build_metainfo_except_info_dict(tr_torrent_metainfo const& tm)
     }
 
     if (auto const& val = tm.source(); !std::empty(val)) {
-        top.try_emplace(TR_KEY_source, val);
+        top.try_emplace(TR_KEY_source, val.sv());
     }
 
     if (auto const& val = tm.creator(); !std::empty(val)) {

--- a/libtransmission/torrent-magnet.cc
+++ b/libtransmission/torrent-magnet.cc
@@ -151,7 +151,7 @@ tr_variant build_metainfo_except_info_dict(tr_torrent_metainfo const& tm)
     auto top = tr_variant::Map{ 8U };
 
     if (auto const& val = tm.comment(); !std::empty(val)) {
-        top.try_emplace(TR_KEY_comment, val);
+        top.try_emplace(TR_KEY_comment, val.sv());
     }
 
     if (auto const& val = tm.source(); !std::empty(val)) {

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -216,7 +216,7 @@ private:
 
     std::vector<tr_sha1_digest_t> pieces_;
 
-    std::string comment_;
+    tr::shared_string comment_;
     tr::shared_string creator_;
     tr::shared_string source_;
 

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -217,7 +217,7 @@ private:
     std::vector<tr_sha1_digest_t> pieces_;
 
     std::string comment_;
-    std::string creator_;
+    tr::shared_string creator_;
     tr::shared_string source_;
 
     time_t date_created_ = 0;

--- a/libtransmission/torrent-metainfo.h
+++ b/libtransmission/torrent-metainfo.h
@@ -13,6 +13,7 @@
 
 #include "libtransmission/block-info.h"
 #include "libtransmission/magnet-metainfo.h"
+#include "libtransmission/shared-string.h"
 #include "libtransmission/torrent-files.h"
 #include "libtransmission/types.h"
 
@@ -217,7 +218,7 @@ private:
 
     std::string comment_;
     std::string creator_;
-    std::string source_;
+    tr::shared_string source_;
 
     time_t date_created_ = 0;
 

--- a/tests/libtransmission/makemeta-test.cc
+++ b/tests/libtransmission/makemeta-test.cc
@@ -176,7 +176,7 @@ TEST_F(MakemetaTest, anonymizeFalse)
     auto builder = tr_metainfo_builder{ filename };
     builder.set_anonymize(false);
     auto const metainfo = testBuilder(builder);
-    EXPECT_TRUE(tr_strv_contains(metainfo.creator(), TR_PROJ_APPNAME_CAPITALIZED)) << metainfo.creator();
+    EXPECT_TRUE(tr_strv_contains(metainfo.creator().sv(), TR_PROJ_APPNAME_CAPITALIZED)) << metainfo.creator().sv();
     auto const now = time(nullptr);
     EXPECT_LE(metainfo.date_created(), now);
     EXPECT_LE(now - 60, metainfo.date_created());

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -169,7 +169,7 @@ void showInfo(app_opts const& opts, tr_torrent_metainfo const& metainfo)
         if (metainfo.has_v2_metadata()) {
             fmt::print("  Hash v2: {:s}\n", metainfo.info_hash2_string());
         }
-        fmt::print("  Created by: {:s}\n", std::empty(metainfo.creator()) ? "Unknown" : metainfo.creator());
+        fmt::print("  Created by: {:s}\n", std::empty(metainfo.creator()) ? "Unknown"sv : metainfo.creator().sv());
         fmt::print("  Created on: {:s}\n\n", toString(metainfo.date_created()));
 
         if (!std::empty(metainfo.comment())) {

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -177,7 +177,7 @@ void showInfo(app_opts const& opts, tr_torrent_metainfo const& metainfo)
         }
 
         if (!std::empty(metainfo.source())) {
-            fmt::print("  Source: {:s}\n", metainfo.source());
+            fmt::print("  Source: {:s}\n", metainfo.source().sv());
         }
 
         fmt::print("  Piece Count: {:d}\n", metainfo.piece_count());

--- a/utils/show.cc
+++ b/utils/show.cc
@@ -173,7 +173,7 @@ void showInfo(app_opts const& opts, tr_torrent_metainfo const& metainfo)
         fmt::print("  Created on: {:s}\n\n", toString(metainfo.date_created()));
 
         if (!std::empty(metainfo.comment())) {
-            fmt::print("  Comment: {:s}\n", metainfo.comment());
+            fmt::print("  Comment: {:s}\n", metainfo.comment().sv());
         }
 
         if (!std::empty(metainfo.source())) {


### PR DESCRIPTION
## Description

Make these fields `tr::shared_string` instead of `std::string` to reduce a little memory use:

- tr_log_message::name
- tr_tier::last_announce_str
- tr_tier::last_scrape_str
- tr_torrent_metainfo::source_
- tr_torrent_metainfo::creator_
- tr_torrent_metainfo::comment_

Notes: Improved libtransmission code to use less CPU.

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
