### PR TITLE
fix: Glib::ustring serializer

### DIFF
--- a/gtk/CMakeLists.txt
+++ b/gtk/CMakeLists.txt
@@ -1,8 +1,10 @@
 find_program(APPSTREAM appstreamcli)
 
-add_executable(${TR_NAME}-gtk WIN32)
+# Everything but main() is a library so that tests/gtk can link the client's
+# code without launching it.
+add_library(${TR_NAME}-gtk-lib STATIC)
 
-target_sources(${TR_NAME}-gtk
+target_sources(${TR_NAME}-gtk-lib
     PRIVATE
         Actions.cc
         Actions.h
@@ -33,7 +35,6 @@ target_sources(${TR_NAME}-gtk
         ListModelAdapter.cc
         ListModelAdapter.h
         Macros.h
-        main.cc
         MainWindow.cc
         MainWindow.h
         MakeDialog.cc
@@ -80,7 +81,7 @@ tr_allow_compile_if(
     [=[[GTK_VERSION EQUAL 3]]=]
         TorrentCellRenderer.cc)
 
-target_sources(${TR_NAME}-gtk
+target_sources(${TR_NAME}-gtk-lib
     PRIVATE
         ui/gtk3/AddTrackerDialog.ui
         ui/gtk3/DetailsDialog.ui
@@ -99,7 +100,7 @@ target_sources(${TR_NAME}-gtk
 source_group(Ui/GTK3
     REGULAR_EXPRESSION [[ui/gtk3/.*\.ui$]])
 
-target_sources(${TR_NAME}-gtk
+target_sources(${TR_NAME}-gtk-lib
     PRIVATE
         ui/gtk4/AddTrackerDialog.ui
         ui/gtk4/DetailsDialog.ui
@@ -141,6 +142,15 @@ else()
     set(UI_SUBDIR ui/gtk3)
 endif()
 
+add_executable(${TR_NAME}-gtk WIN32)
+
+target_sources(${TR_NAME}-gtk
+    PRIVATE
+        main.cc)
+
+# The generated resource file registers itself from a static constructor,
+# which a static library would drop as unreferenced. A test that loads the
+# client's UI adds the same resources to its own executable.
 tr_target_glib_resources(${TR_NAME}-gtk
     transmission.gresource.xml
     ${UI_SUBDIR}/transmission-ui.gresource.xml)
@@ -179,34 +189,41 @@ if(ENABLE_NLS)
             ${METAINFO_FILE})
 endif()
 
-target_compile_definitions(${TR_NAME}-gtk
-    PRIVATE
+target_compile_definitions(${TR_NAME}-gtk-lib
+    PUBLIC
         "TR_GTK_APP_ID=\"${TR_GTK_APP_ID}\""
         TRANSMISSIONLOCALEDIR="${CMAKE_INSTALL_FULL_LOCALEDIR}"
         GETTEXT_PACKAGE="${TR_NAME}-gtk"
         $<$<BOOL:${ENABLE_UTP}>:WITH_UTP>)
 
-target_compile_options(${TR_NAME}-gtk
-    PRIVATE
-        $<$<BOOL:${ENABLE_WERROR}>:$<IF:$<CXX_COMPILER_ID:MSVC>,/WX,-Werror>>
-        $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-exit-time-destructors>)
+foreach(TGT ${TR_NAME}-gtk-lib ${TR_NAME}-gtk)
+    target_compile_options(${TGT}
+        PRIVATE
+            $<$<BOOL:${ENABLE_WERROR}>:$<IF:$<CXX_COMPILER_ID:MSVC>,/WX,-Werror>>
+            $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-exit-time-destructors>)
+endforeach()
 
-target_include_directories(${TR_NAME}-gtk
-    PRIVATE
+target_include_directories(${TR_NAME}-gtk-lib
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_BINARY_DIR})
 
-target_include_directories(${TR_NAME}-gtk SYSTEM
+target_include_directories(${TR_NAME}-gtk-lib SYSTEM
     PRIVATE
         $<$<BOOL:${WITH_APPINDICATOR}>:${APPINDICATOR_INCLUDE_DIRS}>)
 
-target_link_libraries(${TR_NAME}-gtk
-    PRIVATE
+target_link_libraries(${TR_NAME}-gtk-lib
+    PUBLIC
         ${TR_NAME}-app
         ${TR_NAME}
         woke::woke
         transmission::gtk_impl
         transmission::fmt-header-only
         $<$<BOOL:${WITH_APPINDICATOR}>:${APPINDICATOR_LIBRARIES}>)
+
+target_link_libraries(${TR_NAME}-gtk
+    PRIVATE
+        ${TR_NAME}-gtk-lib)
 
 if(MSVC)
     tr_append_target_property(${TR_NAME}-gtk LINK_FLAGS "/ENTRY:mainCRTStartup")

--- a/gtk/Prefs.cc
+++ b/gtk/Prefs.cc
@@ -13,6 +13,7 @@
 #include <libtransmission/variant.h>
 
 #include <glibmm/miscutils.h>
+#include <glibmm/ustring.h>
 
 #include <string>
 #include <string_view>
@@ -147,3 +148,25 @@ void gtr_pref_save(tr_session* session)
 {
     tr_sessionSaveSettings(session, gl_confdir, gtr_pref_get_all());
 }
+
+// ---
+
+namespace tr::serializer
+{
+
+tr_variant Converter<Glib::ustring>::to_variant(Glib::ustring const& src)
+{
+    return src.raw();
+}
+
+bool Converter<Glib::ustring>::to_value(tr_variant const& src, Glib::ustring* const tgt)
+{
+    if (auto const val = src.value_if<std::string_view>()) {
+        *tgt = Glib::ustring{ std::string{ *val } };
+        return true;
+    }
+
+    return false;
+}
+
+} // namespace tr::serializer

--- a/gtk/Prefs.h
+++ b/gtk/Prefs.h
@@ -39,6 +39,11 @@ struct PrefsStringTraits<Glib::ustring> {
 };
 } // namespace tr::app
 
+namespace tr::serializer
+{
+TR_DECLARE_CONVERTER(Glib::ustring)
+} // namespace tr::serializer
+
 // FIXME(ckerr) remove annoying pragma
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnull-dereference"

--- a/tests/gtk/CMakeLists.txt
+++ b/tests/gtk/CMakeLists.txt
@@ -11,3 +11,28 @@ add_test(
         -Dapp_id=${TR_GTK_APP_ID}
         -Dvalidator=${DESKTOP_FILE_VALIDATE}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/desktop-file-test.cmake)
+
+# ---
+
+include(GoogleTest)
+
+# One gtest executable per source file, linked against the client library.
+# A test that loads the client's UI must also add the resources the
+# executable in gtk/ registers, with tr_target_glib_resources().
+function(add_trgtk_test source)
+    get_filename_component(name_no_ext ${source} NAME_WE)
+    string(REGEX REPLACE "-test$" "" test_name ${name_no_ext})
+    set(target gtk-test-${test_name})
+
+    add_executable(${target} ${source} test-fixtures.h)
+    target_link_libraries(${target}
+        PRIVATE
+            ${TR_NAME}-gtk-lib
+            GTest::gtest_main)
+    set_property(TARGET ${target} PROPERTY FOLDER "tests")
+
+    tr_setup_gtest_target(${target} "GTK.")
+    add_dependencies(all-tests ${target})
+endfunction()
+
+add_trgtk_test(serializer-test.cc)

--- a/tests/gtk/serializer-test.cc
+++ b/tests/gtk/serializer-test.cc
@@ -1,0 +1,57 @@
+// This file Copyright © Mnemosaic LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosaic LLC.
+// License text can be found in the licenses/ folder.
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include <glibmm/ustring.h>
+
+#include <gtest/gtest.h>
+
+#include <libtransmission/converters.h>
+#include <libtransmission/quark.h>
+#include <libtransmission/variant.h>
+
+#include "Prefs.h"
+#include "test-fixtures.h"
+
+using namespace std::literals;
+using tr::serializer::to_value;
+using tr::serializer::to_variant;
+
+using SerializerTest = GtkTest;
+
+// `Glib::ustring` is a range of `gunichar`, so without its Converter the
+// generic range fallback would serialize it as a vector of code points.
+TEST_F(SerializerTest, ustringToVariantIsString)
+{
+    auto const var = to_variant(Glib::ustring{ "sort_by_name" });
+    EXPECT_EQ(var.value_if<std::string_view>(), "sort_by_name"sv);
+}
+
+TEST_F(SerializerTest, ustringFromStringVariant)
+{
+    auto const val = to_value<Glib::ustring>(tr_variant{ "sort_by_name"s });
+    ASSERT_TRUE(val.has_value());
+    EXPECT_EQ(*val, "sort_by_name");
+}
+
+TEST_F(SerializerTest, ustringFromNonStringVariantFails)
+{
+    EXPECT_FALSE(to_value<Glib::ustring>(tr_variant{ int64_t{ 42 } }).has_value());
+}
+
+// Text entries hand the prefs a `Glib::ustring`; everything else in the
+// client reads the same key back as a `std::string`.
+TEST_F(SerializerTest, ustringPrefReadsBackAsString)
+{
+    auto constexpr Key = TR_KEY_rpc_username;
+
+    gtr_pref_set(Key, Glib::ustring{ "alice" });
+
+    EXPECT_EQ(gtr_pref_string_get(Key), "alice");
+    EXPECT_EQ(gtr_pref_get<Glib::ustring>(Key), "alice");
+}

--- a/tests/gtk/test-fixtures.h
+++ b/tests/gtk/test-fixtures.h
@@ -1,0 +1,25 @@
+// This file Copyright © Mnemosaic LLC.
+// It may be used under GPLv2 (SPDX: GPL-2.0-only), GPLv3 (SPDX: GPL-3.0-only),
+// or any future license endorsed by Mnemosaic LLC.
+// License text can be found in the licenses/ folder.
+
+#pragma once
+
+#include "../libtransmission-app/test-fixtures.h"
+
+#include "Prefs.h"
+
+// A `SandboxedTest` whose prefs read and write the sandbox directory.
+//
+// The client loads its settings once per process, on first use, from
+// whichever directory `gtr_pref_init()` named at that moment; later
+// tests in the same executable keep that map and only redirect saves.
+class GtkTest : public SandboxedTest
+{
+protected:
+    void SetUp() override
+    {
+        SandboxedTest::SetUp();
+        gtr_pref_init(sandbox_dir());
+    }
+};


### PR DESCRIPTION
## Description

While I was reviewing 321, Fable found an issue with the Glib::ustring serializer. This PR fixes it and adds simple scaffolding to add glib/gtk regression tests. 

Marking as `notes:none` since this bug isn't in any releases

## Checklist

- [x] I have manually written or manually audited all changes in this PR and vouch for them.
- [x] I have explained user-facing changes in a 'Notes:' paragraph for the release notes script.
