### PR TITLE
fix: Add missing <concepts> include to variant.h

### DIFF
--- a/libtransmission/variant.h
+++ b/libtransmission/variant.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <algorithm> // std::move()
+#include <concepts> // std::integral
 #include <cstddef> // size_t
 #include <cstdint> // int64_t
 #include <limits>


### PR DESCRIPTION
### Summary
Explicitly include `<concepts>` in `variant.h` to fix compilation issues where `std::integral` is used but not explicitly imported.

### Context
`libtransmission/variant.h` uses `std::integral`, but relies on implicit transitive includes from other standard headers. In environment setups with strict or updated standard libraries (like newer GCC/Clang versions), this causes a breakdown in compilation due to the missing header.
