### PR TITLE
refactor(mac): remove legacy migrations from PrefsController

### DIFF
--- a/macosx/PrefsController.mm
+++ b/macosx/PrefsController.mm
@@ -120,31 +120,6 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
 
         _fDefaults = NSUserDefaults.standardUserDefaults;
 
-        //check for old version download location (before 1.1)
-        NSString* choice;
-        if ((choice = [_fDefaults stringForKey:@"DownloadChoice"])) {
-            [_fDefaults setBool:[choice isEqualToString:@"Constant"] forKey:@"DownloadLocationConstant"];
-            [_fDefaults setBool:YES forKey:@"DownloadAsk"];
-
-            [_fDefaults removeObjectForKey:@"DownloadChoice"];
-        }
-
-        //check for old version blocklist (before 2.12)
-        NSDate* blocklistDate;
-        if ((blocklistDate = [_fDefaults objectForKey:@"BlocklistLastUpdate"])) {
-            [_fDefaults setObject:blocklistDate forKey:@"BlocklistNewLastUpdateSuccess"];
-            [_fDefaults setObject:blocklistDate forKey:@"BlocklistNewLastUpdate"];
-            [_fDefaults removeObjectForKey:@"BlocklistLastUpdate"];
-
-            NSURL* blocklistDir = [[NSFileManager.defaultManager URLsForDirectory:NSApplicationDirectory inDomains:NSUserDomainMask][0]
-                URLByAppendingPathComponent:@TR_PROJ_APPNAME_CAPITALIZED "/blocklists/"];
-            [NSFileManager.defaultManager
-                moveItemAtURL:[blocklistDir URLByAppendingPathComponent:@"level1.bin"]
-                        toURL:[blocklistDir
-                                  URLByAppendingPathComponent:[NSString stringWithUTF8String:TrDefaultBlocklistFilename.data()]]
-                        error:nil];
-        }
-
         //save a new random port
         if ([_fDefaults boolForKey:@"RandomPort"]) {
             [_fDefaults setInteger:tr_sessionGetPeerPort(_fHandle) forKey:@"BindPort"];
@@ -166,13 +141,6 @@ static NSString* const kWebUIURLFormat = @"http://localhost:%ld/";
         //update rpc whitelist
         _fRPCWhitelistArray = [NSMutableArray arrayWithArray:[self.fDefaults arrayForKey:@"RPCWhitelist"] ?: @[ @"127.0.0.1" ]];
         [self updateRPCWhitelist];
-
-        //reset old Sparkle settings from previous versions
-        [_fDefaults removeObjectForKey:@"SUScheduledCheckInterval"];
-        if ([_fDefaults objectForKey:@"CheckForUpdates"]) {
-            //[[SUUpdater sharedUpdater] setAutomaticallyChecksForUpdates:[fDefaults boolForKey:@"CheckForUpdates"]];
-            [_fDefaults removeObjectForKey:@"CheckForUpdates"];
-        }
 
         _fDefaultAppHelper = [[DefaultAppHelper alloc] init];
     }


### PR DESCRIPTION
### Description
This PR addresses **#245** by removing very old migration and cleanup paths inside `macosx/PrefsController.mm` that date back to versions 1.1 and 2.12.

### Changes
* Removed the outdated `DownloadChoice` preference migration block (pre-1.1).
* Removed the legacy `level1.bin` blocklist data migration and folder renaming logic (pre-2.12).
* Removed the legacy Sparkle framework updater preferences reset code (`CheckForUpdates` / `SUScheduledCheckInterval`).

This is a completely safe, non-breaking cleanup of ancient code blocks that are no longer relevant to modern users.